### PR TITLE
fix: move GTD to knowledge-management category

### DIFF
--- a/docs/anchors/gtd.adoc
+++ b/docs/anchors/gtd.adoc
@@ -1,5 +1,5 @@
 = GTD — Getting Things Done
-:categories: development-workflow
+:categories: knowledge-management
 :roles: software-developer, team-lead, product-owner, educator
 :related: para-method, todotxt-flavoured-markdown, definition-of-done
 :proponents: David Allen

--- a/docs/anchors/gtd.de.adoc
+++ b/docs/anchors/gtd.de.adoc
@@ -1,5 +1,5 @@
 = GTD — Getting Things Done
-:categories: development-workflow
+:categories: knowledge-management
 :roles: software-developer, team-lead, product-owner, educator
 :related: para-method, todotxt-flavoured-markdown, definition-of-done
 :proponents: David Allen

--- a/website/public/data/anchors.json
+++ b/website/public/data/anchors.json
@@ -1412,7 +1412,7 @@
     "id": "gtd",
     "title": "GTD — Getting Things Done",
     "categories": [
-      "development-workflow"
+      "knowledge-management"
     ],
     "roles": [
       "software-developer",

--- a/website/public/data/categories.json
+++ b/website/public/data/categories.json
@@ -88,6 +88,7 @@
     "id": "knowledge-management",
     "name": "Knowledge Management",
     "anchors": [
+      "gtd",
       "para-method",
       "todotxt-flavoured-markdown"
     ]

--- a/website/public/data/metadata.json
+++ b/website/public/data/metadata.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-03-27T08:59:25.567Z",
+  "generatedAt": "2026-03-27T10:14:08.551Z",
   "version": "1.0.0",
   "counts": {
-    "anchors": 111,
+    "anchors": 112,
     "categories": 13,
     "roles": 12
   },
   "statistics": {
     "averageRolesPerAnchor": "3.14",
     "averageCategoriesPerAnchor": "1.01",
-    "anchorsWithTags": 71,
-    "anchorsWithRelated": 42
+    "anchorsWithTags": 72,
+    "anchorsWithRelated": 43
   }
 }


### PR DESCRIPTION
GTD → knowledge-management (was development-workflow).

Knowledge Management now: GTD, P.A.R.A., todo.txt-flavoured Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Änderungen

* **Dokumentation**
  * GTD (Getting Things Done) wurde neu kategorisiert und ist nun unter Knowledge Management zu finden statt unter Development Workflow.

* **Chores**
  * Metadaten und Kategorisierungsindizes aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->