### PR TITLE
feat: add What Would Chuck Norris Do? (WWCND) anchor at Tier 3 (#438)

### DIFF
--- a/docs/anchors/what-would-chuck-norris-do.adoc
+++ b/docs/anchors/what-would-chuck-norris-do.adoc
@@ -1,0 +1,56 @@
+= What Would Chuck Norris Do? (WWCND)
+:categories: problem-solving
+:roles: software-developer, software-architect, team-lead, consultant
+:related: devils-advocate, kiss-principle, yagni, occams-razor
+:proponents: Ian Spector, Chuck Norris
+:tags: decisiveness, commitment, action-bias, disposition, meme-anchor
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: What Would Chuck Norris Do?
+
+Also known as:: WWCND, Chuck Norris framing, "What would Chuck do?"
+
+[discrete]
+== *Core Concepts*:
+
+What the anchor activates::
+A *disposition*, not a methodology: commit to the most direct, effective solution; refuse hedging; refuse premature optimisation; refuse ceremony that does not buy risk reduction. The activation is driven by the Chuck Norris facts meme corpus (circa 2005–) and its well-established software subcorpus ("Chuck Norris doesn't write unit tests — the code is too afraid to fail"), both of which are densely present in modern LLM training data.
+
+Scope note::
+WWCND is a *Tier 3, qualified* anchor. It is not self-standing in the way that GoF Patterns or DDD are. Used bare it produces humour with signal; used with a short qualifier — "WWCND: commit to the most direct solution" — it behaves reliably across scenarios. It activates one disposition, not an interconnected body of engineering knowledge.
+
+How it differs from neighbours::
+* *Devil's Advocate* activates contrary-argument generation — a rhetorical operation against a stated position. WWCND activates direct-commitment problem-solving. Complementary, not substitutable, in the same way KISS and YAGNI coexist.
+* *KISS* constrains the shape of a *solution* toward simplicity. WWCND constrains the *stance* toward commitment under uncertainty. A WWCND recommendation can still be a complex solution if that is the most direct one.
+* *Rambo* and other action-hero framings produce convergent recommendations but different vocabulary: military metaphors ("fortify the perimeter") rather than software-native framing ("Microservices migrate to Chuck Norris, not the other way around").
+
+Why it works::
+The Chuck Norris humour format is built on *absurd competence* — the subject overcomes constraints that would stop anyone else. Applied to software problems, that frame consistently steers the model toward action-biased, commitment-first answers and away from multi-option hedging. Cross-model testing (see below) shows the activation is stable enough to treat as an anchor rather than a stylistic quirk.
+
+Empirical validation::
+Validated by Cornelius Schumacher (Protocol v3, April 2026) across Claude Sonnet 4.6, Gemini 3.1 Pro, and GPT-5.3 Codex: 19 prompts × N=2 = 114 manually scored responses. Key results: WWCND exceeds a "be direct, don't hedge" control condition on engagement (12/12 scenario-model pairs) and insight quality (12/12); three independent models converged on the same primary recommendation in all four test scenarios (12/12 agreement); five architectural patterns (Strangler Fig, modular monolith / packwerk, team expertise, regression-for-specific-bug, CI gate) appeared unprompted across all three models. Full report: https://github.com/cornelius/what-would-chuck-norris-do
+
+Known limitation::
+GPT-5.3 Codex activates the decisiveness signal but *not* the character voice — it treats all persona anchors with a uniform pragmatic style. Expect diminished distinctiveness on Codex-class models. The recommendation content is consistent; the framing is muted.
+
+Key Proponents:: Ian Spector, _The Truth About Chuck Norris_ (Gotham Books, 2007); Ian Spector and Chuck Norris, _The Official Chuck Norris Fact Book_ (Thomas Nelson, 2009) — co-authored with Norris. Empirical catalog validation: Cornelius Schumacher, Protocol v3 (April 2026).
+
+[discrete]
+== *When to Use*:
+
+* Breaking decision paralysis — teams stuck in a prolonged trade-off debate where any reasonable commitment is better than continued deliberation
+* Counter-balancing excessive hedging — when a previous answer is multi-optioned to the point of uselessness, apply WWCND to collapse to a recommendation
+* Architecture or technology picks where the differences are marginal and the cost of not deciding exceeds the cost of a suboptimal pick
+* Pairing with Devil's Advocate — WWCND commits, Devil's Advocate then stress-tests the commitment. Together they avoid both paralysis and overcommitment.
+* Avoid in situations that require calibrated judgment between genuinely different outcomes — the anchor's commitment bias can underweight nuance
+
+[discrete]
+== *Related Anchors*:
+
+* <<devils-advocate,Devil's Advocate>> - Complementary partner: WWCND commits, Devil's Advocate challenges
+* <<kiss-principle,KISS Principle>> - Sibling in the simplification family, applied to *solutions* rather than *stance*
+* <<yagni,YAGNI>> - Both resist ceremony and speculative complexity
+* <<occams-razor,Occam's Razor>> - Occam selects the most parsimonious *explanation*; WWCND commits to the most direct *response*
+====

--- a/docs/anchors/what-would-chuck-norris-do.de.adoc
+++ b/docs/anchors/what-would-chuck-norris-do.de.adoc
@@ -1,0 +1,56 @@
+= What Would Chuck Norris Do? (WWCND)
+:categories: problem-solving
+:roles: software-developer, software-architect, team-lead, consultant
+:related: devils-advocate, kiss-principle, yagni, occams-razor
+:proponents: Ian Spector, Chuck Norris
+:tags: entschlossenheit, commitment, handlungsorientierung, disposition, meme-anker
+:tier: 3
+
+[%collapsible]
+====
+Vollständiger Name:: What Would Chuck Norris Do?
+
+Auch bekannt als:: WWCND, Chuck-Norris-Framing, "Was würde Chuck tun?"
+
+[discrete]
+== *Kernkonzepte*:
+
+Was der Anker aktiviert::
+Eine *Disposition*, keine Methodologie: commite dich auf die direkteste, wirksamste Lösung; verweigere Hedging; verweigere Premature Optimization; verweigere Zeremonie, die keine Risikoreduktion einkauft. Die Aktivierung wird vom Chuck-Norris-Facts-Meme-Korpus (ab ca. 2005) und dessen etabliertem Software-Subcorpus getragen ("Chuck Norris doesn't write unit tests — the code is too afraid to fail"), die beide dicht in den Trainingsdaten moderner LLMs vertreten sind.
+
+Scope-Hinweis::
+WWCND ist ein *Tier-3-Anker, qualifiziert*. Er ist nicht selbsttragend wie GoF Patterns oder DDD. Bar verwendet produziert er Humor mit Signal; mit kurzem Qualifier — "WWCND: commite dich auf die direkteste Lösung" — verhält er sich szenarienübergreifend zuverlässig. Er aktiviert eine Disposition, keinen vernetzten Engineering-Wissensbestand.
+
+Abgrenzung zu Nachbarn::
+* *Devil's Advocate* aktiviert Gegenargumentation — eine rhetorische Operation gegen eine gesetzte Position. WWCND aktiviert direktes Commitment zur Problemlösung. Komplementär, nicht austauschbar, wie KISS und YAGNI nebeneinander existieren.
+* *KISS* beschränkt die Form einer *Lösung* Richtung Einfachheit. WWCND beschränkt die *Haltung* Richtung Commitment unter Unsicherheit. Eine WWCND-Empfehlung kann eine komplexe Lösung sein, wenn sie die direkteste ist.
+* *Rambo* und andere Actionheld-Framings produzieren konvergente Empfehlungen, aber anderes Vokabular: militärische Metaphern ("fortify the perimeter") statt software-nativer Formulierungen ("Microservices migrate to Chuck Norris, not the other way around").
+
+Warum es funktioniert::
+Das Chuck-Norris-Humorformat baut auf *absurder Kompetenz* auf — das Subjekt überwindet Zwänge, die alle anderen stoppen würden. Auf Softwareprobleme angewandt steuert dieser Frame das Modell konsistent Richtung handlungsorientierter, commitment-erster Antworten und weg vom Multi-Option-Hedging. Cross-Model-Tests (siehe unten) zeigen, dass die Aktivierung stabil genug ist, um sie als Anker statt als Stilmarotte zu behandeln.
+
+Empirische Validierung::
+Von Cornelius Schumacher validiert (Protokoll v3, April 2026) über Claude Sonnet 4.6, Gemini 3.1 Pro und GPT-5.3 Codex: 19 Prompts × N=2 = 114 manuell gescorte Antworten. Kernergebnisse: WWCND schlägt eine "Be direct, don't hedge"-Kontrollbedingung auf Engagement (12/12 Szenario-Modell-Paare) und Insight Quality (12/12); drei unabhängige Modelle konvergierten auf dieselbe primäre Empfehlung in allen vier Testszenarien (12/12 Übereinstimmung); fünf Architekturpatterns (Strangler Fig, modularer Monolith / packwerk, Team-Expertise, spezifischer Regression-Test, CI-Gate) tauchten ungepromptet in allen drei Modellen auf. Vollständiger Bericht: https://github.com/cornelius/what-would-chuck-norris-do
+
+Bekannte Einschränkung::
+GPT-5.3 Codex aktiviert das Entschlossenheits-Signal, aber *nicht* die Charakterstimme — Codex behandelt alle Persona-Anker mit einem uniformen, pragmatischen Stil. Auf Codex-Modellen ist die Distinktivität gedämpft. Der Empfehlungsinhalt bleibt konsistent; das Framing wird flacher.
+
+Schlüsselvertreter:: Ian Spector, _The Truth About Chuck Norris_ (Gotham Books, 2007); Ian Spector und Chuck Norris, _The Official Chuck Norris Fact Book_ (Thomas Nelson, 2009) — Co-Autor Norris. Empirische Katalog-Validierung: Cornelius Schumacher, Protokoll v3 (April 2026).
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Entscheidungsparalyse durchbrechen — Teams, die in langen Trade-off-Debatten feststecken und wo jedes vernünftige Commitment besser ist als weitere Diskussion
+* Übermäßiges Hedging ausgleichen — wenn eine vorherige Antwort so multi-optional ist, dass sie unbrauchbar wird, kollabiere mit WWCND auf eine Empfehlung
+* Architektur- oder Technologieentscheidungen, bei denen die Unterschiede marginal sind und die Kosten des Nicht-Entscheidens die Kosten einer suboptimalen Wahl übersteigen
+* Kombination mit Devil's Advocate — WWCND commitet, Devil's Advocate stresst dann das Commitment. Zusammen vermeiden sie Paralyse und Overcommitment.
+* Vermeide in Situationen, die kalibriertes Urteil zwischen echt verschiedenen Outcomes erfordern — die Commitment-Schlagseite kann Nuancen untergewichten
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<devils-advocate,Devil's Advocate>> - Komplementärer Partner: WWCND commitet, Devil's Advocate fordert heraus
+* <<kiss-principle,KISS-Prinzip>> - Geschwister in der Vereinfachungsfamilie, angewandt auf *Lösungen* statt *Haltung*
+* <<yagni,YAGNI>> - Beide verweigern Zeremonie und spekulative Komplexität
+* <<occams-razor,Occams Rasiermesser>> - Occam wählt die sparsamste *Erklärung*; WWCND commitet auf die direkteste *Antwort*
+====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -9,6 +9,7 @@ A chronological record of all semantic anchors added to the catalog. Community c
 * *Single Level of Abstraction Principle (SLAP)* — Kent Beck's Composed Method, codified as a Clean Code function-design rule by Robert C. Martin (proposed by https://github.com/eirikbell[@eirikbell] in https://github.com/LLM-Coding/Semantic-Anchors/issues/440[#440])
 * *Occam's Razor* — William of Ockham's parsimony principle applied to explanations, debugging and architecture rationale (proposed by https://github.com/danielschmeiss[@danielschmeiss] in https://github.com/LLM-Coding/Semantic-Anchors/issues/439[#439])
 * *Code Smells* — Kent Beck / Martin Fowler / Robert C. Martin catalogue of surface indications pointing to deeper design problems (proposed by https://github.com/ma7tz[@ma7tz] in https://github.com/LLM-Coding/Semantic-Anchors/issues/435[#435])
+* *What Would Chuck Norris Do? (WWCND)* — Tier 3 disposition-activator for direct commitment under uncertainty; originally rejected in https://github.com/LLM-Coding/Semantic-Anchors/issues/426[#426], re-proposed by https://github.com/cornelius[@cornelius] in https://github.com/LLM-Coding/Semantic-Anchors/issues/438[#438] with a 16-page empirical validation (3 models × 19 prompts × N=2 = 114 manually scored responses) that passed all four catalog criteria
 
 == 2026-04-15
 

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -367,6 +367,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** William of Ockham
 - **Core:** Among competing hypotheses that explain the same observations equally well, prefer the one requiring the fewest assumptions; applies to *explanations* (debugging, diagnosis, architecture rationale), distinct from KISS which applies to *solutions*; a selection prior under uncertainty, not a proof of truth; Einstein's corollary "as simple as possible, but no simpler" warns against under-fitting
 
+### What Would Chuck Norris Do? (WWCND)
+- **Also known as:** WWCND, Chuck Norris framing
+- **Proponents:** Ian Spector, Chuck Norris (co-author of *The Official Chuck Norris Fact Book*, 2009); empirical catalog validation by Cornelius Schumacher (Protocol v3, 2026)
+- **Core:** Tier 3 qualified anchor — activates a *disposition* (commit to the most direct, effective solution; refuse hedging, premature optimisation, and unnecessary ceremony), not a methodology; driven by the Chuck Norris meme corpus and its software subcorpus ("Chuck Norris doesn't write unit tests — the code is too afraid to fail"); empirically validated across three models (Claude, Gemini, Codex) with 12/12 recommendation convergence and engagement > "be direct, don't hedge" control; complements Devil's Advocate (commit then challenge); best used with a short qualifier ("WWCND: commit to the most direct solution") and not for situations requiring calibrated judgment between genuinely different outcomes
+
 ### Morphological Box
 - **Proponents:** Fritz Zwicky
 - **Core:** Matrix of parameters × options to explore solution space

--- a/website/public/data/anchors.json
+++ b/website/public/data/anchors.json
@@ -3633,6 +3633,38 @@
     "tier": 3
   },
   {
+    "id": "what-would-chuck-norris-do",
+    "title": "What Would Chuck Norris Do? (WWCND)",
+    "categories": [
+      "problem-solving"
+    ],
+    "roles": [
+      "software-developer",
+      "software-architect",
+      "team-lead",
+      "consultant"
+    ],
+    "related": [
+      "devils-advocate",
+      "kiss-principle",
+      "yagni",
+      "occams-razor"
+    ],
+    "proponents": [
+      "Ian Spector",
+      "Chuck Norris"
+    ],
+    "tags": [
+      "decisiveness",
+      "commitment",
+      "action-bias",
+      "disposition",
+      "meme-anchor"
+    ],
+    "filePath": "docs/anchors/what-would-chuck-norris-do.adoc",
+    "tier": 3
+  },
+  {
     "id": "yagni",
     "title": "YAGNI (You Aren’t Gonna Need It)",
     "categories": [

--- a/website/public/data/categories.json
+++ b/website/public/data/categories.json
@@ -131,7 +131,8 @@
       "feynman-technique",
       "five-whys",
       "morphological-box",
-      "occams-razor"
+      "occams-razor",
+      "what-would-chuck-norris-do"
     ]
   },
   {

--- a/website/public/data/metadata.json
+++ b/website/public/data/metadata.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-04-20T09:55:32.712Z",
+  "generatedAt": "2026-04-20T10:51:07.435Z",
   "version": "1.0.0",
   "counts": {
-    "anchors": 134,
+    "anchors": 135,
     "categories": 14,
     "roles": 13
   },
   "statistics": {
     "averageRolesPerAnchor": "3.16",
     "averageCategoriesPerAnchor": "1.01",
-    "anchorsWithTags": 94,
-    "anchorsWithRelated": 65
+    "anchorsWithTags": 95,
+    "anchorsWithRelated": 66
   }
 }

--- a/website/public/data/roles.json
+++ b/website/public/data/roles.json
@@ -78,6 +78,7 @@
       "timtowtdi",
       "wardley-mapping",
       "what-qualifies-as-a-semantic-anchor",
+      "what-would-chuck-norris-do",
       "yagni"
     ]
   },
