### PR TITLE
feat: rename /workflow to /spec-driven-development for SEO

### DIFF
--- a/docs/brownfield-workflow.adoc
+++ b/docs/brownfield-workflow.adoc
@@ -6,7 +6,7 @@ Ralf D. Müller
 
 == Introduction
 
-You have mastered the link:#/workflow[greenfield workflow].
+You have mastered the link:#/spec-driven-development[greenfield workflow].
 Now you want to apply it to an existing codebase.
 
 The core principles remain the same: small steps, high autonomy, error correction loops.
@@ -152,7 +152,7 @@ Stable code that nobody touches does not need specs.
 |link:#/anchor/tdd-london-school[TDD London] / link:#/anchor/tdd-chicago-school[Chicago]
 
 |Continue
-|Follow link:#/workflow[the standard workflow] from Step 3 (PRD) or Step 8 (Implementation), depending on whether you are adding new features or fixing bugs.
+|Follow link:#/spec-driven-development[the standard workflow] from Step 3 (PRD) or Step 8 (Implementation), depending on whether you are adding new features or fixing bugs.
 |{empty}--
 |===
 

--- a/docs/brownfield-workflow.de.adoc
+++ b/docs/brownfield-workflow.de.adoc
@@ -6,7 +6,7 @@ Ralf D. Müller
 
 == Einleitung
 
-Du hast den link:#/workflow[Greenfield-Workflow] gemeistert.
+Du hast den link:#/spec-driven-development[Greenfield-Workflow] gemeistert.
 Jetzt willst du ihn auf eine bestehende Codebasis anwenden.
 
 Die Grundprinzipien bleiben gleich: kleine Schritte, hohe Autonomie, Fehlerkorrektur-Schleifen.
@@ -151,7 +151,7 @@ Stabiler Code, den niemand anfasst, braucht keine Specs.
 |link:#/anchor/tdd-london-school[TDD London] / link:#/anchor/tdd-chicago-school[Chicago]
 
 |Weiter
-|Ab hier dem link:#/workflow[Standard-Workflow] ab Schritt 3 (PRD) oder Schritt 8 (Implementierung) folgen, je nachdem ob neue Features oder Bugs bearbeitet werden.
+|Ab hier dem link:#/spec-driven-development[Standard-Workflow] ab Schritt 3 (PRD) oder Schritt 8 (Implementierung) folgen, je nachdem ob neue Features oder Bugs bearbeitet werden.
 |{empty}--
 |===
 

--- a/docs/spec-driven-workflow.adoc
+++ b/docs/spec-driven-workflow.adoc
@@ -1,4 +1,4 @@
-= The Semantic Anchors Development Workflow
+= Spec-Driven Development with Semantic Anchors
 Ralf D. Müller
 2026-03-14
 :toc:

