### PR TITLE
fix: use replaceState to prevent scroll jump on modal close

### DIFF
--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -101,13 +101,11 @@ export function closeModal() {
     modal.classList.remove('flex')
     document.body.style.overflow = ''
 
-    // Return to the page that was active before the modal opened
+    // Restore URL to the page that was active before the modal opened
+    // Use replaceState to avoid triggering hashchange (which would re-render the page)
     if (window.location.hash.startsWith('#/anchor/')) {
       const returnTo = getRouteBeforeModal() || '/'
-      const scrollY = getScrollBeforeModal()
-      window.location.hash = '#' + returnTo
-      // Restore scroll position after the hashchange event
-      requestAnimationFrame(() => window.scrollTo(0, scrollY))
+      history.replaceState(null, '', '#' + returnTo)
     }
   }
 }


### PR DESCRIPTION
## Summary

Closing the anchor modal caused the page to scroll to top because `window.location.hash = ...` triggered a `hashchange` event, which re-rendered the page.

Fix: Use `history.replaceState` to update the URL silently — the modal hides, the page stays exactly where it was.

## Test plan

- [ ] Open anchor modal from doc page → close → page stays at same scroll position
- [ ] URL updates correctly after modal close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionshinweise

* **Fehlerbehebungen**
  * Optimiertes Schließen von Modalen zur Vermeidung unnötiger Seitenaktualisierungen und verbesserten Navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->