### PR TITLE
fix: make SPA routes crawlable at source (sitemap script + pre-render)

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -22,14 +22,24 @@ const OUTPUT_FILE = path.join(__dirname, '..', 'website', 'public', 'sitemap.xml
 const BASE_URL = 'https://llm-coding.github.io/Semantic-Anchors'
 
 // Static pages served by the SPA router. Keep in sync with
-// website/src/utils/router.js -> ROUTE_TITLES.
+// website/src/utils/router.js -> ROUTE_TITLES AND with the ROUTES list in
+// scripts/prerender-routes.js.
+//
+// Only routes that can be pre-rendered to static HTML are listed here —
+// otherwise the sitemap would advertise URLs that return an empty SPA
+// shell to non-JS crawlers and claude.ai fetchers.
+//
+// Excluded on purpose:
+// - /contracts     — interactive JS page (localStorage, client-side data
+//                    fetching); no static content worth serving
+// - /anchor/:id    — rendered per entry via the anchor loop below
+//
 // priority: 1.0 homepage, 0.8 top-level content, 0.7 contributing/meta, 0.6 anchors
 const PAGES = [
   { path: '/', priority: '1.0', changefreq: 'weekly' },
   { path: '/about', priority: '0.8', changefreq: 'monthly' },
   { path: '/workflow', priority: '0.8', changefreq: 'monthly' },
   { path: '/brownfield', priority: '0.8', changefreq: 'monthly' },
-  { path: '/contracts', priority: '0.8', changefreq: 'monthly' },
   { path: '/evaluations', priority: '0.8', changefreq: 'monthly' },
   { path: '/all-anchors', priority: '0.8', changefreq: 'weekly' },
   { path: '/agentskill', priority: '0.7', changefreq: 'monthly' },

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -3,69 +3,82 @@
 /**
  * generate-sitemap.js
  *
- * Generates sitemap.xml for the Semantic Anchors website
+ * Generates sitemap.xml for the Semantic Anchors website.
+ *
+ * Produces clean (non-hash) URLs that match the History API router in
+ * website/src/utils/router.js. Hash-based URLs (#/about) are not crawlable
+ * by search engines — every hash URL looks like the homepage to a crawler,
+ * and claude.ai / LLM fetchers cannot reach them either.
+ *
+ * Keep the PAGES list in sync with router.js `ROUTE_TITLES` when adding
+ * new routes.
  */
 
 const fs = require('fs')
 const path = require('path')
 
-// Paths
 const ANCHORS_DATA = path.join(__dirname, '..', 'website', 'public', 'data', 'anchors.json')
 const OUTPUT_FILE = path.join(__dirname, '..', 'website', 'public', 'sitemap.xml')
 const BASE_URL = 'https://llm-coding.github.io/Semantic-Anchors'
 
-// Read anchors data
-const anchorsData = JSON.parse(fs.readFileSync(ANCHORS_DATA, 'utf-8'))
+// Static pages served by the SPA router. Keep in sync with
+// website/src/utils/router.js -> ROUTE_TITLES.
+// priority: 1.0 homepage, 0.8 top-level content, 0.7 contributing/meta, 0.6 anchors
+const PAGES = [
+  { path: '/', priority: '1.0', changefreq: 'weekly' },
+  { path: '/about', priority: '0.8', changefreq: 'monthly' },
+  { path: '/workflow', priority: '0.8', changefreq: 'monthly' },
+  { path: '/brownfield', priority: '0.8', changefreq: 'monthly' },
+  { path: '/contracts', priority: '0.8', changefreq: 'monthly' },
+  { path: '/evaluations', priority: '0.8', changefreq: 'monthly' },
+  { path: '/all-anchors', priority: '0.8', changefreq: 'weekly' },
+  { path: '/agentskill', priority: '0.7', changefreq: 'monthly' },
+  { path: '/changelog', priority: '0.7', changefreq: 'weekly' },
+  { path: '/contributing', priority: '0.7', changefreq: 'monthly' },
+  { path: '/rejected-proposals', priority: '0.5', changefreq: 'monthly' },
+]
 
-// Generate sitemap
+const anchorsData = JSON.parse(fs.readFileSync(ANCHORS_DATA, 'utf-8'))
 const today = new Date().toISOString().split('T')[0]
+
+function urlEntry(loc, lastmod, changefreq, priority, comment) {
+  return `  ${comment ? `<!-- ${comment} -->\n  ` : ''}<url>
+    <loc>${loc}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>
+
+`
+}
 
 let sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Homepage -->
-  <url>
-    <loc>${BASE_URL}/</loc>
-    <lastmod>${today}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-
-  <!-- About Page -->
-  <url>
-    <loc>${BASE_URL}/#/about</loc>
-    <lastmod>${today}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <!-- Contributing Page -->
-  <url>
-    <loc>${BASE_URL}/#/contributing</loc>
-    <lastmod>${today}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
 `
 
-// Add all anchors
+// Static pages
+for (const page of PAGES) {
+  const loc = page.path === '/' ? `${BASE_URL}/` : `${BASE_URL}${page.path}`
+  sitemap += urlEntry(loc, today, page.changefreq, page.priority)
+}
+
+// Individual anchor pages
 anchorsData.forEach((anchor) => {
-  sitemap += `  <!-- Anchor: ${anchor.title} -->
-  <url>
-    <loc>${BASE_URL}/#/anchor/${anchor.id}</loc>
-    <lastmod>${today}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-`
+  sitemap += urlEntry(
+    `${BASE_URL}/anchor/${anchor.id}`,
+    today,
+    'monthly',
+    '0.6',
+    `Anchor: ${anchor.title}`
+  )
 })
 
 sitemap += `</urlset>
 `
 
-// Write sitemap
 fs.writeFileSync(OUTPUT_FILE, sitemap, 'utf-8')
 
 console.log(`✓ Sitemap generated: ${OUTPUT_FILE}`)
-console.log(`✓ Total URLs: ${anchorsData.length + 3} (3 pages + ${anchorsData.length} anchors)`)
+console.log(
+  `✓ Total URLs: ${PAGES.length + anchorsData.length} (${PAGES.length} pages + ${anchorsData.length} anchors)`
+)

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -41,6 +41,15 @@ const PAGES = [
 const anchorsData = JSON.parse(fs.readFileSync(ANCHORS_DATA, 'utf-8'))
 const today = new Date().toISOString().split('T')[0]
 
+/**
+ * Render one <url> entry for sitemap.xml.
+ * @param {string} loc - Fully-qualified URL of the page.
+ * @param {string} lastmod - ISO date string (YYYY-MM-DD).
+ * @param {string} changefreq - Sitemap changefreq value (weekly, monthly, ...).
+ * @param {string} priority - Sitemap priority value ("0.0"–"1.0").
+ * @param {string} [comment] - Optional XML comment placed above the entry.
+ * @returns {string} One <url>...</url> block with a trailing blank line.
+ */
 function urlEntry(loc, lastmod, changefreq, priority, comment) {
   return `  ${comment ? `<!-- ${comment} -->\n  ` : ''}<url>
     <loc>${loc}</loc>

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -96,6 +96,12 @@ const ROUTES = [
   },
 ]
 
+/**
+ * Read the Vite-built HTML shell (website/dist/index.html).
+ * Exits with an error if the shell is missing — indicates that the caller
+ * forgot to run `vite build` before this post-build step.
+ * @returns {string} Raw HTML contents of the shell.
+ */
 function readShell() {
   if (!fs.existsSync(SHELL)) {
     console.error(`ERROR: ${SHELL} does not exist. Run 'vite build' first.`)
@@ -104,6 +110,13 @@ function readShell() {
   return fs.readFileSync(SHELL, 'utf-8')
 }
 
+/**
+ * Escape a string for safe insertion into an HTML attribute or text node.
+ * Converts &, <, >, ", and ' to their HTML entity equivalents. Used for
+ * route titles and descriptions that end up inside <title> and meta tags.
+ * @param {string} str - Input string to escape.
+ * @returns {string} HTML-safe string.
+ */
 function escapeHtml(str) {
   return String(str).replace(
     /[&<>"']/g,
@@ -134,6 +147,17 @@ function buildAppMarkup(fragmentHtml) {
   `
 }
 
+/**
+ * Pre-render a single route to website/dist/<route>/index.html.
+ * Reads the AsciiDoc fragment produced by scripts/render-docs.js, injects
+ * it into a copy of the Vite shell, and updates the <title>, meta
+ * description, and canonical URL to match the route. If the fragment is
+ * missing, logs a warning and returns false without writing anything.
+ * @param {string} shell - Raw HTML of the Vite build shell.
+ * @param {{path: string, fragment: string, title: string, description: string}} route
+ *   Route descriptor from the ROUTES list.
+ * @returns {boolean} true when a file was written, false when skipped.
+ */
 function prerenderRoute(shell, route) {
   const fragmentPath = path.join(DIST, route.fragment)
   if (!fs.existsSync(fragmentPath)) {
@@ -173,6 +197,10 @@ function prerenderRoute(shell, route) {
   return true
 }
 
+/**
+ * Entry point: read the shell once, then pre-render every route in ROUTES.
+ * Logs a summary of how many routes were written vs skipped.
+ */
 function main() {
   const shell = readShell()
   let written = 0

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -92,8 +92,7 @@ const ROUTES = [
     path: '/evaluations',
     fragment: 'docs/anchor-evaluations.html',
     title: 'Evaluations — Semantic Anchors',
-    description:
-      'Multiple-choice evaluations of semantic anchor recognition across 10 LLMs.',
+    description: 'Multiple-choice evaluations of semantic anchor recognition across 10 LLMs.',
   },
 ]
 
@@ -106,13 +105,17 @@ function readShell() {
 }
 
 function escapeHtml(str) {
-  return String(str).replace(/[&<>"']/g, (c) => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-  })[c])
+  return String(str).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c]
+  )
 }
 
 /**

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -151,18 +151,21 @@ function buildAppMarkup(fragmentHtml) {
  * Pre-render a single route to website/dist/<route>/index.html.
  * Reads the AsciiDoc fragment produced by scripts/render-docs.js, injects
  * it into a copy of the Vite shell, and updates the <title>, meta
- * description, and canonical URL to match the route. If the fragment is
- * missing, logs a warning and returns false without writing anything.
+ * description, and canonical URL to match the route. Throws if the
+ * fragment is missing so the build fails fast instead of shipping an
+ * incomplete set of pre-rendered pages.
  * @param {string} shell - Raw HTML of the Vite build shell.
  * @param {{path: string, fragment: string, title: string, description: string}} route
  *   Route descriptor from the ROUTES list.
- * @returns {boolean} true when a file was written, false when skipped.
+ * @throws {Error} When the configured fragment file does not exist.
  */
 function prerenderRoute(shell, route) {
   const fragmentPath = path.join(DIST, route.fragment)
   if (!fs.existsSync(fragmentPath)) {
-    console.warn(`  skip ${route.path}: fragment not found at ${route.fragment}`)
-    return false
+    throw new Error(
+      `Missing fragment for ${route.path}: ${route.fragment} (expected at ${fragmentPath}). ` +
+        `Make sure scripts/render-docs.js runs before prerender-routes.js and writes the fragment to website/public/docs/.`
+    )
   }
   const fragment = fs.readFileSync(fragmentPath, 'utf-8')
 
@@ -194,23 +197,20 @@ function prerenderRoute(shell, route) {
   const outFile = path.join(outDir, 'index.html')
   fs.mkdirSync(outDir, { recursive: true })
   fs.writeFileSync(outFile, html, 'utf-8')
-  return true
 }
 
 /**
  * Entry point: read the shell once, then pre-render every route in ROUTES.
- * Logs a summary of how many routes were written vs skipped.
+ * Throws (via prerenderRoute) if any fragment is missing, so the build
+ * fails non-zero instead of shipping an incomplete set of static pages.
  */
 function main() {
   const shell = readShell()
-  let written = 0
   for (const route of ROUTES) {
-    if (prerenderRoute(shell, route)) {
-      console.log(`  ✓ pre-rendered ${route.path}`)
-      written += 1
-    }
+    prerenderRoute(shell, route)
+    console.log(`  ✓ pre-rendered ${route.path}`)
   }
-  console.log(`\n✓ Pre-rendered ${written}/${ROUTES.length} routes to dist/<route>/index.html`)
+  console.log(`\n✓ Pre-rendered ${ROUTES.length} routes to dist/<route>/index.html`)
 }
 
 main()

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * prerender-routes.js
+ *
+ * Post-build step: generate per-route static HTML so crawlers and non-JS
+ * fetchers (claude.ai, curl, search engine bots that skip JS execution) can
+ * access doc-style pages directly at their clean URLs.
+ *
+ * How it works:
+ *   1. Reads the built Vite shell at website/dist/index.html
+ *   2. For each route that has a pre-rendered content fragment in
+ *      website/dist/docs/<fragment>.html, generates
+ *      website/dist/<route>/index.html that injects the fragment into
+ *      the #app div's initial markup and updates the <title> + meta
+ *      description.
+ *   3. When a user-agent with JS loads the page, the SPA boots, clears
+ *      #app, and re-renders as usual — so users get the normal interactive
+ *      experience. Crawlers and no-JS fetchers see real content immediately.
+ *
+ * GitHub Pages serves <route>/index.html automatically when the clean URL
+ * (e.g. /workflow) is requested.
+ *
+ * Keep ROUTES in sync with website/src/utils/router.js and scripts/render-docs.js.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const DIST = path.join(__dirname, '..', 'website', 'dist')
+const SHELL = path.join(DIST, 'index.html')
+
+// Each entry maps a clean-URL route to the doc fragment rendered by
+// scripts/render-docs.js, plus SEO metadata for the per-route <head>.
+const ROUTES = [
+  {
+    path: '/about',
+    fragment: 'docs/about.html',
+    title: 'About — Semantic Anchors',
+    description:
+      'Learn what semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
+  },
+  {
+    path: '/workflow',
+    fragment: 'docs/spec-driven-workflow.html',
+    title: 'Development Workflow — Semantic Anchors',
+    description:
+      'The Semantic Anchors spec-driven development workflow — from requirements to specification to implementation, powered by semantic anchors.',
+  },
+  {
+    path: '/brownfield',
+    fragment: 'docs/brownfield-workflow.html',
+    title: 'Brownfield Workflow — Semantic Anchors',
+    description:
+      'Applying semantic anchors to brownfield codebases using a bounded-context approach.',
+  },
+  {
+    path: '/changelog',
+    fragment: 'docs/changelog.html',
+    title: 'Changelog — Semantic Anchors',
+    description: 'Chronological record of all semantic anchors added to the catalog.',
+  },
+  {
+    path: '/contributing',
+    fragment: 'CONTRIBUTING.html',
+    title: 'Contributing — Semantic Anchors',
+    description:
+      'How to propose new semantic anchors, quality criteria, and the contribution workflow.',
+  },
+  {
+    path: '/agentskill',
+    fragment: 'docs/agentskill.html',
+    title: 'AgentSkill — Semantic Anchors',
+    description:
+      'The semantic-anchor-translator AgentSkill — install semantic anchors into Claude Code, Codex, Cursor, and other coding agents.',
+  },
+  {
+    path: '/rejected-proposals',
+    fragment: 'docs/rejected-proposals.html',
+    title: 'Rejected Proposals — Semantic Anchors',
+    description:
+      'Anchor proposals that did not meet the quality criteria, with reasoning — useful for understanding the curation bar.',
+  },
+  {
+    path: '/all-anchors',
+    fragment: 'docs/all-anchors.html',
+    title: 'Full Reference — Semantic Anchors',
+    description:
+      'Full reference of all semantic anchors in one long document — readable offline, linkable, easy to Ctrl-F.',
+  },
+  {
+    path: '/evaluations',
+    fragment: 'docs/anchor-evaluations.html',
+    title: 'Evaluations — Semantic Anchors',
+    description:
+      'Multiple-choice evaluations of semantic anchor recognition across 10 LLMs.',
+  },
+]
+
+function readShell() {
+  if (!fs.existsSync(SHELL)) {
+    console.error(`ERROR: ${SHELL} does not exist. Run 'vite build' first.`)
+    process.exit(1)
+  }
+  return fs.readFileSync(SHELL, 'utf-8')
+}
+
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[c])
+}
+
+/**
+ * Build the pre-populated markup that goes inside <div id="app">.
+ * Mirrors the layout produced at runtime by renderHeader() + renderDocPage()
+ * + renderFooter() in website/src/main.js, but statically — so crawlers see
+ * real content in the initial HTML response.
+ */
+function buildAppMarkup(fragmentHtml) {
+  return `
+    <main class="flex-1">
+      <article class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div id="doc-content" class="asciidoc-content">${fragmentHtml}</div>
+      </article>
+    </main>
+  `
+}
+
+function prerenderRoute(shell, route) {
+  const fragmentPath = path.join(DIST, route.fragment)
+  if (!fs.existsSync(fragmentPath)) {
+    console.warn(`  skip ${route.path}: fragment not found at ${route.fragment}`)
+    return false
+  }
+  const fragment = fs.readFileSync(fragmentPath, 'utf-8')
+
+  let html = shell
+
+  // Replace <title>
+  html = html.replace(/<title>[\s\S]*?<\/title>/, `<title>${escapeHtml(route.title)}</title>`)
+
+  // Replace meta description if present
+  html = html.replace(
+    /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/,
+    `<meta name="description" content="${escapeHtml(route.description)}" />`
+  )
+
+  // Update canonical URL so each pre-rendered page points to itself
+  const canonicalUrl = `https://llm-coding.github.io/Semantic-Anchors${route.path}`
+  html = html.replace(
+    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/,
+    `<link rel="canonical" href="${canonicalUrl}" />`
+  )
+
+  // Inject pre-rendered content into #app
+  html = html.replace(
+    /<div\s+id="app"\s*>\s*<\/div>/,
+    `<div id="app">${buildAppMarkup(fragment)}</div>`
+  )
+
+  const outDir = path.join(DIST, route.path)
+  const outFile = path.join(outDir, 'index.html')
+  fs.mkdirSync(outDir, { recursive: true })
+  fs.writeFileSync(outFile, html, 'utf-8')
+  return true
+}
+
+function main() {
+  const shell = readShell()
+  let written = 0
+  for (const route of ROUTES) {
+    if (prerenderRoute(shell, route)) {
+      console.log(`  ✓ pre-rendered ${route.path}`)
+      written += 1
+    }
+  }
+  console.log(`\n✓ Pre-rendered ${written}/${ROUTES.length} routes to dist/<route>/index.html`)
+}
+
+main()

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "predev": "node ../scripts/sync-anchors.js",
     "dev": "vite",
     "prebuild": "node ../scripts/sync-anchors.js && node ../scripts/render-docs.js",
-    "build": "vite build",
+    "build": "vite build && node ../scripts/prerender-routes.js",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -29,13 +29,6 @@
   </url>
 
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/contracts</loc>
-    <lastmod>2026-04-13</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/evaluations</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,1065 +1,1118 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Homepage -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/</loc>
-    <lastmod>2026-04-12</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
-  <!-- About Page -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/about</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/about</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
-  <!-- Contributing Page -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/contributing</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/workflow</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/brownfield</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/contracts</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/evaluations</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/all-anchors</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/agentskill</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/changelog</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/contributing</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/rejected-proposals</loc>
+    <lastmod>2026-04-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
   <!-- Anchor: 4MAT -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/4mat</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/4mat</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: ADR according to Nygard -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/adr-according-to-nygard</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/adr-according-to-nygard</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: arc42 Architecture Documentation -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/arc42</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/arc42</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: ATAM -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/atam</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/atam</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: BDD (Behavior-Driven Development) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/bdd-given-when-then</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bdd-given-when-then</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: BEM Methodology -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/bem-methodology</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bem-methodology</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: BLUF (Bottom Line Up Front) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/bluf</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bluf</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: C4-Diagrams -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/c4-diagrams</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/c4-diagrams</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Chain of Thought (CoT) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/chain-of-thought</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/chain-of-thought</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Clean Architecture -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/clean-architecture</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/clean-architecture</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Cohesion Criteria -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/cohesion-criteria</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cohesion-criteria</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Control Chart (Shewhart) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/control-chart-shewhart</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/control-chart-shewhart</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Conventional Commits -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/conventional-commits</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/conventional-commits</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: CQRS (Command Query Responsibility Segregation) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/cqrs</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cqrs</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: CRC-Cards -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/crc-cards</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/crc-cards</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Cynefin Framework -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/cynefin-framework</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cynefin-framework</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Definition of Done -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/definition-of-done</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/definition-of-done</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Devil’s Advocate -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/devils-advocate</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/devils-advocate</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Diátaxis Framework -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/diataxis-framework</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/diataxis-framework</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Docs-as-Code according to Ralf D. Müller -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/docs-as-code</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/docs-as-code</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Domain-Driven Design according to Evans -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/domain-driven-design</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/domain-driven-design</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: EARS-Requirements -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/ears-requirements</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/ears-requirements</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Effective Go -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/effective-go</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/effective-go</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Event-Driven Architecture -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/event-driven-architecture</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/event-driven-architecture</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Fagan Inspection -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/fagan-inspection</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fagan-inspection</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Feynman Technique -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/feynman-technique</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/feynman-technique</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Fichtean Curve -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/fichtean-curve</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fichtean-curve</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Five Whys (Ohno) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/five-whys</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/five-whys</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Patterns of Enterprise Application Architecture (PEAA) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/fowler-patterns</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fowler-patterns</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Freytag’s Pyramid -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/freytags-pyramid</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/freytags-pyramid</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Gherkin -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gherkin</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gherkin</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GitHub Flow -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/github-flow</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/github-flow</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Abstract Factory Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-abstract-factory-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-abstract-factory-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Adapter Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-adapter-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-adapter-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Bridge Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-bridge-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-bridge-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Builder Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-builder-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-builder-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Chain of Responsibility Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-chain-of-responsibility-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-chain-of-responsibility-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Command Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-command-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-command-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Composite Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-composite-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-composite-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Decorator Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-decorator-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-decorator-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF Design Patterns -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-design-patterns</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-design-patterns</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Facade Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-facade-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-facade-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Factory Method Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-factory-method-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-factory-method-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Flyweight Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-flyweight-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-flyweight-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Interpreter Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-interpreter-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-interpreter-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Iterator Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-iterator-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-iterator-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Mediator Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-mediator-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-mediator-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Memento Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-memento-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-memento-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Observer Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-observer-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-observer-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Prototype Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-prototype-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-prototype-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Proxy Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-proxy-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-proxy-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Singleton Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-singleton-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-singleton-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-State Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-state-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-state-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Strategy Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-strategy-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-strategy-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Template Method Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-template-method-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-template-method-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoF-Visitor Pattern -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gof-visitor-pattern</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-visitor-pattern</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GoM -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gom</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gom</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GRASP -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/grasp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/grasp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: GTD — Getting Things Done -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gtd</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gtd</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Gutes Deutsch nach Wolf Schneider -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/gutes-deutsch-wolf-schneider</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gutes-deutsch-wolf-schneider</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Hemingway Bridge -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/hemingway-bridge</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/hemingway-bridge</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Hero’s Journey -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/heros-journey</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/heros-journey</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Hexagonal Architecture (Ports & Adapters) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/hexagonal-architecture</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/hexagonal-architecture</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: IEC 61508 SIL Levels -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/iec-61508-sil-levels</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/iec-61508-sil-levels</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Impact Mapping -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/impact-mapping</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/impact-mapping</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: INVEST -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/invest</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/invest</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: ISO/IEC 25010 -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/iso-25010</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/iso-25010</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Jobs To Be Done (JTBD) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/jobs-to-be-done</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/jobs-to-be-done</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Kishōtenketsu -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/kishotenketsu</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/kishotenketsu</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: KISS Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/kiss-principle</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/kiss-principle</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: LASR according to Toth/Zörner -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/lasr</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/lasr</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: LINDDUN -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/linddun</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/linddun</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: LLM-Evaluations -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/llm-evaluations</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/llm-evaluations</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: MADR -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/madr</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/madr</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: MECE Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/mece</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mece</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Programming as Theory Building (Naur) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/mental-model-according-to-naur</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mental-model-according-to-naur</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Mikado Method -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/mikado-method</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mikado-method</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Morphological Box -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/morphological-box</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/morphological-box</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: MoSCoW -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/moscow</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/moscow</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Mutation Testing -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/mutation-testing</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mutation-testing</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Minimum Viable Product (MVP) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/mvp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mvp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Myers-Briggs Type Indicator (MBTI) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/myers-briggs-type-indicator</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/myers-briggs-type-indicator</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Nelson Rules -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/nelson-rules</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/nelson-rules</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: OWASP Top 10 -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/owasp-top-10</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/owasp-top-10</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: P.A.R.A. Method -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/para-method</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/para-method</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: PERT -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/pert</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pert</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Plain English according to Strunk & White -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/plain-english-strunk-white</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/plain-english-strunk-white</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: PRD -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/prd</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/prd</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Nonviolent Communication (Rosenberg) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/problem-space-nvc</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/problem-space-nvc</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Property-Based Testing -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/property-based-testing</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/property-based-testing</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Pugh-Matrix -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/pugh-matrix</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pugh-matrix</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Pyramid Principle according to Barbara Minto -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/pyramid-principle</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pyramid-principle</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Red/Green TDD -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/red-green-tdd</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/red-green-tdd</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Regulated Environment -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/regulated-environment</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/regulated-environment</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Save the Cat! (15-Beat Sheet) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/save-the-cat</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/save-the-cat</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Semantic Versioning (SemVer) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/semantic-versioning</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/semantic-versioning</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Socratic Method -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/socratic-method</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/socratic-method</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID-Dependency Inversion Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-dip</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-dip</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID-Interface Segregation Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-isp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-isp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID-Liskov Substitution Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-lsp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-lsp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID-Open/Closed Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-ocp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-ocp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID Principles -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-principles</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-principles</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOLID-Single Responsibility Principle -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/solid-srp</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-srp</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SOTA (State-of-the-Art) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/sota</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/sota</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SPC (Statistical Process Control) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/spc</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/spc</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Spike Solution -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/spike-solution</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/spike-solution</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SSOT (Single Source of Truth) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/ssot-principle</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/ssot-principle</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Story Circle (Dan Harmon) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/story-circle-dan-harmon</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/story-circle-dan-harmon</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: STRIDE Threat Model -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/stride</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/stride</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: SWOT -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/swot</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/swot</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: TDD, Chicago School -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-chicago-school</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tdd-chicago-school</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: TDD, London School -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/tdd-london-school</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tdd-london-school</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double: Dummy (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-dummy</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-dummy</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double: Fake (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-fake</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-fake</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-meszaros</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-meszaros</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double: Mock (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-mock</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-mock</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double: Spy (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-spy</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-spy</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Test Double: Stub (Meszaros) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/test-double-stub</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-stub</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Testing Pyramid -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/testing-pyramid</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/testing-pyramid</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Thin Vertical Slice -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/thin-vertical-slice</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/thin-vertical-slice</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Three-Act Structure -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/three-act-structure</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/three-act-structure</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: TIMTOWTDI -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/timtowtdi</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/timtowtdi</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: todo.txt-flavoured Markdown -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/todotxt-flavoured-markdown</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/todotxt-flavoured-markdown</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Tracer Bullet -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/tracer-bullet</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tracer-bullet</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: User Story Mapping -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/user-story-mapping</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/user-story-mapping</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Vertical Slice Architecture (VSA) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/vertical-slice-architecture</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/vertical-slice-architecture</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Walking Skeleton -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/walking-skeleton</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/walking-skeleton</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: Wardley Mapping -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/wardley-mapping</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/wardley-mapping</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: The Spectrum of Semantic Anchors -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/what-qualifies-as-a-semantic-anchor</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/what-qualifies-as-a-semantic-anchor</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- Anchor: YAGNI (You Aren’t Gonna Need It) -->
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/#/anchor/yagni</loc>
-    <lastmod>2026-04-12</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/yagni</loc>
+    <lastmod>2026-04-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring "workflow page is still dynamic" issue. Two separate layers of the problem, both addressed:

### Layer 1: The sitemap script was never fixed

Previous fixes (#371, #384) edited the output \`sitemap.xml\` directly but never touched \`scripts/generate-sitemap.js\`. Every \`npm run build\` ran the script and regenerated the sitemap with the broken hash URLs — silently reverting each fix. This is why the bug kept coming back.

**Fixed:** \`scripts/generate-sitemap.js\` now produces clean, crawlable URLs matching the History API router and includes all 11 pages (was 3). 141 URLs total.

### Layer 2: Clean URLs alone don't help non-JS fetchers

Even with \`/workflow\` as a clean URL, GitHub Pages was serving the empty SPA shell — so pure HTTP fetchers (claude.ai, curl, basic crawlers that don't execute JS) saw nothing.

**Fixed:** New \`scripts/prerender-routes.js\` runs after \`vite build\` and generates \`dist/<route>/index.html\` for each of 9 doc routes. The pre-rendered AsciiDoc fragment from \`render-docs.js\` is injected into a static copy of the Vite shell with per-route \`<title>\`, \`<meta description>\`, and canonical URL.

When GitHub Pages serves \`dist/workflow/index.html\` for \`/workflow\`:
- **Crawlers / claude.ai / curl** see real content immediately in the initial HTML response
- **Users with JS** get the SPA booting on top, which wipes \`#app\` and re-renders as usual — interactive UX is unchanged

## Changes

| File | Change |
|---|---|
| \`scripts/generate-sitemap.js\` | Removed \`#/\` hash prefix, added all 11 pages |
| \`scripts/prerender-routes.js\` | **New** — post-build pre-render step |
| \`website/package.json\` | Chained \`node ../scripts/prerender-routes.js\` into \`build\` |
| \`website/public/sitemap.xml\` | Regenerated (for immediate effect) |

## Pre-rendered routes

/about, /workflow, /brownfield, /changelog, /contributing, /agentskill, /rejected-proposals, /all-anchors, /evaluations

## Test plan

- [x] \`scripts/generate-sitemap.js\` produces clean URLs
- [x] Build generates \`dist/<route>/index.html\` for all 9 doc routes
- [x] \`dist/workflow/index.html\` contains real workflow content (29 content markers)
- [x] Title, description, canonical URL are per-route
- [x] Unit tests pass (89/89)
- [ ] E2E tests pass (will run in CI)
- [ ] After deploy: \`curl https://llm-coding.github.io/Semantic-Anchors/workflow\` returns pre-rendered content without JS execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionshinweise

* **New Features**
  * Erweiterte Sitemap mit zusätzlichen Seiten und sauberen URL-Pfaden statt Hash-basierter Routen für bessere SEO-Unterstützung.
  * Optimierte Vorrendering für statische Seiten zur Verbesserung der Website-Leistung und Indexierbarkeit.

* **Refactor**
  * Aktualisiert Sitemap-Generator für konsistente URL-Verwaltung und dynamische Pfadkonstruktion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->