--- a/docs/spec-driven-workflow.de.adoc
+++ b/docs/spec-driven-workflow.de.adoc
@@ -1,4 +1,4 @@
-= Der Semantic Anchors Entwicklungs-Workflow
+= Spec-Driven Development mit Semantic Anchors
 :author: Ralf D. Müller
 :revdate: 2026-03-14
 :toc:

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -38,7 +38,7 @@ const BASE_URL = 'https://llm-coding.github.io/Semantic-Anchors'
 const PAGES = [
   { path: '/', priority: '1.0', changefreq: 'weekly' },
   { path: '/about', priority: '0.8', changefreq: 'monthly' },
-  { path: '/workflow', priority: '0.8', changefreq: 'monthly' },
+  { path: '/spec-driven-development', priority: '0.8', changefreq: 'monthly' },
   { path: '/brownfield', priority: '0.8', changefreq: 'monthly' },
   { path: '/evaluations', priority: '0.8', changefreq: 'monthly' },
   { path: '/all-anchors', priority: '0.8', changefreq: 'weekly' },

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -41,11 +41,11 @@ const ROUTES = [
       'Learn what semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
   },
   {
-    path: '/workflow',
+    path: '/spec-driven-development',
     fragment: 'docs/spec-driven-workflow.html',
-    title: 'Development Workflow — Semantic Anchors',
+    title: 'Spec-Driven Development with Semantic Anchors',
     description:
-      'The Semantic Anchors spec-driven development workflow — from requirements to specification to implementation, powered by semantic anchors.',
+      'Spec-driven development workflow — from requirements to specification to implementation, powered by semantic anchors.',
   },
   {
     path: '/brownfield',

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -41,6 +41,10 @@ const ROUTES = [
       'Learn what semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
   },
   {
+    path: '/workflow',
+    redirectTo: '/spec-driven-development',
+  },
+  {
     path: '/spec-driven-development',
     fragment: 'docs/spec-driven-workflow.html',
     title: 'Spec-Driven Development with Semantic Anchors',
@@ -158,6 +162,18 @@ function buildDocContentMarkup(fragmentHtml) {
  * @throws {Error} When the configured fragment file does not exist.
  */
 function prerenderRoute(shell, route) {
+  if (route.redirectTo) {
+    const outDir = path.join(DIST, route.path)
+    const outFile = path.join(outDir, 'index.html')
+    fs.mkdirSync(outDir, { recursive: true })
+    fs.writeFileSync(
+      outFile,
+      `<!doctype html><meta charset="utf-8"><link rel="canonical" href="https://llm-coding.github.io/Semantic-Anchors${route.redirectTo}"><meta http-equiv="refresh" content="0;url=${route.redirectTo}"><script>location.replace('${route.redirectTo}')</script>`,
+      'utf-8'
+    )
+    return
+  }
+
   const fragmentPath = path.join(DIST, route.fragment)
   if (!fs.existsSync(fragmentPath)) {
     throw new Error(

--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -36,7 +36,7 @@ export function renderHeader() {
               <div class="flex items-center gap-6 text-2xl">
                 <a href="#/" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
                 <a href="#/contracts" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
-                <a href="#/workflow" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/workflow" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
+                <a href="#/spec-driven-development" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
                 <div class="relative" id="more-menu-container">
                   <button id="more-menu-toggle" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors flex items-center gap-1" data-i18n="nav.more">
                     ${i18n.t('nav.more')}
@@ -155,7 +155,7 @@ export function renderHeader() {
           <div class="flex flex-col gap-2">
             <a href="#/" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
             <a href="#/contracts" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
-            <a href="#/workflow" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/workflow" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
+            <a href="#/spec-driven-development" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
             <a href="#/about" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/about" data-i18n="nav.about">${i18n.t('nav.about')}</a>
             <a href="#/agentskill" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/agentskill" data-i18n="nav.agentskill">${i18n.t('nav.agentskill')}</a>
             <a href="#/contributing" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contributing" data-i18n="nav.contributing">${i18n.t('nav.contributing')}</a>

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -13,7 +13,12 @@ import {
 } from './components/card-grid.js'
 import { fetchData, fetchContractsData } from './utils/data-loader.js'
 import { buildSearchIndex, isIndexReady, isIndexBuilding } from './utils/search-index.js'
-import { initRouter, addRoute, getCurrentRoute as getCurrentRouteSync } from './utils/router.js'
+import {
+  initRouter,
+  addRoute,
+  navigate,
+  getCurrentRoute as getCurrentRouteSync,
+} from './utils/router.js'
 import { renderDocPage, loadDocContent } from './components/doc-page.js'
 import {
   createOnboardingModal,
@@ -141,7 +146,8 @@ function initApp() {
   addRoute('/agentskill', renderAgentSkillPage)
   addRoute('/rejected-proposals', renderRejectedProposalsPage)
   addRoute('/all-anchors', renderAllAnchorsPage)
-  addRoute('/workflow', renderWorkflowPage)
+  addRoute('/spec-driven-development', renderWorkflowPage)
+  addRoute('/workflow', () => navigate('/spec-driven-development'))
   addRoute('/brownfield', renderBrownfieldPage)
   addRoute('/contracts', renderContractsPageHandler)
   addRoute('/evaluations', renderEvaluationsPage)
@@ -494,7 +500,7 @@ function handleLanguageChange() {
     loadDocContent('docs/rejected-proposals.adoc')
   } else if (currentRoute === '/all-anchors') {
     loadDocContent('docs/all-anchors.adoc')
-  } else if (currentRoute === '/workflow') {
+  } else if (currentRoute === '/spec-driven-development') {
     loadDocContent('docs/spec-driven-workflow.adoc')
   } else if (currentRoute === '/brownfield') {
     loadDocContent('docs/brownfield-workflow.adoc')

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -147,7 +147,7 @@ function initApp() {
   addRoute('/rejected-proposals', renderRejectedProposalsPage)
   addRoute('/all-anchors', renderAllAnchorsPage)
   addRoute('/spec-driven-development', renderWorkflowPage)
-  addRoute('/workflow', () => navigate('/spec-driven-development'))
+  addRoute('/workflow', () => navigate('/spec-driven-development', { replace: true }))
   addRoute('/brownfield', renderBrownfieldPage)
   addRoute('/contracts', renderContractsPageHandler)
   addRoute('/evaluations', renderEvaluationsPage)

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -11,7 +11,7 @@
   "nav.contributing": "Mitwirken",
   "nav.changelog": "Änderungsprotokoll",
   "nav.agentskill": "AgentSkill",
-  "nav.workflow": "Workflow",
+  "nav.workflow": "Spec-Driven Dev",
   "nav.more": "Mehr",
   "nav.contracts": "Contracts",
   "contracts.title": "Semantic Contracts",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -11,7 +11,7 @@
   "nav.contributing": "Contributing",
   "nav.changelog": "Changelog",
   "nav.agentskill": "AgentSkill",
-  "nav.workflow": "Workflow",
+  "nav.workflow": "Spec-Driven Dev",
   "nav.more": "More",
   "nav.contracts": "Contracts",
   "contracts.title": "Semantic Contracts",

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -16,7 +16,7 @@ const ROUTE_TITLES = {
   '/': 'Semantic Anchors — Shared Vocabulary for LLM Communication',
   '/about': 'About — Semantic Anchors',
   '/contracts': 'Semantic Contracts — Semantic Anchors',
-  '/workflow': 'Development Workflow — Semantic Anchors',
+  '/spec-driven-development': 'Spec-Driven Development with Semantic Anchors',
   '/brownfield': 'Brownfield Workflow — Semantic Anchors',
   '/evaluations': 'Evaluations — Semantic Anchors',
   '/contributing': 'Contributing — Semantic Anchors',
@@ -138,10 +138,9 @@ export function initRouter() {
 function handleRoute() {
   let path = getCurrentRoute()
 
-  // Normalize trailing slash: GitHub Pages 301-redirects /workflow to /workflow/
-  // when workflow/index.html is served as a directory index. Without this,
-  // routes.get('/workflow/') misses the '/workflow' key and falls through to
-  // the home handler.
+  // Normalize trailing slash: GitHub Pages 301-redirects routes like
+  // /spec-driven-development to /spec-driven-development/ when served as a
+  // directory index. Without this, the trailing slash misses the route key.
   if (path.length > 1 && path.endsWith('/')) {
     path = path.slice(0, -1)
   }

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -55,9 +55,12 @@ export function addRoute(path, handler) {
 /**
  * Navigate to a specific route
  * @param {string} path - Route path
+ * @param {object} [options]
+ * @param {boolean} [options.replace=false] - Replace current history entry instead of pushing
  */
-export function navigate(path) {
-  history.pushState(null, '', buildPath(path))
+export function navigate(path, { replace = false } = {}) {
+  const method = replace ? 'replaceState' : 'pushState'
+  history[method](null, '', buildPath(path))
   handleRoute()
 }
 

--- a/website/tests/e2e/website.spec.js
+++ b/website/tests/e2e/website.spec.js
@@ -286,13 +286,13 @@ test.describe('Routing - Documentation Pages', () => {
   })
 
   test('should render doc page when visited via trailing-slash URL', async ({ page }) => {
-    // GitHub Pages 301-redirects /workflow → /workflow/ when workflow/index.html
-    // is served as a directory index. The SPA must handle the trailing-slash
+    // GitHub Pages 301-redirects /spec-driven-development → /spec-driven-development/
+    // when served as a directory index. The SPA must handle the trailing-slash
     // form or it falls through to the home handler.
-    await page.goto('/Semantic-Anchors/workflow/')
+    await page.goto('/Semantic-Anchors/spec-driven-development/')
 
     await page.waitForSelector('#doc-content h1', { timeout: 10000 })
-    await expect(page.locator('#doc-content h1')).toContainText(/Workflow/i)
+    await expect(page.locator('#doc-content h1')).toContainText(/Spec-Driven Development/i)
 
     // Card grid (home-only content) must not be rendered on top
     await expect(page.locator('.anchor-card')).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Rename route from `/workflow` to `/spec-driven-development` for better SEO discoverability
- Page title: "Spec-Driven Development with Semantic Anchors"
- Nav label: "Spec-Driven Dev" (EN + DE)
- Old `/workflow` URL redirects automatically
- All cross-links updated (brownfield pages, sitemap, prerender-routes)

## Test plan
- [ ] Navigate to `/spec-driven-development` — page loads with new title
- [ ] Navigate to `/workflow` — redirects to `/spec-driven-development`
- [ ] Check nav link text shows "Spec-Driven Dev"
- [ ] Switch to DE — verify nav label and page content
- [ ] Brownfield page links back to `/spec-driven-development`
- [ ] View page source — verify `<title>` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Dokumentationsbereich "Workflow" wurde in "Spec-Driven Development with Semantic Anchors" umbenannt.
  * Dokumentation ist jetzt unter aktualisiertem Titel zugänglich.

* **Chores**
  * Navigation aktualisiert: Menüeinträge verweisen auf neue URL-Struktur.
  * Interne Links in Dokumentation angepasst.
  * Sitemaps und Routing neu konfiguriert.
  * Navigationsbezeichnungen in allen Sprachen aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->