### PR TITLE
docs: update workflow with non-determinism, spec-anchored, and further reading

### DIFF
--- a/docs/spec-driven-workflow.de.html
+++ b/docs/spec-driven-workflow.de.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -590,6 +590,8 @@ Die Phasen in diesem Dokument sind darauf ausgelegt, genau solche präzisen, abg
 <p>Das hängt direkt mit Shannons Theorem zusammen.
 Jeder kleine Schritt ist eine kurze Übertragung über den verrauschten Kanal.
 Kurze Übertragungen mit Fehlerkorrektur (Tests, Linting, Review) sind weit zuverlässiger als eine lange, unkontrollierte Übertragung.
+LLM-Ausgaben sind inhärent nicht-deterministisch&#8201;&#8212;&#8201;derselbe Prompt kann unterschiedlichen Code erzeugen.
+TDD und Reviews sind die Fehlerkorrektur, die diesen verrauschten Kanal nutzbar macht.
 Der Agent arbeitet in einer engen Schleife: implementieren, testen, committen, Dokumentation prüfen.
 Man reviewt an den Übergängen zwischen Phasen, nicht nach jeder einzelnen Codezeile.</p>
 </div>
@@ -669,7 +671,7 @@ chmod +x dtcw
 <div class="sect2">
 <h3 id="_agents_md_als_projektgedächtnis">AGENTS.md als Projektgedächtnis</h3>
 <div class="paragraph">
-<p><code>AGENTS.md</code> ist ein offener Standard zur Steuerung von KI-Coding-Agenten.
+<p><a href="https://agents.md"><code>AGENTS.md</code></a> ist ein offener Standard zur Steuerung von KI-Coding-Agenten.
 Die Datei liegt im Repository-Root und wird automatisch zu Beginn jeder Session gelesen.
 Sie dient als Projektgedächtnis: Coding-Konventionen, Architekturentscheidungen, Dateistruktur und Verweise auf wichtige Dokumente.</p>
 </div>
@@ -1018,7 +1020,8 @@ or architecture documentation need updating?</code></pre>
 </div>
 <div class="paragraph">
 <p>Die Docs aktualisieren, bevor es weitergeht.
-So bleibt die Spezifikation ein lebendiges Dokument statt eines veralteten Artefakts.</p>
+So bleibt die Spezifikation ein lebendiges Dokument statt eines veralteten Artefakts.
+Die Spec ist nicht nur ein Mittel zur Codegenerierung&#8201;&#8212;&#8201;sie bleibt die autoritative Beschreibung des Systemverhaltens, gepflegt neben dem Code, solange das Projekt lebt.</p>
 </div>
 </div>
 <div class="sect3">
@@ -1286,6 +1289,16 @@ Die eigene Aufgabe ist es zu wissen, welchen Anker man wann einsetzt, und die Er
 <p>Beim nächsten Projekt ausprobieren.
 Mit der Sokratischen Methode für die Anforderungen starten und sehen, wohin es führt.
 Wer Anker entdeckt, die im eigenen Workflow gut funktionieren: <a href="https://github.com/LLM-Coding/Semantic-Anchors/blob/main/CONTRIBUTING.md">zur Sammlung beitragen</a>.</p>
+</div>
+<div class="sect2">
+<h3 id="_weiterführende_literatur">Weiterführende Literatur</h3>
+<div class="ulist">
+<ul>
+<li>
+<p>Birgitta Böckeler, <a href="https://martinfowler.com/articles/exploring-gen-ai/">Exploring Gen AI</a> (martinfowler.com)&#8201;&#8212;&#8201;eine kritische Analyse von Spec-Driven-Development-Tools (Kiro, spec-kit, Tessl) und deren Trade-offs. Untersucht, wo aufwändige Upfront-Spezifikationen helfen und wo sie Overhead erzeugen.</p>
+</li>
+</ul>
+</div>
 </div>
 </div>
 </div>

--- a/docs/spec-driven-workflow.html
+++ b/docs/spec-driven-workflow.html
@@ -590,6 +590,8 @@ The phases described in this document are designed to produce exactly that kind 
 <p>This connects directly to Shannon&#8217;s theorem.
 Each small step is a short transmission over the noisy channel.
 Short transmissions with error correction (tests, linting, review) are far more reliable than one long, unchecked transmission.
+LLM output is inherently non-deterministic&#8201;&#8212;&#8201;the same prompt can produce different code each time.
+TDD and reviews are the error correction that makes this noisy channel usable.
 The agent works in a tight loop: implement, test, commit, check docs.
 You review at the boundaries between phases, not after every line of code.</p>
 </div>
@@ -668,7 +670,7 @@ chmod +x dtcw
 <div class="sect2">
 <h3 id="_agents_md_as_project_memory">AGENTS.md as Project Memory</h3>
 <div class="paragraph">
-<p><code>AGENTS.md</code> is an open standard for guiding AI coding agents.
+<p><a href="https://agents.md"><code>AGENTS.md</code></a> is an open standard for guiding AI coding agents.
 The file lives in your repository root and is read automatically at the start of every session.
 It serves as the project memory: coding conventions, architectural decisions, file structure, and pointers to important documents.</p>
 </div>
@@ -1017,7 +1019,8 @@ or architecture documentation need updating?</code></pre>
 </div>
 <div class="paragraph">
 <p>Update the docs before continuing.
-This keeps the specification a living document rather than a stale artifact.</p>
+This keeps the specification a living document rather than a stale artifact.
+The spec is not just a means to generate code&#8201;&#8212;&#8201;it remains the authoritative description of the system&#8217;s behavior, maintained alongside the code for as long as the project lives.</p>
 </div>
 </div>
 <div class="sect3">
@@ -1285,6 +1288,16 @@ Your job is to know which anchor to use when, and to verify the results.</p>
 <p>Try it on your next project.
 Start with the Socratic Method for requirements and see where it leads.
 If you discover anchors that work well in your workflow, <a href="https://github.com/LLM-Coding/Semantic-Anchors/blob/main/CONTRIBUTING.md">contribute them to the collection</a>.</p>
+</div>
+<div class="sect2">
+<h3 id="_further_reading">Further Reading</h3>
+<div class="ulist">
+<ul>
+<li>
+<p>Birgitta Böckeler, <a href="https://martinfowler.com/articles/exploring-gen-ai/">Exploring Gen AI</a> (martinfowler.com)&#8201;&#8212;&#8201;a critical analysis of spec-driven development tools (Kiro, spec-kit, Tessl) and their trade-offs. Examines where elaborate upfront specifications help and where they create overhead.</p>
+</li>
+</ul>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary

Updates to the Spec-Driven Workflow documentation based on comparison with Birgitta Böckeler's SDD analysis on martinfowler.com:

- **Non-determinism**: Explicitly name LLM non-determinism at the Shannon theorem section, with TDD+reviews as error correction
- **Spec-anchored**: Strengthen the living document principle — spec remains authoritative alongside code
- **Further Reading**: Link to Böckeler's "Exploring Gen AI" series for tool comparison (Kiro, spec-kit, Tessl)
- **agents.md**: Link to official website

## Test plan
- [ ] Verify workflow page renders correctly in both EN and DE
- [ ] Verify Further Reading link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)