### PR TITLE
fix: share-link first visit doesn't open anchor modal (#470)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 !website/public/hmze-logo.png
 !docs/workflow-diagram.svg
 .playwright-mcp/
+.venv/
+.linkedin/
 *:Zone.Identifier
 website/public/CONTRIBUTING.html
 website/public/CONTRIBUTING.de.html

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -356,10 +356,10 @@ export async function loadAnchorContent(anchorId) {
 }
 
 export function showAnchorDetails(anchorId) {
-  const modal = document.getElementById('anchor-modal')
-  if (modal) {
-    modal.dataset.currentAnchor = anchorId
-  }
+  // Share-link race: handleRoute may invoke us before initApp's createModal()
+  // microtask runs. createModal is idempotent.
+  const modal = document.getElementById('anchor-modal') || createModal()
+  modal.dataset.currentAnchor = anchorId
   openModal()
   return loadAnchorContent(anchorId)
 }

--- a/website/src/components/anchor-modal.test.js
+++ b/website/src/components/anchor-modal.test.js
@@ -155,6 +155,22 @@ describe('anchor-modal', () => {
       const content = document.getElementById('modal-content')
       expect(content.innerHTML).toContain('Failed to load')
     })
+
+    it('should not crash when modal element is missing (share-link race, #470)', async () => {
+      const existing = document.getElementById('anchor-modal')
+      if (existing) existing.remove()
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => '= Test Anchor\n\nTest content',
+      })
+
+      await expect(showAnchorDetails('test-anchor')).resolves.not.toThrow()
+
+      const modal = document.getElementById('anchor-modal')
+      expect(modal).not.toBeNull()
+      expect(modal.classList.contains('hidden')).toBe(false)
+    })
   })
 
   describe('umbrella anchors', () => {


### PR DESCRIPTION
Closes #470

## Summary

When opening a share-link like \`/#/anchor/<slug>\` in a fresh tab, the homepage was rendered instead of the anchor modal. On a second visit the modal already existed and the link worked — making the bug look intermittent.

## Root cause

\`router.handleRoute()\` invoked \`showAnchorDetails()\` before \`initApp\`'s \`createModal()\` microtask ran. \`loadAnchorContent()\` then crashed inside the dynamic-import callback with:

\`\`\`
TypeError: Cannot read properties of null (reading 'querySelector')
  at loadAnchorContent (anchor-modal.js:164)
\`\`\`

The modal element didn't exist yet, the URL got rewritten to \`/anchor/...\` by the SPA's hash→path migration, the title was set correctly, but no modal opened.

## Fix

Guard \`showAnchorDetails()\` by calling the idempotent \`createModal()\` when the element is missing. Cheap, defensive, no behavioral change on the happy path.

## Test plan

- [x] Regression test added: \`anchor-modal.test.js\` — removes the modal element, calls \`showAnchorDetails\`, asserts it doesn't throw, the modal is created, and the \`hidden\` class is removed
- [x] Full unit test suite passes (90/90)
- [x] Production build verified with Playwright against \`http://localhost:4173/Semantic-Anchors/#/anchor/plain-english-strunk-white\`:
  - Modal opens (\`display: flex\`)
  - Title rendered: \"Plain English according to Strunk & White\"
  - Content loaded (2185 chars)
  - Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Behoben: Das Anker-Detailfenster wird nun zuverlässig angezeigt, auch wenn es unter bestimmten Bedingungen aufgerufen wird.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/474)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->