### PR TITLE
feat: Add GoF Design Patterns semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -25,6 +25,8 @@ include::anchors/dry-principle.adoc[leveloffset=+2]
 
 include::anchors/fowler-patterns.adoc[leveloffset=+2]
 
+include::anchors/gof-design-patterns.adoc[leveloffset=+2]
+
 include::anchors/solid-principles.adoc[leveloffset=+2]
 
 include::anchors/spot-principle.adoc[leveloffset=+2]

--- a/docs/anchors/gof-design-patterns.adoc
+++ b/docs/anchors/gof-design-patterns.adoc
@@ -1,0 +1,48 @@
+= GoF Design Patterns
+:categories: design-principles
+:roles: software-developer, software-architect, educator
+:proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
+:related: solid-principles, fowler-patterns, clean-architecture
+:tags: design-patterns, gang-of-four, oop, creational, structural, behavioral
+
+[%collapsible]
+====
+Full Name:: Gang of Four Design Patterns
+
+Also known as:: Design Patterns, Gang of Four Patterns
+
+[discrete]
+== *Core Concepts*:
+
+Creational Patterns:: Abstract Factory, Builder, Factory Method, Prototype, Singleton — object creation mechanisms
+
+Structural Patterns:: Adapter, Bridge, Composite, Decorator, Facade, Flyweight, Proxy — object composition and relationships
+
+Behavioral Patterns:: Chain of Responsibility, Command, Interpreter, Iterator, Mediator, Memento, Observer, State, Strategy, Template Method, Visitor — object interaction and responsibility
+
+Pattern language:: Shared vocabulary for communicating recurring design problems and proven solutions
+
+Composition over inheritance:: Favor object composition for flexibility over rigid class hierarchies
+
+Program to an interface:: Depend on abstractions rather than concrete implementations
+
+Design for change:: Identify what varies in your design and encapsulate it
+
+
+Key Proponents:: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides ("Design Patterns: Elements of Reusable Object-Oriented Software", 1994)
+
+[discrete]
+== *When to Use*:
+
+* Object-oriented design requiring proven solutions to recurring problems
+* Communicating design decisions using a shared vocabulary
+* Teaching object-oriented design principles through concrete examples
+* Refactoring code to increase flexibility and reusability
+
+[discrete]
+== *Related Anchors*:
+
+* <<solid-principles,SOLID Principles>> - Design principles that GoF patterns help implement
+* <<fowler-patterns,Fowler Patterns>> - Enterprise application architecture patterns (complementary scope)
+* <<clean-architecture,Clean Architecture>> - Architectural style leveraging GoF principles
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -73,6 +73,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 ### SSOT (Single Source of Truth)
 - **Core:** One system is the master for specific data
 
+### GoF Design Patterns
+- **Also known as:** Design Patterns, Gang of Four Patterns
+- **Proponents:** Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
+- **Core:** 23 patterns in 3 categories (Creational, Structural, Behavioral), pattern language, composition over inheritance, program to an interface
+
 ### Patterns of Enterprise Application Architecture (PEAA)
 - **Proponents:** Martin Fowler
 - **Core:** Repository, Unit of Work, Data Mapper, Active Record, etc.


### PR DESCRIPTION
## Summary

- Adds **GoF Design Patterns** as a new semantic anchor
- Covers Gamma/Helm/Johnson/Vlissides' 23 OO design patterns (1994)
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

GoF activates: 23 patterns in 3 categories (Creational, Structural, Behavioral), pattern language as shared vocabulary, composition over inheritance, program to an interface, design for change.

Distinct from: Fowler Patterns (enterprise application architecture — Repository, Unit of Work, Data Mapper). GoF = OO object collaboration and reuse; Fowler = application-layer structure.

"Fowler Patterns" already exists as an anchor but covers PEAA, not GoF. These are complementary but separate bodies of knowledge.

## Files changed

- `docs/anchors/gof-design-patterns.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Design Principles section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry