### PR TITLE
docs: fix broken link to serena

### DIFF
--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -493,7 +493,7 @@ Semantic Anchors activate the right knowledge domain without pretending the mode
 
 In practice, the workflow benefits greatly from specialized tooling.
 MCP servers like https://github.com/mrsimpson/responsible-vibe-mcp[Responsible Vibe MCP] enforce agentic workflows with phase gates and review checkpoints.
-https://serena.dev[Serena] provides semantic code navigation so the agent can work with symbols and references instead of raw text.
+https://oraios.github.io/serena/[Serena] provides semantic code navigation so the agent can work with symbols and references instead of raw text.
 Skill systems like Superpowers encode reusable process patterns like TDD, debugging, and code review workflows.
 https://github.com/microsoft/playwright-mcp[Playwright MCP] lets the agent control a browser for end-to-end testing and exploratory testing of web applications.
 These tools automate the discipline this document describes manually.

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -510,7 +510,7 @@ Semantic Anchors aktivieren das richtige Wissensgebiet, ohne dem Modell eine Rol
 
 In der Praxis profitiert der Workflow stark von spezialisiertem Tooling.
 MCP-Server wie https://github.com/mrsimpson/responsible-vibe-mcp[Responsible Vibe MCP] setzen agentische Workflows mit Phasen-Gates und Review-Checkpoints durch.
-https://serena.dev[Serena] bietet semantische Code-Navigation, sodass der Agent mit Symbolen und Referenzen statt mit Rohtext arbeiten kann.
+https://oraios.github.io/serena/[Serena] bietet semantische Code-Navigation, sodass der Agent mit Symbolen und Referenzen statt mit Rohtext arbeiten kann.
 Skill-Systeme wie Superpowers kodifizieren wiederverwendbare Prozessmuster wie TDD, Debugging und Code-Review-Workflows.
 https://github.com/microsoft/playwright-mcp[Playwright MCP] ermöglicht dem Agenten die Steuerung eines Browsers für End-to-End-Tests und exploratives Testen von Webanwendungen.
 Diese Tools automatisieren die Disziplin, die dieses Dokument manuell beschreibt.

--- a/docs/spec-driven-workflow.de.html
+++ b/docs/spec-driven-workflow.de.html
@@ -1260,7 +1260,7 @@ Semantic Anchors aktivieren das richtige Wissensgebiet, ohne dem Modell eine Rol
 <div class="paragraph">
 <p>In der Praxis profitiert der Workflow stark von spezialisiertem Tooling.
 MCP-Server wie <a href="https://github.com/mrsimpson/responsible-vibe-mcp">Responsible Vibe MCP</a> setzen agentische Workflows mit Phasen-Gates und Review-Checkpoints durch.
-<a href="https://serena.dev">Serena</a> bietet semantische Code-Navigation, sodass der Agent mit Symbolen und Referenzen statt mit Rohtext arbeiten kann.
+<a href="https://oraios.github.io/serena/">Serena</a> bietet semantische Code-Navigation, sodass der Agent mit Symbolen und Referenzen statt mit Rohtext arbeiten kann.
 Skill-Systeme wie Superpowers kodifizieren wiederverwendbare Prozessmuster wie TDD, Debugging und Code-Review-Workflows.
 <a href="https://github.com/microsoft/playwright-mcp">Playwright MCP</a> ermöglicht dem Agenten die Steuerung eines Browsers für End-to-End-Tests und exploratives Testen von Webanwendungen.
 Diese Tools automatisieren die Disziplin, die dieses Dokument manuell beschreibt.</p>

--- a/docs/spec-driven-workflow.html
+++ b/docs/spec-driven-workflow.html
@@ -1259,7 +1259,7 @@ Semantic Anchors activate the right knowledge domain without pretending the mode
 <div class="paragraph">
 <p>In practice, the workflow benefits greatly from specialized tooling.
 MCP servers like <a href="https://github.com/mrsimpson/responsible-vibe-mcp">Responsible Vibe MCP</a> enforce agentic workflows with phase gates and review checkpoints.
-<a href="https://serena.dev">Serena</a> provides semantic code navigation so the agent can work with symbols and references instead of raw text.
+<a href="https://oraios.github.io/serena/">Serena</a> provides semantic code navigation so the agent can work with symbols and references instead of raw text.
 Skill systems like Superpowers encode reusable process patterns like TDD, debugging, and code review workflows.
 <a href="https://github.com/microsoft/playwright-mcp">Playwright MCP</a> lets the agent control a browser for end-to-end testing and exploratory testing of web applications.
 These tools automate the discipline this document describes manually.</p>


### PR DESCRIPTION
The website https://serena.dev does not exist, added the correct website.

@rdmueller I don't now the tool serena, I googled it. Please review the new link if it points to the correct website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation

* Aktualisiert die externe Referenz-URL für das Serena-Tool in der Dokumentation auf mehrere Dateien (HTML- und AsciiDoc-Formate). Die neue URL verweist auf das aktualisierte Ressourcen-Ziel, während alle anderen Inhalte unverändert bleibt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->