### PR TITLE
feat: style discussion section in modal with heading and background

### DIFF
--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -311,6 +311,12 @@ export async function loadAnchorContent(anchorId) {
       if (fb.recentComments && fb.recentComments.length > 0) {
         const commentsHtml = `
           <div class="feedback-section">
+            <h4 class="feedback-heading">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"></path>
+              </svg>
+              ${i18n.t('feedback.discussionHeading')}
+            </h4>
             <div class="feedback-comments">
               ${fb.recentComments
                 .map(

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -184,7 +184,14 @@ body {
 
 /* Feedback section in anchor modal (comments area) */
 .feedback-section {
-  @apply mt-8 pt-6 border-t border-gray-200 dark:border-gray-700;
+  @apply mt-8 p-4 rounded-lg;
+  @apply bg-gray-50 dark:bg-gray-800/50;
+  @apply border border-gray-200 dark:border-gray-700;
+}
+
+.feedback-heading {
+  @apply flex items-center gap-2 text-sm font-semibold mb-3;
+  @apply text-gray-500 dark:text-gray-400;
 }
 
 .feedback-actions {

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -61,5 +61,6 @@
   "feedback.vote": "Abstimmen",
   "feedback.discuss": "Diskutieren",
   "feedback.cta": "Ist dieser Anker hilfreich?",
+  "feedback.discussionHeading": "Community-Diskussion",
   "feedback.requiresLogin": "Erfordert GitHub-Login"
 }

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -61,5 +61,6 @@
   "feedback.vote": "Vote",
   "feedback.discuss": "Discuss",
   "feedback.cta": "Is this anchor useful?",
+  "feedback.discussionHeading": "Community Discussion",
   "feedback.requiresLogin": "Requires GitHub login"
 }


### PR DESCRIPTION
## Summary

Visually separates community discussion comments from anchor content in the modal:

- **Heading**: "Community Discussion" / "Community-Diskussion" with chat icon
- **Background**: Light gray container with rounded corners and subtle border
- **Only visible** when comments exist — no empty box

```
┌─ Modal ─────────────────────────────┐
│                                     │
│  (anchor content in normal style)   │
│                                     │
│  ┌─ 💬 Community Discussion ─────┐ │
│  │  👤 rdmueller                  │ │
│  │  works best for me to clarify  │ │
│  └────────────────────────────────┘ │
│                                     │
├─────────────────────────────────────┤
│ Is this anchor useful?  [Vote] [💬] │
└─────────────────────────────────────┘
```

## Test plan

- [ ] Anchor with comments (Socratic Method): gray box with heading visible
- [ ] Anchor without comments: no feedback section shown
- [ ] Dark mode: appropriate contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Neue Funktionen**
  * Neue Überschrift "Community-Diskussion" im Feedback-Bereich mit visuellem Icon-Element hinzugefügt.

* **Design**
  * Feedback-Sektion überarbeitet: Abstände optimiert, abgerundete Ecken und Hintergrundfarben (Light- und Dark-Modus) erweitert sowie Rahmen verbessert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->