### PR TITLE
feat: Add Chain of Responsibility semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -21,6 +21,8 @@ include::anchors/pyramid-principle.adoc[leveloffset=+2]
 
 == Design Principles & Patterns
 
+include::anchors/chain-of-responsibility.adoc[leveloffset=+2]
+
 include::anchors/dry-principle.adoc[leveloffset=+2]
 
 include::anchors/fowler-patterns.adoc[leveloffset=+2]

--- a/docs/anchors/chain-of-responsibility.adoc
+++ b/docs/anchors/chain-of-responsibility.adoc
@@ -1,0 +1,46 @@
+= Chain of Responsibility
+:categories: design-principles
+:roles: software-developer, software-architect
+:proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
+:related: gof-design-patterns
+:tags: design-pattern, behavioral, middleware, pipeline, handler-chain, request-processing
+
+[%collapsible]
+====
+Also known as:: Handler Chain, Middleware Pattern
+
+[discrete]
+== *Core Concepts*:
+
+Handler chain:: Request passes along an ordered chain of potential handlers
+
+Process or pass:: Each handler decides to process the request, pass it to the next handler, or both
+
+Decoupled sender and receiver:: Sender doesn't know which handler will process the request
+
+Middleware pattern:: Modern incarnation in web frameworks (Express.js, Django, ASP.NET middleware pipeline)
+
+Dynamic chain composition:: Handlers can be added, removed, or reordered at runtime
+
+Single responsibility:: Each handler focuses on exactly one concern (authentication, logging, validation)
+
+Fallback handling:: Default handler at the end of the chain for unhandled requests
+
+Short-circuit capability:: Handlers can terminate the chain early (e.g., reject unauthorized requests)
+
+
+Key Proponents:: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides ("Design Patterns", 1994)
+
+[discrete]
+== *When to Use*:
+
+* Request processing pipelines (HTTP middleware, bot handler groups)
+* Event handling with multiple potential handlers
+* Validation chains with multiple independent rules
+* Logging, authentication, and authorization layers
+
+[discrete]
+== *Related Anchors*:
+
+* <<gof-design-patterns,GoF Design Patterns>> - Chain of Responsibility is one of 23 GoF behavioral patterns
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -61,6 +61,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 
 ## Design Principles
 
+### Chain of Responsibility
+- **Also known as:** Handler Chain, Middleware Pattern
+- **Proponents:** Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
+- **Core:** Request passes along handler chain, each handler decides process-or-pass, middleware concept, decoupled sender/receiver
+
 ### SOLID Principles
 - **Core:** Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion
 


### PR DESCRIPTION
## Summary

- Adds **Chain of Responsibility** as a new semantic anchor
- Covers the GoF behavioral pattern for handler chains and middleware pipelines
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

Chain of Responsibility activates: GoF behavioral pattern, request passes along handler chain, each handler decides process-or-pass, middleware concept (Express/Django), Telegram handler groups, dynamic chain composition, short-circuit capability.

Rich enough for a standalone anchor due to its ubiquity as the middleware pattern in modern frameworks — it transcends its GoF origin.

## Files changed

- `docs/anchors/chain-of-responsibility.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Design Principles section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry