### PR TITLE
fix: correct workflow diagram image path for SPA routing

### DIFF
--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -78,7 +78,7 @@ Short transmissions with error correction are far more reliable than one long, u
 
 == Workflow Overview
 
-image::workflow-diagram.svg[Workflow Overview,width=1100]
+image::docs/workflow-diagram.svg[Workflow Overview,width=1100]
 
 == Cross-Cutting Concerns
 

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -80,7 +80,7 @@ Kurze Übertragungen mit Fehlerkorrektur sind weit zuverlässiger als eine lange
 
 == Workflow-Übersicht
 
-image::workflow-diagram.svg[Workflow-Übersicht,width=1100]
+image::docs/workflow-diagram.svg[Workflow-Übersicht,width=1100]
 
 == Querschnittsthemen
 


### PR DESCRIPTION
## Summary
- Fix broken workflow diagram image on the live site
- The SPA injects HTML via `innerHTML`, so relative `src` paths resolve from the page root (`/Semantic-Anchors/`), not from `/Semantic-Anchors/docs/`
- Change `image::workflow-diagram.svg` → `image::docs/workflow-diagram.svg` in both EN and DE

## Test plan
- [ ] Verify diagram loads on https://llm-coding.github.io/Semantic-Anchors/#/spec-driven-workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Bildreferenzen in der Workflow-Dokumentation wurden aktualisiert und optimiert. Die Dateipfade für die Workflow-Übersicht-Diagramme wurden harmonisiert, um korrekte und konsistente Asset-Auflösung über alle Dokumentationssprachversionen zu gewährleisten. Die Änderungen wurden in der deutschen und englischen Dokumentation durchgeführt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->