### PR TITLE
fix: prevent duplicate event listeners on contracts buttons

### DIFF
--- a/website/src/components/contracts-page.js
+++ b/website/src/components/contracts-page.js
@@ -181,35 +181,25 @@ export function initContractsPage(contracts) {
     }
   })
 
-  // Download button
-  const downloadBtn = document.getElementById('contracts-download')
-  if (downloadBtn) {
-    downloadBtn.addEventListener('click', () => downloadContracts(contracts))
+  // Replace buttons via clone to remove stale listeners from previous init
+  function rebindButton(id, handler) {
+    const old = document.getElementById(id)
+    if (!old) return
+    const fresh = old.cloneNode(true)
+    old.replaceWith(fresh)
+    fresh.addEventListener('click', handler)
   }
 
-  // Copy to clipboard button
-  const copyBtn = document.getElementById('contracts-copy')
-  if (copyBtn) {
-    copyBtn.addEventListener('click', () => copyContracts(contracts))
-  }
-
-  // Select all
-  const selectAllBtn = document.getElementById('contracts-select-all')
-  if (selectAllBtn) {
-    selectAllBtn.addEventListener('click', () => {
-      setSelectedContracts(contracts.map((c) => c.id))
-      initContractsPage(contracts)
-    })
-  }
-
-  // Deselect all
-  const deselectAllBtn = document.getElementById('contracts-deselect-all')
-  if (deselectAllBtn) {
-    deselectAllBtn.addEventListener('click', () => {
-      setSelectedContracts([])
-      initContractsPage(contracts)
-    })
-  }
+  rebindButton('contracts-download', () => downloadContracts(contracts))
+  rebindButton('contracts-copy', () => copyContracts(contracts))
+  rebindButton('contracts-select-all', () => {
+    setSelectedContracts(contracts.map((c) => c.id))
+    initContractsPage(contracts)
+  })
+  rebindButton('contracts-deselect-all', () => {
+    setSelectedContracts([])
+    initContractsPage(contracts)
+  })
 
   updateUI(contracts)
 }


### PR DESCRIPTION
## Summary
Fix multiple downloads/copies triggered per click on the contracts page.

`initContractsPage()` is called repeatedly (via Select All / Deselect All),
but buttons were never cleaned up — each call added another click handler.
Now uses `cloneNode` to replace buttons before re-attaching, same pattern
as the grid.

## Test plan
- [ ] Click Select All, then Download — exactly one file downloaded
- [ ] Click Select All 5x, then Copy — clipboard contains content once
- [ ] Select All / Deselect All still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Änderungen

* **Fehlerbehebungen**
  * Verbesserte Zuverlässigkeit der Schaltflächenfunktionen auf der Vertragsseite. Die Schaltflächen für Download, Kopieren, Auswählen und Abwählen funktionieren jetzt zuverlässiger und konsistenter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->