### PR TITLE
docs: rework spec-driven workflow content

### DIFF
--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -10,12 +10,12 @@ This document describes how to build production-quality software with AI agents,
 
 Semantic Anchors are compact terms that reliably activate rich knowledge domains in LLMs.
 Instead of writing pages of instructions, you reference a concept the model already understands deeply.
-"Use TDD" is shorter than explaining test-driven development.
-"Follow arc42" is shorter than describing 12 architecture sections.
+"Use link:#/anchor/tdd-london-school[TDD, London School]" is shorter than explaining test-driven development with mocks and outside-in design.
+"Follow link:#/anchor/arc42[arc42]" is shorter than describing 12 architecture sections.
 The prompts stay short, precise, and maintainable.
 
 This workflow was used to build three open source projects, all 100% AI-generated.
-The golden rule: I only prompt, I never touch the code myself.
+*The golden rule: I only prompt, I never touch the code myself.*
 Every line of code, every test, every documentation file was written by the AI under my guidance.
 
 * https://github.com/docToolchain/dacli[*dacli*]: A full CLI tool with spec, architecture docs, tests, and user manual. Built by one AI, cross-reviewed by 5 different LLMs.
@@ -41,20 +41,40 @@ That is like asking a junior developer to build an entire application from a one
 The result will be unpredictable at best.
 
 This workflow takes the opposite approach: break the work into small, well-defined steps and let the AI handle each one autonomously.
-Each step produces a concrete artifact that you can review before moving on.
+Each step produces a concrete artifact that you can review if you see the need for it.
 
 The paradox: the smaller you make each task, the more autonomy you can give the agent.
 A vague "build me X" needs constant supervision.
-A precise "implement issue #42 using TDD, respecting the spec in src/docs/specs/" can run on its own.
+A precise "implement issue #42 using TDD, respecting the spec and architecture in src/docs/" can run on its own.
 The phases described in this document are designed to produce exactly that kind of precise, self-contained task.
 
-This connects directly to Shannon's theorem.
-Each small step is a short transmission over the noisy channel.
-Short transmissions with error correction (tests, linting, review) are far more reliable than one long, unchecked transmission.
-LLM output is inherently non-deterministic -- the same prompt can produce different code each time.
-TDD and reviews are the error correction that makes this noisy channel usable.
-The agent works in a tight loop: implement, test, commit, check docs.
-You review at the boundaries between phases, not after every line of code.
+This connects directly to *Eichhorst's Principle*, which applies Shannon's noisy channel theorem to LLM coding.
+An LLM is not a deterministic tool.
+It is a noisy, non-deterministic channel.
+It hallucinates, loses context, and is sometimes plain wrong.
+But an agent in a loop corrects itself: the compiler reports an error, the agent reads it, fixes the code, runs the tests, reads the failure, fixes the logic, and repeats until green.
+That is not magic -- that is error correction, exactly as Shannon described.
+
+When you prompt an LLM and paste the result into your project, you run an *open loop*.
+No compiler check, no test suite, no review.
+The LLM guesses once and you hope it guessed right.
+When an agent writes code, runs the compiler, runs the tests, and iterates until everything passes, that is a *closed loop*.
+The same principle that makes a thermostat work.
+
+Different tests correct different error classes.
+The compiler catches syntax errors.
+Unit tests catch logic errors.
+BDD tests catch domain errors.
+Each layer increases the reliability of the channel.
+Untested code is an uncorrected channel -- the noise passes straight through.
+
+The consequence: *better tests beat better prompts*.
+A comprehensive test suite turns a mediocre model into a reliable coding partner.
+And if the complexity of a specification exceeds the capacity of the LLM, more tokens will not help.
+The answer is smaller specifications, clearer boundaries, and better tests.
+
+Each small step in this workflow is a short transmission over the noisy channel.
+Short transmissions with error correction are far more reliable than one long, unchecked transmission.
 
 == Workflow Overview
 
@@ -68,7 +88,7 @@ These principles apply to all phases:
 ⚓ link:#/anchor/conventional-commits[*Conventional Commits*]:: All commits follow a standardized format for a clean, parseable git history.
 ⚓ link:#/anchor/docs-as-code[*Docs-as-Code according to Ralf D. Müller*]:: Documentation lives in the repository as AsciiDoc, built by https://doctoolchain.org[docToolchain].
 Docs-as-Code treats documentation like source code: version-controlled, peer-reviewed, and built automatically.
