### PR TITLE
fix: remove tag count display from anchor cards

### DIFF
--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -96,7 +96,7 @@ function renderAnchorCard(anchor, categoryColor) {
   const rolesCount = anchor.roles ? anchor.roles.length : 0
   const githubEditUrl = `https://github.com/LLM-Coding/Semantic-Anchors/edit/main/docs/anchors/${anchor.id}.adoc`
   const roleText = rolesCount === 1 ? i18n.t('card.roles') : i18n.t('card.rolesPlural')
-  const tagsText = i18n.t('card.tags')
+
   const editTitle = i18n.t('card.edit')
   const copyLinkTitle = i18n.t('card.copyLink')
   const safeId = escapeHtml(anchor.id)
@@ -162,18 +162,7 @@ function renderAnchorCard(anchor, categoryColor) {
             : ''
         }
 
-        ${
-          anchor.tags && anchor.tags.length > 0
-            ? `
-          <span class="meta-badge">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
-            </svg>
-            <span data-i18n="card.tags">${anchor.tags.length} ${tagsText}</span>
-          </span>
-        `
-            : ''
-        }
+        ${''}
 
         ${
           isUmbrella


### PR DESCRIPTION
## Summary

- Remove the "N tags" badge from anchor cards — tags were never visible to users, only the count was shown
- Tags remain in the `data-tags` attribute and continue to work for search

## Test plan
- [ ] Verify cards render without tag count
- [ ] Verify search still finds anchors by tag keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Tags-Abzeichen auf Kartenelementen werden nicht mehr angezeigt. Die Benutzeroberfläche wurde optimiert und vereinfacht.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->