### PR TITLE
feat: Link llms.txt and all-anchors.adoc from footer and robots.txt

### DIFF
--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -6,5 +6,8 @@ Allow: /
 # Sitemaps
 Sitemap: https://llm-coding.github.io/Semantic-Anchors/sitemap.xml
 
+# LLM-readable full reference
+llms.txt: https://llm-coding.github.io/Semantic-Anchors/llms.txt
+
 # Disallow search bot indexing of specific paths if needed
 # (currently allowing all)

--- a/website/src/components/footer.js
+++ b/website/src/components/footer.js
@@ -24,6 +24,21 @@ export function renderFooter(version) {
             </a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
+              href="llms.txt"
+              class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+              data-i18n="footer.llmsTxt"
+              title="LLM-readable full reference"
+            >${i18n.t('footer.llmsTxt')}</a>
+            <span class="text-gray-300 dark:text-gray-600">|</span>
+            <a
+              href="https://github.com/LLM-Coding/Semantic-Anchors/blob/main/docs/all-anchors.adoc"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+              data-i18n="footer.allAnchors"
+            >${i18n.t('footer.allAnchors')}</a>
+            <span class="text-gray-300 dark:text-gray-600">|</span>
+            <a
               href="https://github.com/LLM-Coding/Semantic-Anchors"
               target="_blank"
               rel="noopener noreferrer"

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -18,6 +18,8 @@
   "footer.tagline": "Semantic Anchors - Gemeinsames Vokabular für LLM-Kommunikation",
   "footer.github": "GitHub",
   "footer.leaveStar": "Dir gefallen die semantischen Anker? Hinterlasse einen Stern!",
+  "footer.llmsTxt": "llms.txt",
+  "footer.allAnchors": "Vollständige Referenz",
   "categories.communication-presentation": "Kommunikation & Präsentation",
   "categories.design-principles": "Design-Prinzipien & Muster",
   "categories.development-workflow": "Entwicklungs-Workflow",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -18,6 +18,8 @@
   "footer.tagline": "Semantic Anchors - Shared vocabulary for LLM communication",
   "footer.github": "GitHub",
   "footer.leaveStar": "Like Semantic Anchors? Leave a star!",
+  "footer.llmsTxt": "llms.txt",
+  "footer.allAnchors": "Full Reference",
   "categories.communication-presentation": "Communication & Presentation",
   "categories.design-principles": "Design Principles & Patterns",
   "categories.development-workflow": "Development Workflow",


### PR DESCRIPTION
## Summary

- **robots.txt**: `llms.txt:` entry added for LLM discoverability (standard convention)
- **Footer**: Two new links added — `llms.txt` (relative, same-origin) and `Full Reference` → `docs/all-anchors.adoc` on GitHub
- **i18n**: New keys `footer.llmsTxt` and `footer.allAnchors` in EN + DE translations

## Test plan

- [ ] Footer shows "llms.txt | Full Reference | GitHub" links
- [ ] `llms.txt` link opens the plain-text file in the browser
- [ ] "Full Reference" opens the AsciiDoc file on GitHub
- [ ] German translation displays "Vollständige Referenz"
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Features

* Zwei neue Navigationslinks in der Fußzeile: ein Link zu llms.txt für maschinell lesbare und strukturierte Referenzen sowie ein Link zur vollständigen Referenzdokumentation auf GitHub, um Benutzern besseren Zugang zu umfassender Dokumentation zu ermöglichen.
* Erweiterte Sprachunterstützung mit vollständigen deutschen und englischen Übersetzungen für alle neuen Navigationselemente zur Verbesserung der globalen Zugänglichkeit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->