-*Definition of Done*:: Code passes all tests, feature branch is merged or PR is created, documentation is updated, architecture decisions are recorded.
+⚓ link:#/anchor/definition-of-done[*Definition of Done*]:: Code passes all tests, feature branch is merged or PR is created, documentation is updated, architecture decisions are recorded.
 
 == Prerequisites
 
@@ -77,6 +97,8 @@ Before starting, set up your project infrastructure:
 . Initialize a git repository
 . Install https://doctoolchain.org[docToolchain] and download the ⚓ link:#/anchor/arc42[*arc42*] template
 . Configure your AI coding environment with an `AGENTS.md` (or tool-specific equivalent like `CLAUDE.md`)
+. Give the AI agent access to GitHub or GitLab via the CLI (`gh` or `glab`). The agent will need this later to create issues, pull requests, and ADR discussions. Consider using a dedicated account for audit traceability.
+. Following Eichhorst's Principle, set up error correction layers for your project: linters, pre-commit hooks, CI pipelines, and static analysis. Each layer catches a different class of error and makes the LLM channel more reliable. The https://github.com/LLM-Coding/vibe-coding-risk-radar[Vibe Coding Risk Radar] can help determine which checks are appropriate for your project's risk profile. These checks unfold their full effect once the first lines of runnable code exist -- set them up early, but revisit as the project grows.
 
 .Installing docToolchain (Linux/macOS)
 [source,bash]
@@ -112,20 +134,20 @@ A minimal `AGENTS.md` for this workflow:
 ## Conventions
 - Documentation: Plain English according to Strunk & White
 - Testing: TDD (London or Chicago School as appropriate)
+- Code: DRY, SOLID, KISS, Ubiquitous Language (DDD)
 - Commits: Conventional Commits, reference issue number
 - Branches: feature/<issue-description>
 
-## Current State
-- Working on: EPIC #3
-- Next issue: #42
 ----
 
-Update this file as the project evolves.
+As the project progresses, the AI agent will maintain this file itself.
 When starting a new AI session, the agent reads `AGENTS.md` and immediately has the context it needs.
 
 [TIP]
 ====
-Start a new AI session for each EPIC or when the conversation becomes sluggish.
+Compact the context before starting a new EPIC.
+Within a session, keep an eye on the context window.
+Compact the conversation manually at natural breakpoints (e.g. after completing an issue) rather than waiting for the model to auto-compact at an inconvenient moment and lose important context.
 The agent picks up context from `AGENTS.md` and the spec files automatically.
 ====
 
@@ -153,8 +175,8 @@ Prompt the AI to use the ⚓ link:#/anchor/socratic-method[*Socratic Method*] to
 [source]
 ----
 Use the Socratic Method to help me clarify requirements for [your project].
-Ask me at most 3 questions at a time. Challenge my assumptions before
-documenting anything.
+Ask me at most 3 questions at a time. Challenge my assumptions.
+Keep asking until you fully understand the requirements.
 ----
 
 This activates targeted questioning, assumption challenging, and productive use of not-knowing.
@@ -173,13 +195,12 @@ Continue the dialogue until both you and the AI are satisfied that the requireme
 
 === Step 3: Document as PRD
 
-Ask the AI to write a *Product Requirements Document (PRD)* and save it as AsciiDoc.
+Ask the AI to write a ⚓ link:#/anchor/prd[*Product Requirements Document (PRD)*] and save it as AsciiDoc.
 A PRD captures the what and why, not the how: problem statement, goals, user personas, success criteria, and scope boundaries.
 
 [source]
 ----
 Write a PRD based on our discussion. Save it as src/docs/specs/prd.adoc.
-Follow Plain English guidelines according to Strunk and White.
 ----
 
 === Step 4: Create Detailed Specification
@@ -198,7 +219,7 @@ Save as .adoc files in src/docs/specs/.
 ⚓ link:#/anchor/gherkin[*Gherkin*] (Given/When/Then) provides acceptance criteria that are both human-readable and machine-testable.
 These criteria become the foundation for TDD later.
 
