### PR TITLE
feat: Add Event-Driven Architecture semantic anchor

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -113,6 +113,8 @@ include::anchors/clean-architecture.adoc[leveloffset=+2]
 
 include::anchors/domain-driven-design.adoc[leveloffset=+2]
 
+include::anchors/event-driven-architecture.adoc[leveloffset=+2]
+
 include::anchors/gom.adoc[leveloffset=+2]
 
 include::anchors/hexagonal-architecture.adoc[leveloffset=+2]

--- a/docs/anchors/event-driven-architecture.adoc
+++ b/docs/anchors/event-driven-architecture.adoc
@@ -1,0 +1,50 @@
+= Event-Driven Architecture
+:categories: software-architecture
+:roles: software-architect, software-developer, devops-engineer
+:proponents: Gregor Hohpe, Bobby Woolf, Martin Fowler
+:related: domain-driven-design, hexagonal-architecture, clean-architecture
+:tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
+
+[%collapsible]
+====
+Also known as:: EDA, Message-Driven Architecture
+
+[discrete]
+== *Core Concepts*:
+
+Event producers and consumers:: Components communicate by emitting and reacting to events rather than direct calls
+
+Publish-subscribe:: Producers publish events without knowing which consumers will process them
+
+Asynchronous decoupling:: Sender and receiver operate independently in time; no blocking request-response
+
+Message queue:: Intermediary that buffers events between producers and consumers (SQS, RabbitMQ, Kafka)
+
+At-least-once delivery:: Most messaging systems guarantee delivery but may deliver duplicates, requiring idempotent consumers
+
+Eventual consistency:: System state converges over time rather than being immediately consistent after each operation
+
+Event notification:: Lightweight event signals that something happened; consumers decide whether to act
+
+Event-carried state transfer:: Events carry enough data for consumers to process without calling back to the producer
+
+Choreography vs. orchestration:: Events can trigger distributed workflows implicitly (choreography) or via a central coordinator (orchestration)
+
+
+Key Proponents:: Gregor Hohpe, Bobby Woolf ("Enterprise Integration Patterns", 2003), Martin Fowler ("What do you mean by Event-Driven?", 2017)
+
+[discrete]
+== *When to Use*:
+
+* Systems requiring loose coupling between components
+* Workloads with asynchronous processing pipelines
+* Architectures that need independent scaling of producers and consumers
+* Distributed systems where components must evolve independently
+
+[discrete]
+== *Related Anchors*:
+
+* <<domain-driven-design,Domain-Driven Design>> - Domain events are a DDD building block
+* <<hexagonal-architecture,Hexagonal Architecture>> - Message queues as driven adapters
+* <<clean-architecture,Clean Architecture>> - Events cross architectural boundaries via interfaces
+====

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -40,6 +40,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Eric Evans
 - **Core:** Ubiquitous language, bounded contexts, aggregates, entities, value objects
 
+### Event-Driven Architecture
+- **Also known as:** EDA, Message-Driven Architecture
+- **Proponents:** Gregor Hohpe, Bobby Woolf, Martin Fowler
+- **Core:** Async decoupling via events, publish-subscribe, event producers/consumers, eventual consistency, idempotency
+
 ### arc42 Architecture Documentation
 - **Proponents:** Gernot Starke, Peter Hruschka
 - **Core:** 12-section template for documenting software architecture


### PR DESCRIPTION
## Summary

- Adds **Event-Driven Architecture** as a new semantic anchor
- Covers Hohpe/Woolf's async decoupling patterns from Enterprise Integration Patterns (2003)
- Includes anchor file, all-anchors include, and AgentSkill catalog entry

## Why this anchor?

EDA is a foundational architectural style with zero coverage in the catalog. It activates: event producers/consumers, publish-subscribe, async decoupling, message queues, at-least-once delivery, idempotency, eventual consistency, choreography vs. orchestration.

The catalog already has architectural anchors (Hexagonal, Clean, DDD) but none covering event-based communication — a gap given how pervasive async messaging is in modern systems.

Key separations from existing anchors:
- **vs. CQRS** (if accepted): CQRS separates read/write models and can use events but doesn't have to — architectural responsibility, not communication style
- **vs. Observer (GoF)**: single-process, synchronous notification — EDA is distributed and async
- **vs. DDD Domain Events**: DDD events are a tactical building block; EDA is the architectural style that governs how events flow between components

## Files changed

- `docs/anchors/event-driven-architecture.adoc` — new anchor file
- `docs/all-anchors.adoc` — added include in Software Architecture section
- `skill/semantic-anchor-translator/references/catalog.md` — added catalog entry