### PR TITLE
fix: resolve high-severity npm audit vulnerability (basic-ftp)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

`npm audit fix` updates `basic-ftp` from 5.2.0 → 5.2.2 to resolve two high-severity CRLF injection advisories:

- [GHSA-6v7q-wjvx-w8wg](https://github.com/advisories/GHSA-6v7q-wjvx-w8wg) — Incomplete CRLF Injection Protection
- [GHSA-chqc-8p9q-pq6q](https://github.com/advisories/GHSA-chqc-8p9q-pq6q) — FTP Command Injection via CRLF

\`basic-ftp\` is a deep transitive dependency:

\`\`\`
@lhci/cli → proxy-agent → pac-proxy-agent → get-uri → basic-ftp
\`\`\`

After the fix: **0 vulnerabilities**. No breaking changes — only package-lock.json is modified.

## Test plan

- [ ] \`npm audit --audit-level=high\` passes (exit code 0)
- [ ] Dependency Security Audit CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)