### PR TITLE
feat: Set up pre-commit hooks with AsciiDoc linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Pre-commit hooks for Semantic Anchors
+# Install: pip install pre-commit
+# Setup: pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  # AsciiDoc Linter
+  - repo: local
+    hooks:
+      - id: asciidoc-linter
+        name: AsciiDoc Linter
+        entry: asciidoc-linter
+        language: system
+        files: \.adoc$
+        pass_filenames: true
+        args: [--format, console]
+        stages: [commit]
+
+  # Trailing whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: \.(adoc|md)$
+      - id: end-of-file-fixer
+        exclude: \.(adoc|md)$
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]

--- a/.pre-commit-install.sh
+++ b/.pre-commit-install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Installation script for pre-commit hooks
+
+set -e
+
+echo "Installing pre-commit framework..."
+
+# Check if Python is available
+if ! command -v python3 &> /dev/null; then
+    echo "Error: Python 3 is required"
+    exit 1
+fi
+
+# Install pre-commit
+pip install pre-commit
+
+# Install AsciiDoc linter
+pip install git+https://github.com/doctoolchain/asciidoc-linter.git
+
+# Install pre-commit hooks
+pre-commit install
+
+echo "✓ Pre-commit hooks installed successfully!"
+echo ""
+echo "Usage:"
+echo "  - Hooks run automatically on 'git commit'"
+echo "  - Run manually: pre-commit run --all-files"
+echo "  - Update hooks: pre-commit autoupdate"

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -61,6 +61,47 @@ Evaluate the response:
 * *Depth:* Does it cover multiple related concepts?
 * *Specificity:* Is the scope well-defined?
 
+== Developer Setup
+
+=== Prerequisites
+
+* Git
+* Python 3.12+ (for pre-commit hooks)
+* Node.js 20+ (for website development, optional)
+
+=== Installing Pre-Commit Hooks
+
+**Required for all contributors!**
+
+Run the installation script:
+
+[source,bash]
+----
+./pre-commit-install.sh
+----
+
+This installs:
+
+* **AsciiDoc Linter** - validates anchor file syntax automatically
+* **pre-commit framework** - runs checks before each commit
+* **Standard hooks** - trailing whitespace, YAML/JSON validation
+
+=== Manual Hook Execution
+
+Run all hooks on all files:
+
+[source,bash]
+----
+pre-commit run --all-files
+----
+
+Run specific hook:
+
+[source,bash]
+----
+pre-commit run asciidoc-linter --all-files
+----
+
 == How to Propose a New Anchor
 
 We use an *automated workflow with GitHub Copilot* to validate and enrich proposals:


### PR DESCRIPTION
## Changes

Implements **Issue #82**: Pre-commit hooks with AsciiDoc linter

### What's New

✅ **Pre-commit configuration** (`.pre-commit-config.yaml`)
- AsciiDoc linter runs automatically on all `.adoc` files
- Standard hooks: trailing whitespace, EOF fixer, YAML/JSON validation
- Runs on `git commit`, validates before code is committed

✅ **Installation script** (`.pre-commit-install.sh`)
- One-command setup: `./pre-commit-install.sh`
- Installs pre-commit framework
- Installs AsciiDoc linter
- Sets up git hooks

✅ **Updated CONTRIBUTING.adoc**
- Added developer setup section
- Pre-commit hooks now required for all contributors
- Instructions for manual hook execution

### Benefits

- **Prevents invalid AsciiDoc** from being committed
- **Consistency**: Same linter rules in CI and locally
- **Fast feedback**: Catch errors before push
- **Easy setup**: Single script installation

### How Contributors Use It

```bash
# First time setup
./pre-commit-install.sh

# Hooks run automatically on commit
git commit -m "feat: Add new anchor"

# Manual execution
pre-commit run --all-files
```

### CI Integration

Pre-commit hooks complement the existing CI workflow:
- **Local**: Pre-commit catches issues before commit
- **CI**: GitHub Actions validates on PR (fallback)

Closes #82