### PR TITLE
fix: correct Vibe Coding Risk Radar dead link

### DIFF
--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -20,7 +20,7 @@ Every line of code, every test, every documentation file was written by the AI u
 
 * https://github.com/docToolchain/dacli[*dacli*]: A full CLI tool with spec, architecture docs, tests, and user manual. Built by one AI, cross-reviewed by 5 different LLMs.
 * https://github.com/LLM-Coding/Semantic-Anchors[*Semantic Anchors Website*]: 228+ GitHub stars, documentation, and a video series.
-* https://github.com/rdmueller/vibe-coding-risk-radar[*Vibe Coding Risk Radar*]: An interactive web app for assessing AI coding risks.
+* https://github.com/LLM-Coding/vibe-coding-risk-radar[*Vibe Coding Risk Radar*]: An interactive web app for assessing AI coding risks.
 
 [NOTE]
 ====

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -22,7 +22,7 @@ Jede Zeile Code, jeder Test, jede Dokumentationsdatei wurde von der KI unter mei
 
 * https://github.com/docToolchain/dacli[*dacli*]: Ein vollständiges CLI-Tool mit Spezifikation, Architekturdokumentation, Tests und Benutzerhandbuch. Von einer KI gebaut, von 5 verschiedenen LLMs gegengelesen.
 * https://github.com/LLM-Coding/Semantic-Anchors[*Semantic Anchors Website*]: 228+ GitHub Stars, Dokumentation und eine Videoserie.
-* https://github.com/rdmueller/vibe-coding-risk-radar[*Vibe Coding Risk Radar*]: Eine interaktive Webanwendung zur Bewertung von KI-Coding-Risiken.
+* https://github.com/LLM-Coding/vibe-coding-risk-radar[*Vibe Coding Risk Radar*]: Eine interaktive Webanwendung zur Bewertung von KI-Coding-Risiken.
 
 [NOTE]
 ====


### PR DESCRIPTION
Fixed dead link in workflow doc (EN + DE): `rdmueller/vibe-coding-risk-radar` → `LLM-Coding/vibe-coding-risk-radar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Aktualisierte externe Verweise auf die "Vibe Coding Risk Radar" Ressource in der Dokumentation (Englisch und Deutsch).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->