### PR TITLE
feat: replace Font Awesome anchor icon with ⚓ emoji

### DIFF
--- a/docs/spec-driven-workflow.de.html
+++ b/docs/spec-driven-workflow.de.html
@@ -544,7 +544,7 @@ Jede Zeile Code, jeder Test, jede Dokumentationsdatei wurde von der KI unter mei
 </td>
 <td class="content">
 <div class="paragraph">
-<p>Semantic Anchors sind im Dokument mit <span class="icon"><i class="fa fa-anchor"></i></span> gekennzeichnet.
+<p>Semantic Anchors sind im Dokument mit ⚓ gekennzeichnet.
 Ein Klick auf einen Anker führt zur vollständigen Definition auf der Semantic Anchors Website.</p>
 </div>
 </td>
@@ -613,16 +613,16 @@ Man reviewt an den Übergängen zwischen Phasen, nicht nach jeder einzelnen Code
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/plain-english-strunk-white"><strong>Plain English nach Strunk &amp; White</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/plain-english-strunk-white"><strong>Plain English nach Strunk &amp; White</strong></a></dt>
 <dd>
 <p>Alle Dokumentation verwendet kurze Sätze, aktive Sprache und keine überflüssigen Wörter.
-Für deutschsprachige Dokumentation gilt analog <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gutes-deutsch-wolf-schneider"><strong>Gutes Deutsch nach Wolf Schneider</strong></a>.</p>
+Für deutschsprachige Dokumentation gilt analog ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gutes-deutsch-wolf-schneider"><strong>Gutes Deutsch nach Wolf Schneider</strong></a>.</p>
 </dd>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/conventional-commits"><strong>Conventional Commits</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/conventional-commits"><strong>Conventional Commits</strong></a></dt>
 <dd>
 <p>Alle Commits folgen einem standardisierten Format für eine saubere, maschinenlesbare Git-History.</p>
 </dd>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/docs-as-code"><strong>Docs-as-Code nach Ralf D. Müller</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/docs-as-code"><strong>Docs-as-Code nach Ralf D. Müller</strong></a></dt>
 <dd>
 <p>Dokumentation lebt im Repository als AsciiDoc, gebaut von <a href="https://doctoolchain.org">docToolchain</a>.
 Docs-as-Code behandelt Dokumentation wie Quellcode: versioniert, reviewt und automatisch gebaut.</p>
@@ -647,7 +647,7 @@ Docs-as-Code behandelt Dokumentation wie Quellcode: versioniert, reviewt und aut
 <p>Git-Repository initialisieren</p>
 </li>
 <li>
-<p><a href="https://doctoolchain.org">docToolchain</a> installieren und das <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a>-Template herunterladen</p>
+<p><a href="https://doctoolchain.org">docToolchain</a> installieren und das ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a>-Template herunterladen</p>
 </li>
 <li>
 <p>KI-Coding-Umgebung mit einer <code>AGENTS.md</code> konfigurieren (oder toolspezifisches Äquivalent wie <code>CLAUDE.md</code>)</p>
@@ -761,7 +761,7 @@ Der nächste Schritt bringt Struktur in die rohen Ideen.</p>
 <div class="sect2">
 <h3 id="_schritt_2_anforderungen_mit_der_sokratischen_methode_klären">Schritt 2: Anforderungen mit der Sokratischen Methode klären</h3>
 <div class="paragraph">
-<p>Die KI auffordern, die <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/socratic-method"><strong>Sokratische Methode</strong></a> zur Klärung der Anforderungen zu nutzen.</p>
+<p>Die KI auffordern, die ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/socratic-method"><strong>Sokratische Methode</strong></a> zur Klärung der Anforderungen zu nutzen.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -783,7 +783,7 @@ Die Einschränkung "höchstens 3 Fragen" verhindert Fragen-Überflutung.</p>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/mece"><strong>MECE</strong></a> (Mutually Exclusive, Collectively Exhaustive) stellt sicher, dass die Fragen alle Bereiche überlappungsfrei abdecken.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/mece"><strong>MECE</strong></a> (Mutually Exclusive, Collectively Exhaustive) stellt sicher, dass die Fragen alle Bereiche überlappungsfrei abdecken.</p>
 </div>
 <div class="paragraph">
 <p>Den Dialog fortführen, bis man mit der KI zufrieden ist, dass die Anforderungen klar sind.</p>
