### PR TITLE
fix: remove table of contents from changelog page

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -1,7 +1,4 @@
 = Changelog
-:toc:
-:toc-placement: preamble
-:toclevels: 2
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 


### PR DESCRIPTION
## Summary
- Remove `:toc:` attributes from changelog.adoc to hide the table of contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Vereinfachte Dokumentationsstruktur durch Entfernung von Inhaltsverzeichnis-Konfigurationseinstellungen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->