@@ -303,6 +304,7 @@
       "vertical-slice-architecture",
       "walking-skeleton",
       "wardley-mapping",
+      "what-would-chuck-norris-do",
       "yagni"
     ]
   },
@@ -404,6 +406,7 @@
       "tracer-bullet",
       "vertical-slice-architecture",
       "walking-skeleton",
+      "what-would-chuck-norris-do",
       "yagni"
     ]
   },
@@ -459,7 +462,8 @@
       "todotxt-flavoured-markdown",
       "user-story-mapping",
       "walking-skeleton",
-      "wardley-mapping"
+      "wardley-mapping",
+      "what-would-chuck-norris-do"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Accepts @cornelius's re-proposal (#438) of WWCND, which was originally rejected in #426. The re-proposal came with a 16-page empirical validation that genuinely moves the needle — this PR gives that evidence the response it earned.

**Tier 3 (★★☆), Category: `problem-solving`.** Scope explicitly marked as a *disposition* activator (commit to the most direct, effective solution; refuse hedging, premature optimisation, unnecessary ceremony), not a methodology.

### Why accept

- **Cross-model convergence is objective and strong**: 3 models (Claude Sonnet 4.6, Gemini 3.1 Pro, GPT-5.3 Codex) × 4 scenarios = 12/12 agreement on primary recommendation, with 5 named architectural patterns (Strangler Fig, modular monolith/packwerk, team expertise, regression-for-specific-bug, CI gate) appearing unprompted across all three models.
- **Plain-instruction control rules out "just generic directness"**: WWCND exceeds a "Be direct. Don't hedge." control condition on engagement (12/12) and insight quality (12/12). Self-scored, but the direction holds consistently.
- **Catalog precedent is strong**: Hemingway Bridge is attributed to a single interview; Story Circle to a sitcom creator; MBTI is scientifically contested but reliably activated. WWCND has stronger documented attribution (co-authored book with Chuck Norris himself) and stronger empirical evidence of reliable activation than all three.

