### PR TITLE
feat: Add YAGNI semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -31,6 +31,8 @@ include::anchors/spot-principle.adoc[leveloffset=+2]
 
 include::anchors/ssot-principle.adoc[leveloffset=+2]
 
+include::anchors/yagni.adoc[leveloffset=+2]
+
 <<<
 
 == Development Workflow

--- a/docs/anchors/yagni.adoc
+++ b/docs/anchors/yagni.adoc
@@ -1,0 +1,46 @@
+= YAGNI (You Aren't Gonna Need It)
+:categories: design-principles
+:roles: software-developer, software-architect, consultant
+:proponents: Ron Jeffries, Kent Beck
+:related: dry-principle, spot-principle, tdd-chicago-school
+:tags: yagni, extreme-programming, simplicity, incremental-design, over-engineering
+
+[%collapsible]
+====
+Full Name:: You Aren't Gonna Need It
+
+[discrete]
+== *Core Concepts*:
+
+Don't build for hypothetical futures:: Only implement functionality when it is actually needed, not when you foresee it might be needed
+
+Speculative generality:: Anti-pattern of building abstractions for imagined future requirements that may never materialize
+
+Incremental design:: Let design emerge through actual needs; evolve architecture as requirements become concrete
+
+Cost of carry:: Unused code adds maintenance burden, increases complexity, and creates cognitive load for the entire team
+
+Delete dead code:: Aggressively remove code that no longer serves a current purpose
+
+Extreme Programming origin:: Core XP practice alongside TDD, refactoring, and continuous integration
+
+Reversibility:: Prefer simple, changeable decisions over premature commitments to complex solutions
+
+
+Key Proponents:: Ron Jeffries (coined the phrase), Kent Beck ("Extreme Programming Explained", 1999)
+
+[discrete]
+== *When to Use*:
+
+* Fighting over-engineering and premature abstraction
+* Agile projects with iterative delivery and evolving requirements
+* Refactoring legacy systems burdened with unused features
+* When tempted to add "just in case" functionality or configurability
+
+[discrete]
+== *Related Anchors*:
+
+* <<dry-principle,DRY>> - Eliminates duplication of existing knowledge (complementary but distinct)
+* <<spot-principle,SPOT>> - Single Point of Truth, related simplicity principle
+* <<tdd-chicago-school,TDD, Chicago School>> - YAGNI is a core principle of classicist TDD
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -73,6 +73,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 ### SSOT (Single Source of Truth)
 - **Core:** One system is the master for specific data
 
+### YAGNI (You Aren't Gonna Need It)
+- **Proponents:** Ron Jeffries, Kent Beck
+- **Core:** Don't build for hypothetical futures, speculative generality anti-pattern, incremental design, delete dead code
+
 ### Patterns of Enterprise Application Architecture (PEAA)
 - **Proponents:** Martin Fowler
 - **Core:** Repository, Unit of Work, Data Mapper, Active Record, etc.


### PR DESCRIPTION
## Summary

- Adds **YAGNI (You Aren't Gonna Need It)** as a standalone semantic anchor
- Promotes from sub-bullet in Chicago School TDD to independent entry
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

YAGNI activates: Ron Jeffries/XP, don't build for hypothetical future requirements, speculative generality anti-pattern, incremental design, delete dead code, cost of carry.

Distinct from: DRY (eliminates duplication of existing knowledge), KISS (simplicity of what exists). YAGNI = don't add what's not needed yet.

Currently only a sub-bullet in `tdd-chicago-school.adoc` — deserves standalone entry as a widely-used design principle in its own right.

## Files changed

- `docs/anchors/yagni.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Design Principles section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry