### PR TITLE
chore: update meta tags (110+ anchors, contracts, evaluations)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary Meta Tags -->
-    <title>Semantic Anchors - Curated Catalog for LLM Communication</title>
-    <meta name="title" content="Semantic Anchors - Curated Catalog for LLM Communication" />
-    <meta name="description" content="60+ curated semantic anchors - well-defined terms, methodologies, and frameworks for precise communication with Large Language Models. Browse by category or role." />
-    <meta name="keywords" content="semantic anchors, LLM, large language models, AI communication, prompt engineering, software development, TDD, architecture patterns, design principles" />
+    <title>Semantic Anchors - Shared Vocabulary for LLM Communication</title>
+    <meta name="title" content="Semantic Anchors - Shared Vocabulary for LLM Communication" />
+    <meta name="description" content="110+ semantic anchors and semantic contracts for precise LLM communication. Curated methodologies, frameworks, and composable project conventions. Evaluated across 10 models." />
+    <meta name="keywords" content="semantic anchors, semantic contracts, LLM, large language models, AI communication, prompt engineering, software development, TDD, architecture patterns, design principles, AGENTS.md" />
     <meta name="author" content="LLM Coding Community" />
     <meta name="language" content="English, German" />
 
@@ -27,8 +27,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://llm-coding.github.io/Semantic-Anchors/" />
-    <meta property="og:title" content="Semantic Anchors - Curated Catalog for LLM Communication" />
-    <meta property="og:description" content="60+ curated semantic anchors for precise LLM communication. Browse methodologies, frameworks, and patterns by category or professional role." />
+    <meta property="og:title" content="Semantic Anchors - Shared Vocabulary for LLM Communication" />
+    <meta property="og:description" content="110+ semantic anchors and semantic contracts for precise LLM communication. Evaluated across 10 models." />
     <meta property="og:image" content="https://llm-coding.github.io/Semantic-Anchors/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -39,8 +39,8 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://llm-coding.github.io/Semantic-Anchors/" />
-    <meta name="twitter:title" content="Semantic Anchors - Curated Catalog for LLM Communication" />
-    <meta name="twitter:description" content="60+ curated semantic anchors for precise LLM communication. Browse by category or role." />
+    <meta name="twitter:title" content="Semantic Anchors - Shared Vocabulary for LLM Communication" />
+    <meta name="twitter:description" content="110+ semantic anchors and semantic contracts for precise LLM communication. Evaluated across 10 models." />
     <meta name="twitter:image" content="https://llm-coding.github.io/Semantic-Anchors/twitter-card.png" />
 
     <!-- Structured Data (Schema.org) -->
@@ -51,7 +51,7 @@
       "name": "Semantic Anchors",
       "alternateName": "Semantic Anchors for LLMs",
       "url": "https://llm-coding.github.io/Semantic-Anchors/",
-      "description": "A curated catalog of 60+ semantic anchors - well-defined terms, methodologies, and frameworks for precise communication with Large Language Models",
+      "description": "110+ semantic anchors and semantic contracts for precise communication with Large Language Models. Evaluated across 10 models.",
       "inLanguage": ["en", "de"],
       "publisher": {
         "@type": "Organization",


### PR DESCRIPTION
Updated all meta tags from "60+ curated semantic anchors" to "110+ semantic anchors and semantic contracts, evaluated across 10 models."

Partial fix for #371 (quick win — the hash routing SEO issue remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Sonstige Updates**
  * Website-Metadaten aktualisiert: Der Titel wurde überarbeitet, um das Konzept der gemeinsamen Vokabular besser widerzuspiegeln.
  * Erhöhte Anzahl von semantischen Ankern (110+) und neue Informationen zu semantischen Verträgen sowie komponierbaren Projektkonventionen hinzugefügt.
  * SEO- und Social-Media-Felder entsprechend angepasst.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->