### PR TITLE
fix: Lighthouse CI tests canonical upstream URL

### DIFF
--- a/website/.lighthouserc.json
+++ b/website/.lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://raifdmueller.github.io/Semantic-Anchors/"],
+      "url": ["https://llm-coding.github.io/Semantic-Anchors/"],
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop"


### PR DESCRIPTION
## Summary

Lighthouse CI has been failing on **every merge to main since 2026-04-06** (10 consecutive failures). Root cause: \`.lighthouserc.json\` tests \`https://raifdmueller.github.io/Semantic-Anchors/\` — the fork URL, which is a leftover from when development happened in the fork before the move to upstream.

The fork's GH Pages site hasn't been redeployed since **2026-03-27** (verified via HTTP \`last-modified\` headers):

| URL | last-modified |
|---|---|
| \`llm-coding.github.io/Semantic-Anchors/\` | 2026-04-13 21:13 (current) |
| \`raifdmueller.github.io/Semantic-Anchors/\` | 2026-03-27 12:45 (stale) |

So every merge to upstream triggered Lighthouse against a 2+ week old snapshot of the site, producing stale Performance/Accessibility scores that had nothing to do with the actual code changes.

## Fix

Point \`.lighthouserc.json\` at \`https://llm-coding.github.io/Semantic-Anchors/\` — the canonical deployed URL that \`deploy.yml\` actually publishes to.

## Test plan

- [ ] After merge, Lighthouse CI runs against the canonical URL
- [ ] Chronic failure streak ends (or surfaces a real perf/a11y issue on the actual site, which would then be a separate fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)