-Activity Diagrams force you to think about error paths, edge cases, and alternative flows early.
+Activity Diagrams are an important part of the specification because they define flows, error paths, and edge cases in a way the AI can follow during implementation.
 
 == Phase 2: Architecture
 
@@ -208,16 +229,17 @@ Ask the AI to derive an architecture from the specification:
 
 [source]
 ----
-Create an arc42 architecture document based on the specification in src/docs/specs/.
-Save it in src/docs/arc42/.
+Fill the arc42 template in src/docs/arc42/ based on the specification in src/docs/specs/.
 Use PlantUML C4 diagrams for architecture visualization.
 ----
 
+The arc42 template was downloaded in the prerequisites step.
+The AI knows the template structure and fills the 12 sections appropriately.
+
 ⚓ link:#/anchor/arc42[*arc42*] provides 12 sections covering everything from context to deployment.
-The AI knows the template structure and fills it appropriately.
 
 ⚓ link:#/anchor/c4-diagrams[*C4 Diagrams*] combined with PlantUML provide text-based architecture visualization at four levels: Context, Container, Component, Code.
-The AI can create and modify these diagrams without graphical tools.
+Since the documentation uses AsciiDoc, PlantUML and other text-to-diagram tools are supported natively -- the AI generates diagrams as code, and the build renders them automatically.
 
 ==== Architecture Decision Records
 
@@ -238,7 +260,7 @@ The AI creates each ADR as a GitHub/GitLab issue first.
 You review the issue, comment, or approve it.
 Only after your approval is the ADR incorporated into the arc42 documentation.
 This way, every architectural decision is traceable through the issue history.
-All ADRs must align with the quality goals defined in arc42 Section 1.2.
+All ADRs must align with the quality requirements defined in arc42 Section 10.
 
 === Step 6: Architecture Review (ATAM)
 
@@ -269,7 +291,7 @@ Use MoSCoW prioritization for the initial backlog order.
 Mark dependencies between issues with labels or cross-references.
 ----
 
-⚓ *INVEST* ensures User Stories are Independent, Negotiable, Valuable, Estimable, Small, and Testable.
+⚓ link:#/anchor/invest[*INVEST*] ensures User Stories are Independent, Negotiable, Valuable, Estimable, Small, and Testable.
 
 ⚓ link:#/anchor/moscow[*MoSCoW*] (Must have, Should have, Could have, Won't have) provides clear prioritization.
 
@@ -281,20 +303,12 @@ As the project evolves, groom the backlog regularly to re-prioritize based on ne
 
 === Step 8: Implement Issue by Issue
 
-Create a feature branch for each EPIC or logical group of issues:
-
-[source,bash]
-----
-git checkout -b feature/<epic-or-issue-description>
-----
-
-Then enter the core development loop:
-
 [source]
 ----
+Create a feature branch for this EPIC.
 Select the next logical issue from the backlog (respect dependencies).
 Analyze it and document your analysis as a comment on the issue.
-Implement it using TDD. Commit when done.
+Implement it using TDD (choose London or Chicago School as appropriate). Commit when done.
 Check if the spec or architecture docs need updating.
 ----
 
@@ -305,19 +319,13 @@ For each issue:
 . *Commit*: After the issue is implemented and all tests pass, commit with a reference to the issue number
 . *Check docs*: Ask whether the specification or architecture documentation needs updating based on what was learned during implementation
 
-⚓ *TDD* (Test-Driven Development) comes in two schools:
+TDD (Test-Driven Development) comes in two schools:
 
-* ⚓ link:#/anchor/tdd-london-school[*London School*] (mockist): isolate the unit under test, mock dependencies. Good for interaction-heavy code.
-* ⚓ link:#/anchor/tdd-chicago-school[*Chicago School*] (classicist): test behavior through the public API, use real collaborators. Good for state-based logic.
+* ⚓ link:#/anchor/tdd-london-school[*TDD, London School*] (mockist): isolate the unit under test, mock dependencies. Good for interaction-heavy code.
+* ⚓ link:#/anchor/tdd-chicago-school[*TDD, Chicago School*] (classicist): test behavior through the public API, use real collaborators. Good for state-based logic.
 
 The AI selects the appropriate school based on the code's characteristics.
 