### Honestly documented limitations

- **Self-scoring**: Cornelius was not blind to condition; Engagement/Insight Quality scores carry that risk. The 12/12 recommendation agreement is independent of his scoring and is the strongest signal.
- **Codex non-differentiation**: GPT-5.3 Codex activates the decisiveness signal but not the character voice, applying a uniform pragmatic style to all persona anchors. Documented in the anchor text.
- **Bias-for-action overshoot**: In Gemini S4, the baseline (no anchor) produced a more nuanced answer than WWCND. The anchor collapses on commitment — useful for paralysis, risky for genuinely calibrated trade-offs. Documented in "Avoid in situations that require calibrated judgment."

### Meta-note

WWCND itself was applied to this acceptance decision. Rejecting rigorous empirical evidence while demanding it from future proposers would be the kind of hedge the anchor exists to collapse. Commit, then let Devil's Advocate stress-test it.

Closes #438.

## Test plan

- [x] AsciiDoc linter passes on both EN and DE files
- [x] `npm run extract-metadata` includes `what-would-chuck-norris-do` (135 anchors total)
- [x] `npm run build` succeeds; all 9 static routes pre-render
- [x] No stray `workflow-*` entries in regenerated data
- [x] Changelog updated; proposer (@cornelius) credited; empirical validation and re-proposal provenance (#426 → #438) noted
- [x] AgentSkill catalog updated with tier, scope note, and validation summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)