@@ -817,7 +817,7 @@ Save as .adoc files in src/docs/specs/.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gherkin"><strong>Gherkin</strong></a> (Given/When/Then) liefert Akzeptanzkriterien, die sowohl für Menschen lesbar als auch maschinell testbar sind.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gherkin"><strong>Gherkin</strong></a> (Given/When/Then) liefert Akzeptanzkriterien, die sowohl für Menschen lesbar als auch maschinell testbar sind.
 Diese Kriterien werden später die Grundlage für TDD.</p>
 </div>
 <div class="paragraph">
@@ -842,21 +842,21 @@ Use PlantUML C4 diagrams for architecture visualization.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> bietet 12 Abschnitte, die alles von Kontextabgrenzung bis Deployment abdecken.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> bietet 12 Abschnitte, die alles von Kontextabgrenzung bis Deployment abdecken.
 Die KI kennt die Template-Struktur und füllt sie passend.</p>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/c4-diagrams"><strong>C4 Diagrams</strong></a> kombiniert mit PlantUML ermöglichen textbasierte Architektur-Visualisierung auf vier Ebenen: Context, Container, Component, Code.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/c4-diagrams"><strong>C4 Diagrams</strong></a> kombiniert mit PlantUML ermöglichen textbasierte Architektur-Visualisierung auf vier Ebenen: Context, Container, Component, Code.
 Die KI kann diese Diagramme ohne grafische Tools erstellen und ändern.</p>
 </div>
 <div class="sect3">
 <h4 id="_architecture_decision_records">Architecture Decision Records</h4>
 <div class="paragraph">
-<p>Architekturentscheidungen werden als <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/adr-according-to-nygard"><strong>ADRs nach Nygard</strong></a> dokumentiert.
+<p>Architekturentscheidungen werden als ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/adr-according-to-nygard"><strong>ADRs nach Nygard</strong></a> dokumentiert.
 Jedes ADR folgt der Struktur: Titel, Status, Kontext, Entscheidung, Konsequenzen.</p>
 </div>
 <div class="paragraph">
-<p>Für jede Entscheidung wird eine <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/pugh-matrix"><strong>Pugh-Matrix</strong></a> mit 3-Punkt-Skala (-1, 0, +1) erstellt, um Alternativen gegen Qualitätskriterien zu bewerten.</p>
+<p>Für jede Entscheidung wird eine ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/pugh-matrix"><strong>Pugh-Matrix</strong></a> mit 3-Punkt-Skala (-1, 0, +1) erstellt, um Alternativen gegen Qualitätskriterien zu bewerten.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -878,7 +878,7 @@ Alle ADRs müssen sich an den Qualitätszielen aus arc42 Abschnitt 1.2 orientier
 <div class="sect2">
 <h3 id="_schritt_6_architektur_review_atam">Schritt 6: Architektur-Review (ATAM)</h3>
 <div class="paragraph">
