### PR TITLE
fix: eliminate CLS 0.975 via static page shell in index.html (#432)

### DIFF
--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -132,18 +132,16 @@ function escapeHtml(str) {
 }
 
 /**
- * Build the pre-populated markup that goes inside <div id="app">.
- * Mirrors the layout produced at runtime by renderHeader() + renderDocPage()
- * + renderFooter() in website/src/main.js, but statically — so crawlers see
- * real content in the initial HTML response.
+ * Wrap the doc fragment in the structure that website/src/components/doc-page.js
+ * produces at runtime: a centered article container with a #doc-content div.
+ * The content is injected into the shell's #page-content div so crawlers and
+ * non-JS fetchers see real content in the initial HTML response.
  */
-function buildAppMarkup(fragmentHtml) {
+function buildDocContentMarkup(fragmentHtml) {
   return `
-    <main class="flex-1">
-      <article class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        <div id="doc-content" class="asciidoc-content">${fragmentHtml}</div>
-      </article>
-    </main>
+    <article class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <div id="doc-content" class="asciidoc-content">${fragmentHtml}</div>
+    </article>
   `
 }
 
@@ -187,11 +185,19 @@ function prerenderRoute(shell, route) {
     `<link rel="canonical" href="${canonicalUrl}" />`
   )
 
-  // Inject pre-rendered content into #app
-  html = html.replace(
-    /<div\s+id="app"\s*>\s*<\/div>/,
-    `<div id="app">${buildAppMarkup(fragment)}</div>`
-  )
+  // Inject pre-rendered content into the static shell's #page-content div.
+  // The shell (set up in website/index.html and preserved through vite build)
+  // contains:
+  //   <div id="page-content" ... style="..."></div>
+  // We match that empty div by id and fill it with the doc content so crawlers
+  // receive real HTML while JS users still get the SPA hydration on top.
+  const pageContentRegex = /(<div\s+id="page-content"[^>]*>)\s*(<\/div>)/
+  if (!pageContentRegex.test(html)) {
+    throw new Error(
+      `Shell #page-content div not found in dist/index.html. Did website/index.html lose the skeleton structure?`
+    )
+  }
+  html = html.replace(pageContentRegex, `$1${buildDocContentMarkup(fragment)}$2`)
 
   const outDir = path.join(DIST, route.path)
   const outFile = path.join(outDir, 'index.html')

--- a/website/index.html
+++ b/website/index.html
@@ -67,7 +67,20 @@
     </script>
   </head>
   <body>
-    <div id="app"></div>
+    <!--
+      Skeleton shell: reserves viewport-height layout space so first paint
+      already has the expected header/content/footer footprint. Without this
+      the SPA boot caused CLS ~0.975 (empty #app → populated #app). main.js
+      detects the skeleton via #shell-header / #shell-footer and replaces the
+      header + footer in place, leaving #page-content untouched. See #432.
+    -->
+    <div id="app">
+      <div id="shell-root" class="flex flex-col" style="min-height: 100vh;">
+        <div id="shell-header" class="border-b border-[var(--color-border)]" style="min-height: 10.5rem;" aria-hidden="true"></div>
+        <div id="page-content" class="flex-1" style="min-height: calc(100vh - 16.5rem);"></div>
+        <div id="shell-footer" class="border-t border-[var(--color-border)]" style="min-height: 6rem;" aria-hidden="true"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -126,7 +126,6 @@ function hydrateShell(app) {
     <div id="page-content"></div>
     ${renderFooter(APP_VERSION)}
   `
-  // eslint-disable-next-line no-unsanitized/property -- trusted template strings
   app.innerHTML = shellHtml
 }
 

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -97,6 +97,39 @@ function triggerSearchIndexBuild() {
     })
 }
 
+/**
+ * Hydrate the #app element on boot.
+ *
+ * The production build ships website/index.html with a static skeleton
+ * inside #app: a #shell-header placeholder, a real #page-content div, and
+ * a #shell-footer placeholder. Reserving those boxes at first paint
+ * eliminates the empty-→-populated layout shift that used to dominate CLS
+ * on the homepage (see #432).
+ *
+ * If the skeleton is present, replace just the header + footer placeholders
+ * in place — #page-content remains untouched so the route handlers can
+ * populate it normally.
+ *
+ * If the skeleton is absent (dev server / non-prerendered load) we still
+ * need the shell, so fall back to the previous full rewrite of #app.
+ */
+function hydrateShell(app) {
+  const shellHeader = document.getElementById('shell-header')
+  const shellFooter = document.getElementById('shell-footer')
+  if (shellHeader && shellFooter) {
+    shellHeader.outerHTML = renderHeader()
+    shellFooter.outerHTML = renderFooter(APP_VERSION)
+    return
+  }
+  const shellHtml = `
+    ${renderHeader()}
+    <div id="page-content"></div>
+    ${renderFooter(APP_VERSION)}
+  `
+  // eslint-disable-next-line no-unsanitized/property -- trusted template strings
+  app.innerHTML = shellHtml
+}
+
 function initApp() {
   i18n.init()
   initTheme()
@@ -117,11 +150,7 @@ function initApp() {
   const app = document.querySelector('#app')
   if (!app) return
 
-  app.innerHTML = `
-    ${renderHeader()}
-    <div id="page-content"></div>
-    ${renderFooter(APP_VERSION)}
-  `
+  hydrateShell(app)
 
   applyTranslations()
   updateThemeIcon()


### PR DESCRIPTION
Closes #432.

## Problem

Homepage CLS was **0.975** — effectively the entire viewport shifted once during boot — which kept Performance at **0.76** even after every other perf audit was green. The SPA was shipping an empty \`<div id=\"app\"></div>\` and JS was filling it on boot, so the entire page materialised in one frame.

Full analysis and alternatives considered in #432.

## Fix: static skeleton + in-place hydration

Three coordinated changes:

### 1. \`website/index.html\` now ships a static shell inside \`#app\`

\`\`\`html
<div id=\"app\">
  <div id=\"shell-root\" style=\"min-height: 100vh\">
    <div id=\"shell-header\" style=\"min-height: 10.5rem\" aria-hidden>...
    <div id=\"page-content\" style=\"min-height: calc(100vh - 16.5rem)\">...
    <div id=\"shell-footer\" style=\"min-height: 6rem\" aria-hidden>...
  </div>
</div>
\`\`\`

First paint therefore already has the final layout footprint. No empty → populated transition.

### 2. \`website/src/main.js\` hydrates in place

New \`hydrateShell(app)\` detects the skeleton on boot and replaces the two placeholder elements via \`outerHTML\` with the full \`renderHeader()\` / \`renderFooter()\` output. \`#page-content\` stays in place so route handlers continue to populate it normally — no big innerHTML swap, no new DOM nodes appearing where there was nothing before.

Fallback path preserved for the dev server when the skeleton isn't present.

### 3. \`scripts/prerender-routes.js\` injects into \`#page-content\`

The 9 pre-rendered doc routes used to regex-replace the whole empty \`#app\` element. Now they inject the doc fragment into the existing \`#page-content\` div, preserving the shell. A failed regex throws so the build fails fast if \`website/index.html\` ever loses the skeleton.

## Verified locally

- \`dist/index.html\` — contains the skeleton, so first paint has the final footprint
- \`dist/workflow/index.html\` (and the 8 other pre-rendered routes) — full doc content inside \`#page-content\`, shell preserved for crawlers
- Unit tests: 89/89 green
- Vite build: all 9 routes pre-rendered

## Expected after deploy

| Metric | Before | After |
|---|---|---|
| CLS | 0.975 | ~0.00 |
| Performance | 0.76 | ≥ 0.9 |
| Lighthouse CI | red | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refaktor**
  * Die App-Initialisierungslogik wurde überarbeitet, um eine effizientere Vorkompilierung und schnelleres Seiten-Rendering zu ermöglichen.
  * Die Validierungsprüfungen der erforderlichen App-Struktur wurden verbessert, um Fehler während des Build-Prozesses frühzeitig zu erkennen.
  * Die Handhabung von Kopf- und Fußzeilenkomponenten beim App-Start wurde optimiert und vereinfacht.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->