### PR TITLE
feat: Add Test Double (Meszaros) semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -157,6 +157,8 @@ include::anchors/property-based-testing.adoc[leveloffset=+2]
 
 include::anchors/tdd-chicago-school.adoc[leveloffset=+2]
 
+include::anchors/test-double-meszaros.adoc[leveloffset=+2]
+
 include::anchors/tdd-london-school.adoc[leveloffset=+2]
 
 include::anchors/testing-pyramid.adoc[leveloffset=+2]

--- a/docs/anchors/test-double-meszaros.adoc
+++ b/docs/anchors/test-double-meszaros.adoc
@@ -1,0 +1,47 @@
+= Test Double (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer, educator
+:proponents: Gerard Meszaros
+:related: tdd-london-school, tdd-chicago-school, property-based-testing
+:tags: test-double, mock, stub, spy, fake, dummy, xunit, testing, isolation
+
+[%collapsible]
+====
+Full Name:: Test Double taxonomy according to Gerard Meszaros
+
+Also known as:: xUnit Test Patterns test double taxonomy
+
+[discrete]
+== *Core Concepts*:
+
+Dummy:: Object passed to fill a parameter list but never actually used
+
+Stub:: Provides canned responses to calls made during a test; no verification of interactions
+
+Spy:: Records calls made to it for later assertion; a stub that also captures interaction data
+
+Mock:: Pre-programmed with expectations; verifies that specific interactions occurred (interaction-based verification)
+
+Fake:: Working simplified implementation with shortcuts unsuitable for production (e.g., in-memory database, in-memory repository)
+
+Test Double:: Umbrella term for any object substituted for a real dependency during testing
+
+Vocabulary precision:: Distinguishing what a double IS (taxonomy) from when to use it (TDD school philosophy)
+
+
+Key Proponent:: Gerard Meszaros ("xUnit Test Patterns: Refactoring Test Code", 2007)
+
+[discrete]
+== *When to Use*:
+
+* Communicating precisely about test isolation strategies
+* Choosing the right type of double for a given testing scenario
+* Avoiding vocabulary collisions (e.g., calling a Stub a "mock" triggers wrong reasoning)
+* Teaching or reviewing test code with shared terminology
+
+[discrete]
+== *Related Anchors*:
+
+* <<tdd-london-school,TDD, London School>> - Philosophy of when to use doubles heavily (interaction-based)
+* <<tdd-chicago-school,TDD, Chicago School>> - Philosophy of minimal doubling (state-based)
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -14,6 +14,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Kent Beck, Martin Fowler
 - **Core:** State-based testing, real objects over mocks, refactoring-focused
 
+### Test Double (Meszaros)
+- **Proponents:** Gerard Meszaros
+- **Core:** Taxonomy of test substitutes — Dummy (unused), Stub (canned responses), Spy (records calls), Mock (verifies interactions), Fake (simplified implementation)
+
 ### Testing Pyramid
 - **Core:** Many unit tests, fewer integration tests, fewest E2E tests
 


### PR DESCRIPTION
## Summary

- Adds **Test Double (Meszaros)** as a new semantic anchor
- Covers Gerard Meszaros' 5-type taxonomy from xUnit Test Patterns (2007)
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

The catalog has London School TDD ("mock-heavy") and Chicago School TDD ("minimal mocking"), but neither defines *what kind of double* you're using. Meszaros' taxonomy is the canonical classification:

- **Dummy** — passed but never used
- **Stub** — canned responses, no verification
- **Spy** — records calls for later assertion
- **Mock** — pre-programmed expectations, verifies interactions
- **Fake** — working simplified implementation

This is orthogonal to both TDD schools: they define *when/how much* to use doubles, Meszaros defines *what the double IS*. London School TDD already mentions "test doubles (mocks, stubs)" in passing but never defines the taxonomy — this anchor fills that gap.

## Files changed

- `docs/anchors/test-double-meszaros.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Testing & Quality section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry