### PR TITLE
docs: add Martinelli and podcast to workflow further reading

### DIFF
--- a/docs/spec-driven-workflow.de.html
+++ b/docs/spec-driven-workflow.de.html
@@ -1300,6 +1300,9 @@ Wer Anker entdeckt, die im eigenen Workflow gut funktionieren: <a href="https://
 <li>
 <p>Simon Martinelli, <a href="https://unifiedprocess.ai/">AI Unified Process</a>&#8201;&#8212;&#8201;eine anforderungsgetriebene Methodik, die Rational-Unified-Process-Prinzipien mit KI-Tooling kombiniert. Behandelt KI als Konsistenz-Engine, die Code aus sich entwickelnden Spezifikationen regeneriert, in vier Phasen: Inception, Elaboration, Construction, Transition.</p>
 </li>
+<li>
+<p>Ralf D. Müller &amp; Simon Martinelli, <a href="https://software-architektur.tv/2026/01/16/folge298.html">Spec-Driven Development</a> (software-architektur.tv, Folge 298)&#8201;&#8212;&#8201;Podcast-Diskussion darüber, wie Spezifikationen und Anforderungen ins Zentrum KI-gestützter Entwicklung rücken, und warum iterative Verfeinerung besser funktioniert als perfekte Upfront-Specs.</p>
+</li>
 </ul>
 </div>
 </div>

--- a/docs/spec-driven-workflow.html
+++ b/docs/spec-driven-workflow.html
@@ -1299,6 +1299,9 @@ If you discover anchors that work well in your workflow, <a href="https://github
 <li>
 <p>Simon Martinelli, <a href="https://unifiedprocess.ai/">AI Unified Process</a>&#8201;&#8212;&#8201;a requirements-driven methodology combining Rational Unified Process principles with AI tooling. Treats AI as a consistency engine that regenerates code from evolving specifications, with four phases: Inception, Elaboration, Construction, Transition.</p>
 </li>
+<li>
+<p>Ralf D. Müller &amp; Simon Martinelli, <a href="https://software-architektur.tv/2026/01/16/folge298.html">Spec-Driven Development</a> (software-architektur.tv, Episode 298)&#8201;&#8212;&#8201;podcast discussion on how specifications and requirements take center stage in AI-assisted development, and why iterative refinement beats perfect upfront specs.</p>
+</li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
## Summary

- Add Simon Martinelli's AI Unified Process to further reading (EN/DE)
- Add software-architektur.tv Episode 298 (Müller & Martinelli on Spec-Driven Development) to further reading (EN/DE)

## Test plan
- [ ] Verify further reading links render and work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)