-<p>Ein Architektur-Review mit der <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/atam"><strong>Architecture Tradeoff Analysis Method (ATAM)</strong></a> durchführen:</p>
+<p>Ein Architektur-Review mit der ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/atam"><strong>Architecture Tradeoff Analysis Method (ATAM)</strong></a> durchführen:</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -912,10 +912,10 @@ Mark dependencies between issues with labels or cross-references.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>INVEST</strong> stellt sicher, dass User Stories Independent, Negotiable, Valuable, Estimable, Small und Testable sind.</p>
+<p>⚓ <strong>INVEST</strong> stellt sicher, dass User Stories Independent, Negotiable, Valuable, Estimable, Small und Testable sind.</p>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/moscow"><strong>MoSCoW</strong></a> (Must have, Should have, Could have, Won&#8217;t have) liefert klare Priorisierung.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/moscow"><strong>MoSCoW</strong></a> (Must have, Should have, Could have, Won&#8217;t have) liefert klare Priorisierung.</p>
 </div>
 <div class="paragraph">
 <p>Die initiale Backlog-Reihenfolge folgt der EPIC-Sequenz.
@@ -969,15 +969,15 @@ Check if the spec or architecture docs need updating.</code></pre>
 </ol>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>TDD</strong> (Test-Driven Development) gibt es in zwei Schulen:</p>
+<p>⚓ <strong>TDD</strong> (Test-Driven Development) gibt es in zwei Schulen:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-london-school"><strong>London School</strong></a> (Mockist): Unit Under Test isolieren, Abhängigkeiten mocken. Gut für interaktionslastigen Code.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-london-school"><strong>London School</strong></a> (Mockist): Unit Under Test isolieren, Abhängigkeiten mocken. Gut für interaktionslastigen Code.</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-chicago-school"><strong>Chicago School</strong></a> (Classicist): Verhalten über die öffentliche API testen, echte Kollaborateure nutzen. Gut für zustandsbasierte Logik.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-chicago-school"><strong>Chicago School</strong></a> (Classicist): Verhalten über die öffentliche API testen, echte Kollaborateure nutzen. Gut für zustandsbasierte Logik.</p>
 </li>
 </ul>
 </div>
@@ -990,16 +990,16 @@ Check if the spec or architecture docs need updating.</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/dry-principle"><strong>DRY</strong></a> (Don&#8217;t Repeat Yourself)</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/dry-principle"><strong>DRY</strong></a> (Don&#8217;t Repeat Yourself)</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-principles"><strong>SOLID</strong></a>-Prinzipien</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-principles"><strong>SOLID</strong></a>-Prinzipien</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>KISS</strong> (Keep It Simple, Stupid)</p>
+<p>⚓ <strong>KISS</strong> (Keep It Simple, Stupid)</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/domain-driven-design"><strong>Ubiquitous Language</strong></a> aus Domain-Driven Design: dieselben Begriffe im Code wie in der Spezifikation</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/domain-driven-design"><strong>Ubiquitous Language</strong></a> aus Domain-Driven Design: dieselben Begriffe im Code wie in der Spezifikation</p>
 </li>
 </ul>
 </div>
@@ -1084,7 +1084,7 @@ Create GitHub issues for any vulnerabilities found.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/owasp-top-10"><strong>OWASP Top 10</strong></a> deckt die kritischsten Sicherheitsrisiken für Webanwendungen ab.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/owasp-top-10"><strong>OWASP Top 10</strong></a> deckt die kritischsten Sicherheitsrisiken für Webanwendungen ab.
 Auch für CLI-Tools oder Libraries identifiziert die Methodik gängige Schwachstellenmuster.</p>
 </div>
 </div>

--- a/docs/spec-driven-workflow.html
+++ b/docs/spec-driven-workflow.html
@@ -544,7 +544,7 @@ Every line of code, every test, every documentation file was written by the AI u
 </td>
 <td class="content">
 <div class="paragraph">
-<p>Semantic Anchors marked with <span class="icon"><i class="fa fa-anchor"></i></span> are highlighted throughout this document.
+<p>Semantic Anchors marked with ⚓ are highlighted throughout this document.
 Click on any anchor to see its full definition on the Semantic Anchors website.</p>
 </div>
 </td>
@@ -613,15 +613,15 @@ You review at the boundaries between phases, not after every line of code.</p>
 </div>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/plain-english-strunk-white"><strong>Plain English according to Strunk &amp; White</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/plain-english-strunk-white"><strong>Plain English according to Strunk &amp; White</strong></a></dt>
 <dd>
 <p>All documentation uses short sentences, active voice, and no unnecessary words.</p>
 </dd>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/conventional-commits"><strong>Conventional Commits</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/conventional-commits"><strong>Conventional Commits</strong></a></dt>
 <dd>
 <p>All commits follow a standardized format for a clean, parseable git history.</p>
 </dd>
-<dt class="hdlist1"><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/docs-as-code"><strong>Docs-as-Code according to Ralf D. Müller</strong></a></dt>
+<dt class="hdlist1">⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/docs-as-code"><strong>Docs-as-Code according to Ralf D. Müller</strong></a></dt>
 <dd>
 <p>Documentation lives in the repository as AsciiDoc, built by <a href="https://doctoolchain.org">docToolchain</a>.
 Docs-as-Code treats documentation like source code: version-controlled, peer-reviewed, and built automatically.</p>
@@ -646,7 +646,7 @@ Docs-as-Code treats documentation like source code: version-controlled, peer-rev
 <p>Initialize a git repository</p>
 </li>
 <li>
-<p>Install <a href="https://doctoolchain.org">docToolchain</a> and download the <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> template</p>
+<p>Install <a href="https://doctoolchain.org">docToolchain</a> and download the ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> template</p>
 </li>
 <li>
 <p>Configure your AI coding environment with an <code>AGENTS.md</code> (or tool-specific equivalent like <code>CLAUDE.md</code>)</p>
@@ -760,7 +760,7 @@ The next step will bring structure to your raw ideas.</p>
 <div class="sect2">
 <h3 id="_step_2_clarify_requirements_with_the_socratic_method">Step 2: Clarify Requirements with the Socratic Method</h3>
 <div class="paragraph">
-<p>Prompt the AI to use the <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/socratic-method"><strong>Socratic Method</strong></a> to clarify requirements.</p>
+<p>Prompt the AI to use the ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/socratic-method"><strong>Socratic Method</strong></a> to clarify requirements.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -782,7 +782,7 @@ The constraint "at most 3 questions" prevents question overload.</p>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/mece"><strong>MECE</strong></a> (Mutually Exclusive, Collectively Exhaustive) ensures questions cover all areas without overlap.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/mece"><strong>MECE</strong></a> (Mutually Exclusive, Collectively Exhaustive) ensures questions cover all areas without overlap.</p>
 </div>
 <div class="paragraph">
 <p>Continue the dialogue until both you and the AI are satisfied that the requirements are clear.</p>
@@ -816,7 +816,7 @@ Save as .adoc files in src/docs/specs/.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gherkin"><strong>Gherkin</strong></a> (Given/When/Then) provides acceptance criteria that are both human-readable and machine-testable.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/gherkin"><strong>Gherkin</strong></a> (Given/When/Then) provides acceptance criteria that are both human-readable and machine-testable.
 These criteria become the foundation for TDD later.</p>
 </div>
 <div class="paragraph">
@@ -841,21 +841,21 @@ Use PlantUML C4 diagrams for architecture visualization.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> provides 12 sections covering everything from context to deployment.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42"><strong>arc42</strong></a> provides 12 sections covering everything from context to deployment.
 The AI knows the template structure and fills it appropriately.</p>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/c4-diagrams"><strong>C4 Diagrams</strong></a> combined with PlantUML provide text-based architecture visualization at four levels: Context, Container, Component, Code.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/c4-diagrams"><strong>C4 Diagrams</strong></a> combined with PlantUML provide text-based architecture visualization at four levels: Context, Container, Component, Code.
 The AI can create and modify these diagrams without graphical tools.</p>
 </div>
 <div class="sect3">
 <h4 id="_architecture_decision_records">Architecture Decision Records</h4>
 <div class="paragraph">
-<p>Architecture decisions are documented as <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/adr-according-to-nygard"><strong>ADRs according to Nygard</strong></a>.
+<p>Architecture decisions are documented as ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/adr-according-to-nygard"><strong>ADRs according to Nygard</strong></a>.
 Each ADR follows the structure: Title, Status, Context, Decision, Consequences.</p>
 </div>
 <div class="paragraph">
-<p>For each decision, create a <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/pugh-matrix"><strong>Pugh Matrix</strong></a> with a 3-point scale (-1, 0, +1) to evaluate alternatives against quality criteria.</p>
+<p>For each decision, create a ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/pugh-matrix"><strong>Pugh Matrix</strong></a> with a 3-point scale (-1, 0, +1) to evaluate alternatives against quality criteria.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -877,7 +877,7 @@ All ADRs must align with the quality goals defined in arc42 Section 1.2.</p>
 <div class="sect2">
 <h3 id="_step_6_architecture_review_atam">Step 6: Architecture Review (ATAM)</h3>
 <div class="paragraph">
-<p>Conduct an architecture review using the <span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/atam"><strong>Architecture Tradeoff Analysis Method (ATAM)</strong></a>:</p>
+<p>Conduct an architecture review using the ⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/atam"><strong>Architecture Tradeoff Analysis Method (ATAM)</strong></a>:</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -911,10 +911,10 @@ Mark dependencies between issues with labels or cross-references.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>INVEST</strong> ensures User Stories are Independent, Negotiable, Valuable, Estimable, Small, and Testable.</p>
+<p>⚓ <strong>INVEST</strong> ensures User Stories are Independent, Negotiable, Valuable, Estimable, Small, and Testable.</p>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/moscow"><strong>MoSCoW</strong></a> (Must have, Should have, Could have, Won&#8217;t have) provides clear prioritization.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/moscow"><strong>MoSCoW</strong></a> (Must have, Should have, Could have, Won&#8217;t have) provides clear prioritization.</p>
 </div>
 <div class="paragraph">
 <p>The initial backlog order follows the EPIC sequence.
@@ -968,15 +968,15 @@ Check if the spec or architecture docs need updating.</code></pre>
 </ol>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>TDD</strong> (Test-Driven Development) comes in two schools:</p>
+<p>⚓ <strong>TDD</strong> (Test-Driven Development) comes in two schools:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-london-school"><strong>London School</strong></a> (mockist): isolate the unit under test, mock dependencies. Good for interaction-heavy code.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-london-school"><strong>London School</strong></a> (mockist): isolate the unit under test, mock dependencies. Good for interaction-heavy code.</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-chicago-school"><strong>Chicago School</strong></a> (classicist): test behavior through the public API, use real collaborators. Good for state-based logic.</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-chicago-school"><strong>Chicago School</strong></a> (classicist): test behavior through the public API, use real collaborators. Good for state-based logic.</p>
 </li>
 </ul>
 </div>
@@ -989,16 +989,16 @@ Check if the spec or architecture docs need updating.</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/dry-principle"><strong>DRY</strong></a> (Don&#8217;t Repeat Yourself)</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/dry-principle"><strong>DRY</strong></a> (Don&#8217;t Repeat Yourself)</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-principles"><strong>SOLID</strong></a> principles</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-principles"><strong>SOLID</strong></a> principles</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <strong>KISS</strong> (Keep It Simple, Stupid)</p>
+<p>⚓ <strong>KISS</strong> (Keep It Simple, Stupid)</p>
 </li>
 <li>
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/domain-driven-design"><strong>Ubiquitous Language</strong></a> from Domain-Driven Design: use the same terms in code as in the specification</p>
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/domain-driven-design"><strong>Ubiquitous Language</strong></a> from Domain-Driven Design: use the same terms in code as in the specification</p>
 </li>
 </ul>
 </div>
@@ -1083,7 +1083,7 @@ Create GitHub issues for any vulnerabilities found.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p><span class="icon"><i class="fa fa-anchor"></i></span> <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/owasp-top-10"><strong>OWASP Top 10</strong></a> covers the most critical web application security risks.
+<p>⚓ <a href="https://llm-coding.github.io/Semantic-Anchors/#/anchor/owasp-top-10"><strong>OWASP Top 10</strong></a> covers the most critical web application security risks.
 Even for CLI tools or libraries, the methodology identifies common vulnerability patterns.</p>
 </div>
 </div>


### PR DESCRIPTION
## Summary

- Replace `<span class="icon"><i class="fa fa-anchor"></i></span>` with the ⚓ emoji in both EN and DE workflow documentation
- The emoji is copyable — when users copy text from the site, the anchor symbol is preserved in any target system
- No dependency on Font Awesome for the anchor marker

Note: Font Awesome remains loaded for admonition icons (note, tip, warning, etc.)

## Test plan

- [ ] Verify ⚓ emoji displays before each Semantic Anchor reference
- [ ] Copy text with anchor markers and paste elsewhere — verify ⚓ is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Ankerelement-Ikonen in HTML-Dokumentationsdateien aktualisiert: Ersetzung des Font-Awesome-Icon-Markups durch einfache ⚓-Emoji-Symbole für verbesserte visuelle Klarheit und vereinfachte Wartbarkeit.

* **Style**
  * Visuelle Konsistenz in Dokumentationsdateien erhöht durch Vereinheitlichung der Darstellung von Navigationselementen. Keine Auswirkungen auf Funktionalität oder Dokumentstruktur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->