-Each implementation follows the Red-Green-Refactor cycle and respects:
-
-* ⚓ link:#/anchor/dry-principle[*DRY*] (Don't Repeat Yourself)
-* ⚓ link:#/anchor/solid-principles[*SOLID*] principles
-* ⚓ *KISS* (Keep It Simple, Stupid)
-* ⚓ link:#/anchor/domain-driven-design[*Ubiquitous Language*] from Domain-Driven Design: use the same terms in code as in the specification
 
 ==== Feedback Loop to Specification
 
@@ -337,15 +345,8 @@ The spec is not just a means to generate code -- it remains the authoritative de
 
 ==== Merging
 
-When an EPIC or a logical group of issues is complete, merge the feature branch:
-
-[source,bash]
-----
-git checkout main
-git merge feature/<epic-or-issue-description>
-----
-
-For team projects, use Pull Requests for code review before merging.
+When an EPIC is complete, the AI agent creates a Pull Request for the feature branch.
+You review and merge it.
 
 == Phase 5: Quality Assurance
 

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -12,12 +12,12 @@ Dieses Dokument beschreibt, wie man mit KI-Agenten produktionsreife Software ent
 
 Semantic Anchors sind kompakte Begriffe, die in LLMs zuverlässig reiches Domänenwissen aktivieren.
 Statt seitenlange Anweisungen zu schreiben, referenziert man ein Konzept, das das Modell bereits tief versteht.
-"Nutze TDD" ist kürzer als Test-Driven Development zu erklären.
-"Folge arc42" ist kürzer als 12 Architektur-Abschnitte zu beschreiben.
+"Nutze link:#/anchor/tdd-london-school[TDD, London School]" ist kürzer als Test-Driven Development mit Mocks und Outside-In-Design zu erklären.
+"Folge link:#/anchor/arc42[arc42]" ist kürzer als 12 Architektur-Abschnitte zu beschreiben.
 Die Prompts bleiben kurz, präzise und wartbar.
 
 Dieser Workflow wurde verwendet, um drei Open-Source-Projekte zu bauen, alle 100% KI-generiert.
-Die goldene Regel: Ich prompte nur, ich fasse den Code nie selbst an.
+*Die goldene Regel: Ich prompte nur, ich fasse den Code nie selbst an.*
 Jede Zeile Code, jeder Test, jede Dokumentationsdatei wurde von der KI unter meiner Anleitung geschrieben.
 
 * https://github.com/docToolchain/dacli[*dacli*]: Ein vollständiges CLI-Tool mit Spezifikation, Architekturdokumentation, Tests und Benutzerhandbuch. Von einer KI gebaut, von 5 verschiedenen LLMs gegengelesen.
@@ -43,20 +43,40 @@ Das ist so, als würde man einen Junior-Entwickler bitten, aus einem Einzeiler-B
 Das Ergebnis ist bestenfalls unvorhersehbar.
 
 Dieser Workflow geht den umgekehrten Weg: Die Arbeit wird in kleine, klar definierte Schritte zerlegt, und der Agent bearbeitet jeden davon eigenständig.
-Jeder Schritt erzeugt ein konkretes Artefakt, das man prüfen kann, bevor es weitergeht.
+Jeder Schritt erzeugt ein konkretes Artefakt, das man bei Bedarf prüfen kann.
 
 Das Paradox: Je kleiner man die einzelne Aufgabe macht, desto mehr Autonomie kann man dem Agenten geben.
 Ein vages "Baue mir X" erfordert ständige Kontrolle.
-Ein präzises "Implementiere Issue #42 mit TDD, basierend auf der Spec in src/docs/specs/" kann eigenständig laufen.
+Ein präzises "Implementiere Issue #42 mit TDD, basierend auf Spec und Architektur in src/docs/" kann eigenständig laufen.
 Die Phasen in diesem Dokument sind darauf ausgelegt, genau solche präzisen, abgeschlossenen Aufgaben zu erzeugen.
 
