### PR TITLE
fix: Convert AsciiDoc cross-reference links to router navigation

### DIFF
--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -139,6 +139,20 @@ export async function loadAnchorContent(anchorId) {
       details.setAttribute('open', '')
     })
 
+    // Convert internal AsciiDoc cross-reference links to router navigation
+    contentEl.querySelectorAll('a[href^="#"]').forEach(link => {
+      const href = link.getAttribute('href')
+      // Only process simple hash links (cross-references), not hash routes
+      if (href && href.startsWith('#') && !href.startsWith('#/')) {
+        const anchorId = href.substring(1) // Remove the '#'
+        link.addEventListener('click', (e) => {
+          e.preventDefault()
+          // Navigate to the linked anchor
+          window.location.hash = `#/anchor/${anchorId}`
+        })
+      }
+    })
+
   } catch (error) {
     console.error('Error loading anchor content:', error)
     titleEl.textContent = 'Error'


### PR DESCRIPTION
## Summary
Fixes internal AsciiDoc cross-reference links to work with hash-based routing.

AsciiDoc cross-references like `<<spc,SPC>>` were generating simple hash links (`#spc`) which don't work with our hash-based routing system (`#/anchor/spc`). This PR adds event listeners to intercept clicks on these internal links and convert them to proper router navigation.

## Changes
- Modified `website/src/components/anchor-modal.js` to intercept clicks on internal cross-reference links
- Links like `<<anchor-id,text>>` now navigate to `#/anchor/anchor-id` instead of `#anchor-id`

## Testing
Tested with Nelson Rules anchor which contains a cross-reference to SPC. Clicking the link now correctly navigates to the SPC anchor modal.

Fixes: https://github.com/LLM-Coding/Semantic-Anchors/issues/XX

🤖 Generated with [Claude Code](https://claude.com/claude-code)