### PR TITLE
fix: Add CSS styles for AsciiDoc definition lists

### DIFF
--- a/website/src/styles/asciidoctor-scoped.css
+++ b/website/src/styles/asciidoctor-scoped.css
@@ -104,6 +104,46 @@
     margin: 0.5rem 0;
   }
 
+  /* Definition Lists */
+  & dl {
+    margin: 1.25rem 0;
+  }
+
+  & dt {
+    font-weight: 700;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    color: inherit;
+  }
+
+  & dt:first-child {
+    margin-top: 0;
+  }
+
+  & dd {
+    margin-left: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  & dd:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Nested definition lists (:::) */
+  & dd > dl {
+    margin-top: 0.5rem;
+    margin-left: 0;
+  }
+
+  & dd > dl dt {
+    font-weight: 600;
+    margin-top: 0.5rem;
+  }
+
+  & dd > dl dd {
+    margin-left: 1.5rem;
+  }
+
   & table {
     border-collapse: collapse;
     width: 100%;


### PR DESCRIPTION
## Problem
Definition lists in anchor files were not visually styled, making them indistinguishable from regular text.

## Solution
Add proper CSS styling for AsciiDoc definition list elements:

**Definition Terms (`dt`)**:
- Bold font weight
- Proper vertical spacing
- Clear visual hierarchy

**Definitions (`dd`)**:
- Indented 2rem for clear structure
- Appropriate bottom margin

**Nested Definition Lists**:
- Support for `:::` syntax (nested definitions)
- Lighter font weight for nested terms
- Additional indentation

## Visual Example

**Before** (no styling):
```
Lightweight documentation Short, focused records
Immutability ADRs are never deleted
```

**After** (with styling):
```
Lightweight documentation
  Short, focused records

Immutability
  ADRs are never deleted
```

## Testing
- [x] Tested locally with definition lists
- [x] Nested definition lists render correctly
- [x] Dark mode compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)