### PR TITLE
fix: SPA router ignores trailing slash, breaking direct URL visits (#441)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -136,7 +136,15 @@ export function initRouter() {
  * Handle route change
  */
 function handleRoute() {
-  const path = getCurrentRoute()
+  let path = getCurrentRoute()
+
+  // Normalize trailing slash: GitHub Pages 301-redirects /workflow to /workflow/
+  // when workflow/index.html is served as a directory index. Without this,
+  // routes.get('/workflow/') misses the '/workflow' key and falls through to
+  // the home handler.
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.slice(0, -1)
+  }
 
   // Check for anchor route (/anchor/:id)
   if (path.startsWith('/anchor/')) {

--- a/website/tests/e2e/website.spec.js
+++ b/website/tests/e2e/website.spec.js
@@ -277,13 +277,25 @@ test.describe('Routing - Documentation Pages', () => {
     await expect(anchorsLink).toHaveClass(/font-semibold/)
   })
 
-  test.skip('should handle direct URL to About page', async ({ page }) => {
-    // Skip: direct URL routing requires 404.html fallback (only works on GitHub Pages)
-    await page.goto('/about')
+  test('should handle direct URL to About page', async ({ page }) => {
+    await page.goto('/Semantic-Anchors/about')
 
     // Wait for AsciiDoc content to load and check h1 in content area (not header)
     await page.waitForSelector('#doc-content h1', { timeout: 10000 })
     await expect(page.locator('#doc-content h1')).toContainText(/About|What are/)
+  })
+
+  test('should render doc page when visited via trailing-slash URL', async ({ page }) => {
+    // GitHub Pages 301-redirects /workflow → /workflow/ when workflow/index.html
+    // is served as a directory index. The SPA must handle the trailing-slash
+    // form or it falls through to the home handler.
+    await page.goto('/Semantic-Anchors/workflow/')
+
+    await page.waitForSelector('#doc-content h1', { timeout: 10000 })
+    await expect(page.locator('#doc-content h1')).toContainText(/Workflow/i)
+
+    // Card grid (home-only content) must not be rendered on top
+    await expect(page.locator('.anchor-card')).toHaveCount(0)
   })
 
   test('should handle browser back button', async ({ page }) => {


### PR DESCRIPTION
Closes #441

## Problem

Direct visits to clean routes (e.g. `https://llm-coding.github.io/Semantic-Anchors/workflow`) landed on the home page instead of the target page. In-app navigation worked; only direct URL entry broke.

## Root cause

GitHub Pages 301-redirects `/workflow` → `/workflow/` when `workflow/index.html` is served as a directory index. After the redirect, `window.location.pathname` ends in a trailing slash. The router's `routes.get('/workflow/')` lookup missed the `/workflow` key and fell through to the home-page fallback, which wiped out the pre-rendered doc content.

Affected routes: `/workflow`, `/brownfield`, `/about`, `/changelog`, `/contributing`, `/agentskill`, `/rejected-proposals`, `/all-anchors`, `/evaluations`.

## Fix

Normalize the trailing slash in `handleRoute()` before looking up the handler. Root path `/` remains unchanged.

## Tests (Red/Green TDD)

- Added `should render doc page when visited via trailing-slash URL` — goes to `/Semantic-Anchors/workflow/` and asserts workflow content (not cards) renders.
- Un-skipped `should handle direct URL to About page` — the stale skip comment referenced a 404.html fallback that's been superseded by per-route pre-rendering.

Verified Red on base branch (test fails without the router fix), Green after the change.

## Test plan

- [x] New E2E test reproduces the bug on base
- [x] All 35 E2E tests pass after fix
- [x] All 89 unit tests still pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Der Router normalisiert jetzt automatisch URL-Pfade mit abschließendem Schrägstrich. Pfade wie `/workflow/` werden nun konsistent mit ihrer Entsprechung ohne Schrägstrich (`/workflow`) aufgelöst, was die Zuverlässigkeit der Routenauflösung verbessert.

* **Tests**
  * Neue End-to-End-Tests zur Validierung der korrekten Routenauflösung und Inhaltsdarstellung bei URLs mit und ohne Trailing-Slash-Format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->