-Das hängt direkt mit Shannons Theorem zusammen.
-Jeder kleine Schritt ist eine kurze Übertragung über den verrauschten Kanal.
-Kurze Übertragungen mit Fehlerkorrektur (Tests, Linting, Review) sind weit zuverlässiger als eine lange, unkontrollierte Übertragung.
-LLM-Ausgaben sind inhärent nicht-deterministisch -- derselbe Prompt kann unterschiedlichen Code erzeugen.
-TDD und Reviews sind die Fehlerkorrektur, die diesen verrauschten Kanal nutzbar macht.
-Der Agent arbeitet in einer engen Schleife: implementieren, testen, committen, Dokumentation prüfen.
-Man reviewt an den Übergängen zwischen Phasen, nicht nach jeder einzelnen Codezeile.
+Das hängt direkt mit *Eichhorst's Principle* zusammen, das Shannons Noisy-Channel-Theorem auf LLM-Coding anwendet.
+Ein LLM ist kein deterministisches Werkzeug.
+Es ist ein verrauschter, nicht-deterministischer Kanal.
+Es halluziniert, verliert Kontext und liegt manchmal schlicht falsch.
+Aber ein Agent in einer Schleife korrigiert sich selbst: Der Compiler meldet einen Fehler, der Agent liest ihn, fixt den Code, führt die Tests aus, liest den Fehlschlag, korrigiert die Logik und wiederholt -- bis alles grün ist.
+Das ist keine Magie -- das ist Fehlerkorrektur, genau wie Shannon sie beschrieben hat.
+
+Wer einen LLM promptet und das Ergebnis ins Projekt einfügt, betreibt eine *offene Schleife*.
+Kein Compiler-Check, keine Test-Suite, kein Review.
+Das LLM rät einmal und man hofft, dass es richtig geraten hat.
+Wenn ein Agent Code schreibt, den Compiler ausführt, die Tests laufen lässt und iteriert bis alles passt, ist das eine *geschlossene Schleife*.
+Dasselbe Prinzip, das einen Thermostaten funktionieren lässt.
+
+Verschiedene Tests korrigieren verschiedene Fehlerklassen.
+Der Compiler fängt Syntaxfehler.
+Unit-Tests fangen Logikfehler.
+BDD-Tests fangen Domänenfehler.
+Jede Schicht erhöht die Zuverlässigkeit des Kanals.
+Ungetesteter Code ist ein unkorrigierter Kanal -- das Rauschen geht direkt durch.
+
+Die Konsequenz: *Bessere Tests schlagen bessere Prompts*.
+Eine umfassende Test-Suite macht aus einem mittelmäßigen Modell einen zuverlässigen Coding-Partner.
+Und wenn die Komplexität einer Spezifikation die Kapazität des LLM übersteigt, helfen mehr Tokens nicht.
+Die Antwort sind kleinere Spezifikationen, klarere Grenzen und bessere Tests.
+
+Jeder kleine Schritt in diesem Workflow ist eine kurze Übertragung über den verrauschten Kanal.
+Kurze Übertragungen mit Fehlerkorrektur sind weit zuverlässiger als eine lange, unkontrollierte Übertragung.
 
 == Workflow-Übersicht
 
@@ -77,7 +97,7 @@ Alle Commits folgen einem standardisierten Format für eine saubere, maschinenle
 Dokumentation lebt im Repository als AsciiDoc, gebaut von https://doctoolchain.org[docToolchain].
 Docs-as-Code behandelt Dokumentation wie Quellcode: versioniert, reviewt und automatisch gebaut.
 
-*Definition of Done*::
+⚓ link:#/anchor/definition-of-done[*Definition of Done*]::
 Code besteht alle Tests, Feature-Branch ist gemergt oder PR erstellt, Dokumentation ist aktualisiert, Architekturentscheidungen sind dokumentiert.
 
 == Voraussetzungen
@@ -87,6 +107,8 @@ Bevor es losgeht, die Projektinfrastruktur aufsetzen:
 . Git-Repository initialisieren
 . https://doctoolchain.org[docToolchain] installieren und das ⚓ link:#/anchor/arc42[*arc42*]-Template herunterladen
 . KI-Coding-Umgebung mit einer `AGENTS.md` konfigurieren (oder toolspezifisches Äquivalent wie `CLAUDE.md`)
