### PR TITLE
fix: Apply asciidoc-content class to modal

### DIFF
--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -29,7 +29,7 @@ export function createModal() {
           </button>
         </div>
       </div>
-      <div id="modal-content" class="flex-1 overflow-y-auto p-6 prose prose-slate dark:prose-invert max-w-none">
+      <div id="modal-content" class="flex-1 overflow-y-auto p-6 prose prose-slate dark:prose-invert max-w-none asciidoc-content">
         <div class="flex items-center justify-center h-64">
           <div class="text-[var(--color-text-secondary)]">Loading...</div>
         </div>


### PR DESCRIPTION
## Problem
Definition list styles were not being applied in the modal because the modal-content div was missing the `.asciidoc-content` class.

## Solution
Add `asciidoc-content` class to the modal-content div.

**Before**: Labels were normal weight
**After**: Labels are bold with proper spacing

## Testing
- [x] Tested in Playwright - definition terms now have correct styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
