### PR TITLE
feat: assign tier 2 to Definition of Done anchor

### DIFF
--- a/docs/anchors/definition-of-done.adoc
+++ b/docs/anchors/definition-of-done.adoc
@@ -4,6 +4,7 @@
 :related: bdd-given-when-then, user-story-mapping, moscow
 :proponents: Ken Schwaber, Jeff Sutherland
 :tags: dod, acceptance criteria, scrum, agile, quality gates, done, sprint, increment
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/definition-of-done.de.adoc
+++ b/docs/anchors/definition-of-done.de.adoc
@@ -4,6 +4,7 @@
 :related: bdd-given-when-then, user-story-mapping, moscow
 :proponents: Ken Schwaber, Jeff Sutherland
 :tags: dod, acceptance criteria, scrum, agile, quality gates, done, sprint, increment
+:tier: 2
 
 [%collapsible]
 ====


### PR DESCRIPTION
## Summary

Assigns `:tier: 2` to the newly added Definition of Done anchor (EN + DE).

Tier 2 (★★☆): Well-known concept with consistent LLM activation, but relatively shallow depth compared to tier 1 anchors — the core is essentially a quality checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Die Tier-2-Klassifizierung wurde zu den Definition-of-Done-Dokumentationen hinzugefügt, um die Priorität anzugeben.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->