+. Dem KI-Agenten Zugriff auf GitHub oder GitLab über die CLI geben (`gh` oder `glab`). Der Agent braucht das später für Issues, Pull Requests und ADR-Diskussionen. Für Nachvollziehbarkeit empfiehlt sich ein eigener Account.
+. Entsprechend Eichhorst's Principle Fehlerkorrektur-Schichten für das Projekt aufsetzen: Linter, Pre-Commit-Hooks, CI-Pipelines und statische Analyse. Jede Schicht fängt eine andere Fehlerklasse ab und macht den LLM-Kanal zuverlässiger. Der https://github.com/LLM-Coding/vibe-coding-risk-radar[Vibe Coding Risk Radar] kann helfen, die passenden Checks für das Risikoprofil des Projekts zu bestimmen. Diese Checks entfalten ihre volle Wirkung erst mit den ersten Zeilen lauffähigen Codes -- früh aufsetzen, aber mit wachsendem Projekt erneut prüfen.
 
 .docToolchain installieren (Linux/macOS)
 [source,bash]
@@ -122,20 +144,20 @@ Eine minimale `AGENTS.md` für diesen Workflow:
 ## Conventions
 - Documentation: Plain English according to Strunk & White
 - Testing: TDD (London or Chicago School as appropriate)
+- Code: DRY, SOLID, KISS, Ubiquitous Language (DDD)
 - Commits: Conventional Commits, reference issue number
 - Branches: feature/<issue-description>
 
-## Current State
-- Working on: EPIC #3
-- Next issue: #42
 ----
 
-Diese Datei wird laufend aktualisiert.
+Im weiteren Verlauf wird der KI-Agent die Datei selbst weiter pflegen.
 Beim Start einer neuen KI-Session liest der Agent die `AGENTS.md` und hat sofort den nötigen Kontext.
 
 [TIP]
 ====
-Neue KI-Session pro EPIC starten oder wenn die Konversation träge wird.
+Vor jedem neuen EPIC den Kontext komprimieren.
+Innerhalb einer Session das Kontextfenster im Auge behalten.
+An natürlichen Übergängen (z.B. nach Abschluss eines Issues) manuell komprimieren, statt zu warten, bis das Modell im ungünstigen Moment auto-komprimiert und dabei wichtigen Kontext verliert.
 Der Agent holt sich den Kontext automatisch aus `AGENTS.md` und den Spec-Dateien.
 ====
 
@@ -163,8 +185,8 @@ Die KI auffordern, die ⚓ link:#/anchor/socratic-method[*Sokratische Methode*] 
 [source]
 ----
 Use the Socratic Method to help me clarify requirements for [your project].
-Ask me at most 3 questions at a time. Challenge my assumptions before
-documenting anything.
+Ask me at most 3 questions at a time. Challenge my assumptions.
+Keep asking until you fully understand the requirements.
 ----
 
 Das aktiviert gezieltes Fragen, Hinterfragen von Annahmen und produktiven Umgang mit Nicht-Wissen.
@@ -183,13 +205,12 @@ Den Dialog fortführen, bis man mit der KI zufrieden ist, dass die Anforderungen
 
 === Schritt 3: Als PRD dokumentieren
 
-Die KI bitten, ein *Product Requirements Document (PRD)* als AsciiDoc zu schreiben.
+Die KI bitten, ein ⚓ link:#/anchor/prd[*Product Requirements Document (PRD)*] als AsciiDoc zu schreiben.
 Ein PRD erfasst das Was und Warum, nicht das Wie: Problemstellung, Ziele, Nutzer-Personas, Erfolgskriterien und Scope-Grenzen.
 
 [source]
 ----
 Write a PRD based on our discussion. Save it as src/docs/specs/prd.adoc.
-Follow Plain English guidelines according to Strunk and White.
 ----
 
 === Schritt 4: Detaillierte Spezifikation erstellen
@@ -208,7 +229,7 @@ Save as .adoc files in src/docs/specs/.
 ⚓ link:#/anchor/gherkin[*Gherkin*] (Given/When/Then) liefert Akzeptanzkriterien, die sowohl für Menschen lesbar als auch maschinell testbar sind.
 Diese Kriterien werden später die Grundlage für TDD.
 
