### PR TITLE
fix: broken workflow diagram and scroll jump on anchor modal

### DIFF
--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -58,7 +58,7 @@ You review at the boundaries between phases, not after every line of code.
 
 == Workflow Overview
 
-image::workflow-diagram.png[Workflow Overview,width=800]
+image::docs/workflow-diagram.png[Workflow Overview,width=800]
 
 == Cross-Cutting Concerns
 

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -60,7 +60,7 @@ Man reviewt an den Übergängen zwischen Phasen, nicht nach jeder einzelnen Code
 
 == Workflow-Übersicht
 
-image::workflow-diagram.png[Workflow-Übersicht,width=800]
+image::docs/workflow-diagram.png[Workflow-Übersicht,width=800]
 
 == Querschnittsthemen
 

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -1,6 +1,6 @@
 import { i18n } from '../i18n.js'
 import { fetchAnchorsData } from '../utils/data-loader.js'
-import { getRouteBeforeModal } from '../utils/router.js'
+import { getRouteBeforeModal, getScrollBeforeModal } from '../utils/router.js'
 
 let asciidoctor = null
 
@@ -104,7 +104,10 @@ export function closeModal() {
     // Return to the page that was active before the modal opened
     if (window.location.hash.startsWith('#/anchor/')) {
       const returnTo = getRouteBeforeModal() || '/'
+      const scrollY = getScrollBeforeModal()
       window.location.hash = '#' + returnTo
+      // Restore scroll position after the hashchange event
+      requestAnimationFrame(() => window.scrollTo(0, scrollY))
     }
   }
 }

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -5,6 +5,7 @@
 const routes = new Map()
 let currentRoute = null
 let routeBeforeModal = null
+let scrollBeforeModal = 0
 
 /**
  * Register a route handler
@@ -55,8 +56,9 @@ function handleRoute() {
     const safeAnchorId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(anchorId) ? anchorId : null
     if (!safeAnchorId) return
 
-    // Remember the current route so we can return to it when the modal closes
+    // Remember the current route and scroll position for restoring after modal close
     routeBeforeModal = currentRoute
+    scrollBeforeModal = window.scrollY
 
     // Only navigate to home if no page is currently rendered
     if (!currentRoute) {
@@ -66,6 +68,9 @@ function handleRoute() {
         homeHandler()
       }
     }
+    // Restore scroll position (browser resets it on hash change)
+    window.scrollTo(0, scrollBeforeModal)
+
     // Open the anchor modal as overlay on current page
     // Import dynamically to avoid circular dependency
     import('../components/anchor-modal.js').then(({ showAnchorDetails }) => {
@@ -104,4 +109,12 @@ export function isActive(path) {
  */
 export function getRouteBeforeModal() {
   return routeBeforeModal
+}
+
+/**
+ * Get the scroll position that was active before the anchor modal opened
+ * @returns {number} Scroll Y position
+ */
+export function getScrollBeforeModal() {
+  return scrollBeforeModal
 }


### PR DESCRIPTION
## Summary

Follow-up to #198 — the second commit was pushed after merge and missed deployment.

- **Broken image**: Fix `workflow-diagram.png` path to `docs/workflow-diagram.png` (relative to SPA root)
- **Scroll jump**: Preserve and restore scroll position when opening/closing anchor modal on doc pages

## Test plan

- [ ] Workflow diagram displays correctly on Spec-Driven Workflow page
- [ ] Click anchor link on doc page → no scroll jump, modal opens as overlay
- [ ] Close modal → page returns to previous scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Verbesserte Scroll-Position-Verwaltung beim Schließen von Modalen, um die vorherige Scroll-Position wiederherzustellen.

* **Documentation**
  * Aktualisierte Bildverweise in der Dokumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->