### PR TITLE
feat: Add CQRS semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -103,6 +103,8 @@ include::anchors/user-story-mapping.adoc[leveloffset=+2]
 
 include::anchors/adr-according-to-nygard.adoc[leveloffset=+2]
 
+include::anchors/cqrs.adoc[leveloffset=+2]
+
 include::anchors/arc42.adoc[leveloffset=+2]
 
 include::anchors/atam.adoc[leveloffset=+2]

--- a/docs/anchors/cqrs.adoc
+++ b/docs/anchors/cqrs.adoc
@@ -1,0 +1,49 @@
+= CQRS (Command Query Responsibility Segregation)
+:categories: software-architecture
+:roles: software-architect, software-developer
+:proponents: Greg Young, Bertrand Meyer, Udi Dahan
+:related: domain-driven-design, hexagonal-architecture, fowler-patterns
+:tags: cqrs, cqs, architecture, commands, queries, read-write-separation
+
+[%collapsible]
+====
+Also known as:: CQS at architectural scale
+
+[discrete]
+== *Core Concepts*:
+
+Command Query Separation (CQS):: Bertrand Meyer's principle — methods either change state (commands) or return data (queries), never both
+
+Commands:: Write operations that change state and return void; represent intent as immutable command objects
+
+Queries:: Read operations that return data with no side effects; safe to retry and cache
+
+Separate read/write models:: Independent data models optimized for their respective purpose
+
+Eventual consistency:: Read model may lag behind write model; acceptable trade-off for scalability
+
+Event-based synchronization:: Domain events propagate changes from write side to read side projections
+
+Independent scalability:: Read and write sides can be scaled, deployed, and optimized independently
+
+Event sourcing optional:: CQRS does not require event sourcing; the patterns are complementary but independent
+
+
+Key Proponents:: Greg Young (coined CQRS), Bertrand Meyer (CQS origin, "Object-Oriented Software Construction", 1988), Udi Dahan
+
+[discrete]
+== *When to Use*:
+
+* Systems with asymmetric read/write workloads
+* Complex domains where read and write models diverge significantly
+* Event-sourced systems requiring materialized views
+* High-performance systems needing independent scaling of reads and writes
+* Collaborative domains with task-based UIs
+
+[discrete]
+== *Related Anchors*:
+
+* <<domain-driven-design,Domain-Driven Design>> - Often combined with CQRS for complex domains
+* <<hexagonal-architecture,Hexagonal Architecture>> - Ports and adapters complement CQRS separation
+* <<fowler-patterns,Fowler Patterns>> - CQRS builds on enterprise application patterns
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -44,6 +44,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Gernot Starke, Peter Hruschka
 - **Core:** 12-section template for documenting software architecture
 
+### CQRS (Command Query Responsibility Segregation)
+- **Proponents:** Greg Young, Bertrand Meyer, Udi Dahan
+- **Core:** Separate read/write models, commands return void, queries return data with no side effects, independent scalability
+
 ### C4-Diagrams
 - **Core:** Context, Container, Component, Code — 4 zoom levels
 


### PR DESCRIPTION
## Summary

- Adds **CQRS (Command Query Responsibility Segregation)** as a new semantic anchor
- Covers Greg Young's architectural pattern for separating read and write models
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

CQRS activates a rich set of concepts: immutable commands, separate read/write models, commands return void, queries return data with no side effects, eventual consistency, independent scalability. Attributable to Greg Young, Bertrand Meyer (CQS origin), and Udi Dahan.

Distinct from: Event Sourcing (CQRS doesn't require it), GoF Command Pattern (OO encapsulation, not architectural segregation), Fowler Patterns (enterprise app architecture).

## Files changed

- `docs/anchors/cqrs.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Software Architecture section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dokumentation**
  * Neue CQRS-Dokumentation hinzugefügt mit Übersicht über Kernkonzepte, Anwendungsfälle und verwandte Architekturmuster
  * CQRS-Referenzen in die Dokumentationskataloge aufgenommen für verbesserte Auffindbarkeit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->