-Activity Diagrams zwingen dazu, frühzeitig über Fehlerpfade, Randfälle und alternative Abläufe nachzudenken.
+Activity Diagrams sind ein wichtiger Teil der Spezifikation, weil sie Abläufe, Fehlerpfade und Randfälle so definieren, dass die KI ihnen bei der Implementierung folgen kann.
 
 == Phase 2: Architektur
 
@@ -218,16 +239,17 @@ Die KI bitten, aus der Spezifikation eine Architektur abzuleiten:
 
 [source]
 ----
-Create an arc42 architecture document based on the specification in src/docs/specs/.
-Save it in src/docs/arc42/.
+Fill the arc42 template in src/docs/arc42/ based on the specification in src/docs/specs/.
 Use PlantUML C4 diagrams for architecture visualization.
 ----
 
+Das arc42-Template wurde im Vorbereitungsschritt heruntergeladen.
+Die KI kennt die Template-Struktur und füllt die 12 Abschnitte passend.
+
 ⚓ link:#/anchor/arc42[*arc42*] bietet 12 Abschnitte, die alles von Kontextabgrenzung bis Deployment abdecken.
-Die KI kennt die Template-Struktur und füllt sie passend.
 
 ⚓ link:#/anchor/c4-diagrams[*C4 Diagrams*] kombiniert mit PlantUML ermöglichen textbasierte Architektur-Visualisierung auf vier Ebenen: Context, Container, Component, Code.
-Die KI kann diese Diagramme ohne grafische Tools erstellen und ändern.
+Da die Dokumentation AsciiDoc verwendet, werden PlantUML und andere Text-to-Diagram-Tools nativ unterstützt -- die KI generiert Diagramme als Code, und der Build rendert sie automatisch.
 
 ==== Architecture Decision Records
 
@@ -248,7 +270,7 @@ Die KI erstellt jeden ADR zunächst als GitHub/GitLab Issue.
 Man prüft das Issue, kommentiert oder genehmigt es.
 Erst nach Freigabe wird der ADR in die arc42-Dokumentation übernommen.
 So ist jede Architekturentscheidung über die Issue-Historie nachvollziehbar.
-Alle ADRs müssen sich an den Qualitätszielen aus arc42 Abschnitt 1.2 orientieren.
+Alle ADRs müssen sich an den Qualitätsanforderungen aus arc42 Abschnitt 10 orientieren.
 
 === Schritt 6: Architektur-Review (ATAM)
 
@@ -279,7 +301,7 @@ Use MoSCoW prioritization for the initial backlog order.
 Mark dependencies between issues with labels or cross-references.
 ----
 
-⚓ *INVEST* stellt sicher, dass User Stories Independent, Negotiable, Valuable, Estimable, Small und Testable sind.
+⚓ link:#/anchor/invest[*INVEST*] stellt sicher, dass User Stories Independent, Negotiable, Valuable, Estimable, Small und Testable sind.
 
 ⚓ link:#/anchor/moscow[*MoSCoW*] (Must have, Should have, Could have, Won't have) liefert klare Priorisierung.
 
@@ -291,20 +313,12 @@ Mit wachsendem Projekt das Backlog regelmäßig groomen und nach neuen Erkenntni
 
 === Schritt 8: Issue für Issue implementieren
 
-Für jedes EPIC oder jede logische Gruppe von Issues einen Feature-Branch erstellen:
-
-[source,bash]
-----
-git checkout -b feature/<epic-oder-issue-beschreibung>
-----
-
-Dann den Entwicklungs-Loop starten:
-
 [source]
 ----
+Create a feature branch for this EPIC.
 Select the next logical issue from the backlog (respect dependencies).
 Analyze it and document your analysis as a comment on the issue.
-Implement it using TDD. Commit when done.
+Implement it using TDD (choose London or Chicago School as appropriate). Commit when done.
 Check if the spec or architecture docs need updating.
 ----
 
@@ -315,19 +329,13 @@ Für jedes Issue:
 . *Committen*: Nach Implementierung und grünen Tests committen mit Referenz auf die Issue-Nummer
 . *Docs prüfen*: Fragen, ob Spezifikation oder Architekturdokumentation basierend auf den Erkenntnissen aktualisiert werden muss
 
-⚓ *TDD* (Test-Driven Development) gibt es in zwei Schulen:
+TDD (Test-Driven Development) gibt es in zwei Schulen:
 
-* ⚓ link:#/anchor/tdd-london-school[*London School*] (Mockist): Unit Under Test isolieren, Abhängigkeiten mocken. Gut für interaktionslastigen Code.
-* ⚓ link:#/anchor/tdd-chicago-school[*Chicago School*] (Classicist): Verhalten über die öffentliche API testen, echte Kollaborateure nutzen. Gut für zustandsbasierte Logik.
+* ⚓ link:#/anchor/tdd-london-school[*TDD, London School*] (Mockist): Unit Under Test isolieren, Abhängigkeiten mocken. Gut für interaktionslastigen Code.
+* ⚓ link:#/anchor/tdd-chicago-school[*TDD, Chicago School*] (Classicist): Verhalten über die öffentliche API testen, echte Kollaborateure nutzen. Gut für zustandsbasierte Logik.
 
 Die KI wählt die passende Schule basierend auf den Code-Eigenschaften.
 
-Jede Implementierung folgt dem Red-Green-Refactor-Zyklus und beachtet:
-
-* ⚓ link:#/anchor/dry-principle[*DRY*] (Don't Repeat Yourself)
-* ⚓ link:#/anchor/solid-principles[*SOLID*]-Prinzipien
-* ⚓ *KISS* (Keep It Simple, Stupid)
-* ⚓ link:#/anchor/domain-driven-design[*Ubiquitous Language*] aus Domain-Driven Design: dieselben Begriffe im Code wie in der Spezifikation
 
 ==== Feedback-Loop zur Spezifikation
 
@@ -347,15 +355,8 @@ Die Spec ist nicht nur ein Mittel zur Codegenerierung -- sie bleibt die autorita
 
 ==== Merging
 
-Wenn ein EPIC oder eine logische Gruppe von Issues abgeschlossen ist, den Feature-Branch mergen:
-
-[source,bash]
-----
-git checkout main
-git merge feature/<epic-oder-issue-beschreibung>
-----
-
-Für Teamprojekte Pull Requests für Code Review vor dem Merge nutzen.
+Wenn ein EPIC abgeschlossen ist, erstellt der KI-Agent einen Pull Request für den Feature-Branch.
+Man reviewt und mergt ihn.
 
 == Phase 5: Qualitätssicherung
 


### PR DESCRIPTION
## Summary
- Introduce **Eichhorst's Principle** (Shannon's noisy channel theorem applied to LLM coding) with open-loop vs closed-loop explanation and error correction layers
- Link previously unlinked anchors: TDD London School, arc42, Definition of Done, PRD, INVEST
- Use "TDD, London School" instead of bare "TDD" as anchor example (TDD alone is not a good anchor)
- Move DRY/SOLID/KISS/Ubiquitous Language to AGENTS.md conventions instead of per-step checklist
- Add prerequisites: GitHub/GitLab CLI access for AI agent, Vibe Coding Risk Radar for quality gates
- Replace manual git merge with AI-created Pull Requests
- Replace "new session per EPIC" with context compaction guidance (manual /compact at natural breakpoints)
- Let AI agent maintain AGENTS.md itself (remove manual Current State section)
- Soften review language to reflect trust-based workflow
- Explain AsciiDoc advantage for native PlantUML/text-to-diagram support
- Reference arc42 Section 10 for full quality requirements (not just Section 1.2)

All changes applied to both EN and DE versions.

## Test plan
- [ ] Verify rendered HTML on workflow page (EN + DE)
- [ ] Check all anchor links resolve correctly
- [ ] Verify no broken formatting in AsciiDoc rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation

* **Dokumentation**
  * Umfangreiche Überarbeitung der Workflow-Dokumentation mit verbesserten Erklärungen und strukturierten Verweisen
  * Klarere Gliederung von Best Practices und Methodologien (TDD, arc42)
  * Erweiterte Guidance zu Anforderungsermittlung und iterativen Prozessen
  * Bessere Navigation durch interne Querverweise und Ankerlinks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->