### PR TITLE
feat: add Hoshin Kanri, Double Diamond, Decisional Balance Sheet (#468, #467, #448)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 !website/public/hmze-logo.png
 !docs/workflow-diagram.svg
 .playwright-mcp/
+.venv/
+.linkedin/
 *:Zone.Identifier
 website/public/CONTRIBUTING.html
 website/public/CONTRIBUTING.de.html

--- a/docs/anchors/decisional-balance-sheet.adoc
+++ b/docs/anchors/decisional-balance-sheet.adoc
@@ -1,0 +1,50 @@
+= Decisional Balance Sheet
+:categories: problem-solving, strategic-planning
+:roles: consultant, team-lead, product-owner, business-analyst
+:related: pugh-matrix, adr-according-to-nygard, moscow
+:proponents: Irving Janis, Leon Mann
+:tags: decision-making, pros-cons, ambivalence, motivational-interviewing
+:tier: 3
+
+[%collapsible]
+====
+Also known as:: Benjamin Franklin Analysis, Moral Algebra, Pros-and-Cons Sheet
+
+[discrete]
+== *Core Concepts*:
+
+Four-Cell Matrix:: The full Janis & Mann form has four categories of consequence for each alternative — *utilitarian gains/losses for self*, *utilitarian gains/losses for significant others*, *self-approval/disapproval*, and *approval/disapproval from others*. Stretches "pros and cons" beyond instrumental outcomes into identity and social cost.
+
+Simplified Two-Column Form:: The everyday "pros vs cons" list popularised by Benjamin Franklin (1772 letter to Joseph Priestley). Strictly a degenerate case of the four-cell matrix — useful for quick decisions, lossy for complex ones.
+
+Weighting:: Each entry gets a numeric weight reflecting its importance. The decision is *not* a vote count — the discipline is to make trade-offs explicit, not to mechanise the choice.
+
+Resolving Ambivalence:: The artifact's primary purpose is *not* arithmetic but surfacing concerns the decider has not yet articulated. Listing the cons of a tempting option, or the pros of the rejected one, breaks the "all pros, no cons" framing that drives impulsive decisions.
+
+Decisional Conflict:: Janis & Mann's parent theory; high-stakes decisions produce stress that distorts judgment. The balance sheet is one of several debiasing techniques alongside vigilant information search and contingency planning.
+
+Motivational Interviewing Variant:: In the Prochaska–DiClemente *Stages of Change* model and Miller & Rollnick's *Motivational Interviewing*, the balance sheet is used to elicit change-talk: the client *says* the cons of staying the same and the pros of changing — moving them through ambivalence rather than persuading them.
+
+Limits:: The model is *deliberative*, not intuitive. It works poorly under time pressure and for decisions dominated by uncertainty (where Pugh Matrix or scenario-based methods fit better). It also doesn't surface options that aren't on the list — separate from the option-generation step.
+
+
+Key Proponents:: Irving Janis & Leon Mann ("Decision Making: A Psychological Analysis of Conflict, Choice, and Commitment", 1977 — the formal four-cell model). Benjamin Franklin (1772 letter, "moral algebra" — the informal pros/cons ancestor). William R. Miller & Stephen Rollnick ("Motivational Interviewing", 1991) for the clinical adaptation.
+
+Historical Context:: Franklin's pros/cons letter is one of the earliest documented decision-aid techniques in the Western tradition. Janis & Mann turned it into a research instrument in the 1970s; the simplified two-column form has spread through self-help, coaching, and Motivational Interviewing into mainstream use. Now a staple of decision coaching, financial advisory, and health-behaviour-change interventions.
+
+[discrete]
+== *When to Use*:
+
+* Personal or career decisions where the alternatives are roughly comparable and the deciding factor is the decider's own clarity
+* Coaching conversations where the client is *stuck in ambivalence* — the four-cell version surfaces concerns the simple pros/cons list misses
+* Pre-mortem variant: pre-listing the "approval/disapproval from others" cell often predicts political resistance the team forgot to address
+* Motivational Interviewing settings — health behaviour, addiction recovery, career changes
+* Decision documentation in low-formality contexts where a full ADR is overkill but "we considered the alternatives" must be visible
+
+[discrete]
+== *Related Anchors*:
+
+* <<pugh-matrix,Pugh Matrix>> — scores alternatives against weighted criteria; complement when uncertainty or technical trade-offs dominate over personal/social cost
+* <<adr-according-to-nygard,ADR according to Nygard>> — captures architecture decisions with Context/Decision/Consequences; the balance sheet feeds the Consequences section
+* <<moscow,MoSCoW>> — prioritisation among items chosen *after* the decision is made; the balance sheet helps decide *whether* to do the work at all
+====

--- a/docs/anchors/decisional-balance-sheet.de.adoc
+++ b/docs/anchors/decisional-balance-sheet.de.adoc
@@ -1,0 +1,50 @@
+= Decisional Balance Sheet
+:categories: problem-solving, strategic-planning
+:roles: consultant, team-lead, product-owner, business-analyst
+:related: pugh-matrix, adr-according-to-nygard, moscow
+:proponents: Irving Janis, Leon Mann
+:tags: decision-making, pros-cons, ambivalence, motivational-interviewing
+:tier: 3
+
+[%collapsible]
+====
+Auch bekannt als:: Benjamin-Franklin-Analyse, Moralische Algebra, Pro-und-Contra-Liste
+
+[discrete]
+== *Kernkonzepte*:
+
+Vier-Zellen-Matrix:: Die volle Janis-&-Mann-Form hat vier Kategorien von Konsequenzen für jede Alternative — *utilitaristische Gewinne/Verluste für sich selbst*, *utilitaristische Gewinne/Verluste für nahestehende Personen*, *Selbst-Zustimmung/Ablehnung* und *Zustimmung/Ablehnung durch andere*. Dehnt "Pro und Contra" über instrumentelle Ergebnisse hinaus auf Identität und sozialen Preis.
+
+Vereinfachte Zwei-Spalten-Form:: Die alltägliche "Pro vs. Contra"-Liste, populär gemacht durch Benjamin Franklin (Brief 1772 an Joseph Priestley). Streng genommen ein Spezialfall der Vier-Zellen-Matrix — nützlich für schnelle Entscheidungen, verlustbehaftet bei komplexen.
+
+Gewichtung:: Jeder Eintrag bekommt ein numerisches Gewicht, das seine Wichtigkeit ausdrückt. Die Entscheidung ist *keine* Stimmenauszählung — die Disziplin ist, Trade-offs explizit zu machen, nicht die Wahl zu mechanisieren.
+
+Ambivalenz auflösen:: Der eigentliche Zweck ist nicht Arithmetik, sondern das Aufdecken von Bedenken, die der/die Entscheider:in noch nicht ausgesprochen hat. Die Contra-Seite einer verlockenden Option zu listen oder die Pro-Seite der verworfenen, bricht das "nur Pros, keine Contras"-Framing auf, das impulsive Entscheidungen treibt.
+
+Decisional Conflict:: Janis & Manns Mutter-Theorie; Entscheidungen mit hohem Einsatz erzeugen Stress, der das Urteil verzerrt. Die Balance Sheet ist eine von mehreren Debiasing-Techniken neben aufmerksamer Informationssuche und Notfallplanung.
+
+Variante in Motivational Interviewing:: Im Prochaska-DiClemente *Stages-of-Change*-Modell und in Miller & Rollnicks *Motivational Interviewing* wird die Balance Sheet eingesetzt, um Change-Talk hervorzulocken: der/die Klient:in *spricht selbst* die Contras des Status quo und die Pros der Veränderung aus — der Weg aus der Ambivalenz heraus statt durch Überredung.
+
+Grenzen:: Das Modell ist *deliberativ*, nicht intuitiv. Es funktioniert schlecht unter Zeitdruck und bei Entscheidungen, die von Unsicherheit dominiert werden (dort passen Pugh Matrix oder szenariobasierte Methoden besser). Es findet auch keine Optionen, die nicht auf der Liste stehen — die Optionsgenerierung muss vorher passieren.
+
+
+Schlüsselvertreter:: Irving Janis & Leon Mann ("Decision Making: A Psychological Analysis of Conflict, Choice, and Commitment", 1977 — das formale Vier-Zellen-Modell). Benjamin Franklin (Brief 1772, "moralische Algebra" — der informelle Pro/Contra-Vorläufer). William R. Miller & Stephen Rollnick ("Motivational Interviewing", 1991) für die klinische Adaption.
+
+Historischer Kontext:: Franklins Pro/Contra-Brief ist eine der frühesten dokumentierten Entscheidungshilfe-Techniken in der westlichen Tradition. Janis & Mann machten daraus in den 1970ern ein Forschungsinstrument; die vereinfachte Zwei-Spalten-Form wurde über Selbsthilfe, Coaching und Motivational Interviewing zum Mainstream. Heute Standard in Entscheidungs-Coaching, Finanzberatung und gesundheitsbezogenen Verhaltensänderungs-Interventionen.
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Persönliche oder berufliche Entscheidungen, in denen die Alternativen ungefähr vergleichbar sind und die eigene Klarheit der ausschlaggebende Faktor ist
+* Coaching-Gespräche, in denen der/die Klient:in *in Ambivalenz feststeckt* — die Vier-Zellen-Version fördert Bedenken zutage, die die einfache Pro/Contra-Liste verfehlt
+* Pre-Mortem-Variante: das Vorab-Listen der "Zustimmung/Ablehnung anderer"-Zelle sagt oft politischen Widerstand voraus, den das Team übersehen hat
+* Motivational-Interviewing-Settings — Gesundheitsverhalten, Suchtberatung, Karrierewechsel
+* Entscheidungsdokumentation in Kontexten mit niedriger Formalität, in denen ein voller ADR übertrieben ist, aber "wir haben die Alternativen geprüft" sichtbar bleiben muss
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<pugh-matrix,Pugh Matrix>> — bewertet Alternativen gegen gewichtete Kriterien; ergänzend, wenn Unsicherheit oder technische Trade-offs dominieren statt persönlicher/sozialer Kosten
+* <<adr-according-to-nygard,ADR according to Nygard>> — erfasst Architekturentscheidungen mit Context/Decision/Consequences; die Balance Sheet speist den Consequences-Abschnitt
+* <<moscow,MoSCoW>> — Priorisierung *nach* der Entscheidung; die Balance Sheet hilft zu entscheiden, *ob* die Arbeit überhaupt gemacht werden soll
+====

--- a/docs/anchors/double-diamond.adoc
+++ b/docs/anchors/double-diamond.adoc
@@ -1,0 +1,57 @@
+= Double Diamond
+:categories: problem-solving, requirements-engineering
+:roles: ux-designer, product-owner, business-analyst, consultant
+:related: jobs-to-be-done, problem-space-nvc, xy-problem, mvp
+:proponents: UK Design Council
+:tags: design-thinking, problem-framing, divergent-convergent, ux, innovation
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Double Diamond Design Process Model
+
+Also known as:: 4Ds Model, Design Council Double Diamond
+
+[discrete]
+== *Core Concepts*:
+
+Two Diamonds, Four Phases:: *Discover → Define → Develop → Deliver*. Each diamond is one divergent-convergent cycle. The first diamond explores and frames the *problem*; the second diamond explores and ships the *solution*.
+
+Discover (Divergent, Problem Space):: Broad research — interviews, observation, immersion, data analysis. Goal: widen the understanding of what's actually going on, not jump to causes.
+
+Define (Convergent, Problem Space):: Synthesize findings into a sharp problem statement. The famous slogan: *"Are we solving the right problem?"* — the diamond ends with a problem worth solving, not a list of features.
+
+Develop (Divergent, Solution Space):: Generate many candidate solutions — sketches, prototypes, co-design workshops. Diverge widely before narrowing; resist solution fixation.
+
+Deliver (Convergent, Solution Space):: Test, refine, ship. The chosen concept is iterated until it's production-ready; failed candidates are explicitly killed rather than left lingering.
+
+Design the Right Thing, Then Design the Thing Right:: The canonical summary. The first diamond addresses "right thing" (problem worth solving); the second addresses "thing right" (solution that works).
+
+Divergent Before Convergent:: A hard discipline at every phase. Premature convergence — picking the obvious problem or obvious solution — is the failure mode the model is designed to prevent.
+
+Iteration, Not Waterfall:: The diamonds are not strictly linear. Learnings in Develop frequently send the team back to Discover or Define. The 2019 *Framework for Innovation* update made this explicit.
+
+Mindsets and Principles:: The Design Council pairs the four phases with four principles (Put people first, Communicate visually and inclusively, Collaborate and co-create, Iterate, iterate, iterate) — the diamonds without the mindset is just process theater.
+
+
+Key Proponents:: UK Design Council (originally published 2005; expanded as *Framework for Innovation* in 2019). Built on the divergent-convergent tradition of J.P. Guilford (1956) and Béla H. Bánáthy.
+
+Historical Context:: Developed by the Design Council in 2005 after research into how leading design organizations actually worked. The 2019 update reframed it as a system-level innovation framework, adding the principles, key roles, and explicit iteration arrows. Adopted broadly in UX, service design, government innovation (UK GDS, NHS, Danish Mindlab), and design education.
+
+[discrete]
+== *When to Use*:
+
+* Framing UX or service design projects when the team is at risk of jumping to solutions
+* Innovation workshops and design sprints — the diamonds give a shared visual model for sequencing divergent and convergent work
+* Discovery phases of product development when the problem itself is not yet well understood
+* Teaching design thinking — the model is more concrete than abstract "design thinking" because it names the four moves
+* Communicating *why* a discovery phase is necessary to stakeholders who want to skip straight to delivery
+
+[discrete]
+== *Related Anchors*:
+
+* <<jobs-to-be-done,Jobs to be Done>> — sharpens the *Define* output by reframing customer needs as functional, emotional, and social jobs
+* <<problem-space-nvc,Problem Space (NVC)>> — separates needs from strategies; complements the first-diamond discipline of staying in problem space
+* <<xy-problem,XY Problem>> — anti-pattern that the first diamond is designed to prevent (solving Y before understanding X)
+* <<mvp,MVP>> — the *Deliver* output is often shaped as an MVP to validate the chosen solution against the defined problem
+====

--- a/docs/anchors/double-diamond.de.adoc
+++ b/docs/anchors/double-diamond.de.adoc
@@ -1,0 +1,57 @@
+= Double Diamond
+:categories: problem-solving, requirements-engineering
+:roles: ux-designer, product-owner, business-analyst, consultant
+:related: jobs-to-be-done, problem-space-nvc, xy-problem, mvp
+:proponents: UK Design Council
+:tags: design-thinking, problem-framing, divergent-convergent, ux, innovation
+:tier: 3
+
+[%collapsible]
+====
+Voller Name:: Double Diamond Design Process Model
+
+Auch bekannt als:: 4Ds-Modell, Design Council Double Diamond
+
+[discrete]
+== *Kernkonzepte*:
+
+Zwei Diamanten, vier Phasen:: *Discover → Define → Develop → Deliver*. Jeder Diamant ist ein Divergent-Konvergent-Zyklus. Der erste Diamant erforscht und rahmt das *Problem*; der zweite Diamant erforscht und liefert die *Lösung*.
+
+Discover (divergent, Problemraum):: Breite Recherche — Interviews, Beobachtung, Immersion, Datenanalyse. Ziel: das Verständnis dessen, was tatsächlich passiert, weit aufmachen, nicht zu Ursachen springen.
+
+Define (konvergent, Problemraum):: Erkenntnisse zu einer scharfen Problemformulierung verdichten. Der berühmte Slogan: *"Lösen wir das richtige Problem?"* — der Diamant endet mit einem lohnenswerten Problem, nicht mit einer Feature-Liste.
+
+Develop (divergent, Lösungsraum):: Viele Kandidaten-Lösungen erzeugen — Skizzen, Prototypen, Co-Design-Workshops. Erst weit auffächern, dann verengen; Lösungs-Fixierung widerstehen.
+
+Deliver (konvergent, Lösungsraum):: Testen, verfeinern, ausliefern. Das gewählte Konzept wird bis zur Produktionsreife iteriert; gescheiterte Kandidaten werden explizit beerdigt statt herumzuliegen.
+
+Das Richtige entwerfen, dann es richtig entwerfen:: Die kanonische Zusammenfassung. Der erste Diamant adressiert "das Richtige" (lohnenswertes Problem); der zweite adressiert "richtig entwerfen" (Lösung, die funktioniert).
+
+Divergent vor konvergent:: Eine harte Disziplin in jeder Phase. Verfrühte Konvergenz — das offensichtliche Problem oder die offensichtliche Lösung wählen — ist der Fehlermodus, den das Modell verhindern soll.
+
+Iteration, kein Wasserfall:: Die Diamanten sind nicht strikt linear. Erkenntnisse im Develop schicken das Team häufig zurück in Discover oder Define. Das 2019er *Framework for Innovation*-Update machte das explizit.
+
+Mindsets und Prinzipien:: Der Design Council ergänzt die vier Phasen mit vier Prinzipien (Put people first, Communicate visually and inclusively, Collaborate and co-create, Iterate, iterate, iterate) — die Diamanten ohne das Mindset sind nur Prozess-Theater.
+
+
+Schlüsselvertreter:: UK Design Council (Ursprung 2005; erweitert als *Framework for Innovation* 2019). Aufbauend auf der Divergent-Konvergent-Tradition von J.P. Guilford (1956) und Béla H. Bánáthy.
+
+Historischer Kontext:: Vom Design Council 2005 entwickelt nach einer Untersuchung, wie führende Design-Organisationen tatsächlich arbeiten. Das 2019er Update reframte es als System-Innovations-Rahmenwerk und ergänzte explizit Prinzipien, Rollen und Iterations-Pfeile. Breit verbreitet in UX, Service Design, Government Innovation (UK GDS, NHS, Danish Mindlab) und Design-Ausbildung.
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Rahmung von UX- oder Service-Design-Projekten, wenn das Team Gefahr läuft, zu Lösungen zu springen
+* Innovations-Workshops und Design Sprints — die Diamanten geben ein geteiltes visuelles Modell, um divergente und konvergente Arbeit zu sequenzieren
+* Discovery-Phasen der Produktentwicklung, in denen das Problem selbst noch nicht gut verstanden ist
+* Beim Lehren von Design Thinking — das Modell ist konkreter als abstraktes "Design Thinking", weil es die vier Moves benennt
+* Wenn Stakeholdern, die direkt zur Auslieferung springen wollen, vermittelt werden muss, *warum* eine Discovery-Phase nötig ist
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<jobs-to-be-done,Jobs to be Done>> — schärft das *Define*-Ergebnis durch Umformulierung von Kundenbedürfnissen als funktionale, emotionale und soziale Jobs
+* <<problem-space-nvc,Problem Space (NVC)>> — trennt Bedürfnisse von Strategien; ergänzt die Disziplin des ersten Diamanten, im Problemraum zu bleiben
+* <<xy-problem,XY Problem>> — Anti-Muster, das der erste Diamant verhindern soll (Y lösen, ohne X verstanden zu haben)
+* <<mvp,MVP>> — das *Deliver*-Ergebnis wird oft als MVP zugeschnitten, um die gewählte Lösung gegen das definierte Problem zu validieren
+====

--- a/docs/anchors/hoshin-kanri.adoc
+++ b/docs/anchors/hoshin-kanri.adoc
@@ -1,0 +1,54 @@
+= Hoshin Kanri
+:categories: strategic-planning
+:roles: team-lead, consultant, product-owner
+:related: kotter-8-step-change-model, moscow, kano-model
+:proponents: Yoji Akao, Thomas L. Jackson
+:tags: strategy-deployment, lean, alignment, x-matrix, catchball
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Hoshin Kanri (方針管理 — "direction management")
+
+Also known as:: Policy Deployment, Strategy Deployment, Hoshin Planning
+
+[discrete]
+== *Core Concepts*:
+
+True North:: The 3-5 year *breakthrough objectives* that define where the organization must be — chosen sparingly so the whole company can pull in the same direction.
+
+Annual Hoshin:: The 1-year priorities derived from True North. Typically 3-5 organization-wide goals; everything else is "business as usual" and not on the hoshin.
+
+X-Matrix:: Single-page A3 artifact that links four legs — *long-term strategy*, *annual objectives*, *improvement priorities*, and *metrics/targets* — plus the accountable owners. Correlations between legs are made explicit with symbols (strong/medium/weak).
+
+Catchball:: Iterative two-way negotiation of goals between levels. Leadership proposes targets; teams respond with "what's possible and what's needed"; the ball passes back and forth until commitments are realistic *and* ambitious. Distinguishes Hoshin Kanri from top-down cascades.
+
+PDCA for Strategy:: Plan-Do-Check-Act applied to the annual hoshin itself — monthly or quarterly *check* reviews ensure the strategy adapts to reality, not just the tactics.
+
+Cascade and Alignment:: Each level translates the level above into its own X-Matrix. Vertical alignment is verified at every step; horizontal alignment is verified across peer teams to prevent local optimization.
+
+Bowling Chart / Hoshin Review:: Monthly status board comparing actual vs target for each KPI; red/yellow/green status forces conversations about countermeasures rather than excuses.
+
+Few Vital, Not Many Trivial:: A core discipline — restrict the hoshin to the small number of goals that *require* breakthrough thinking. Most organizational work continues outside the hoshin process.
+
+
+Key Proponents:: Yoji Akao ("Hoshin Kanri: Policy Deployment for Successful TQM", 1991), Thomas L. Jackson ("Hoshin Kanri for the Lean Enterprise", 2006), Pascal Dennis ("Getting the Right Things Done", 2006)
+
+Historical Context:: Emerged in Japanese manufacturing in the 1960s; Bridgestone Tire is widely credited with the first formalized use after winning the Deming Prize. Spread through Toyota, Komatsu, and the broader TQM movement; translated to Western practice in the 1980s as part of Lean. Now widely adopted in Lean enterprises, healthcare systems (Virginia Mason), and increasingly in scaled agile contexts.
+
+[discrete]
+== *When to Use*:
+
+* Annual or multi-year strategic planning when alignment across many teams is the critical risk
+* Translating a vision or mission into measurable, accountable work
+* Scaling an organization where local optimization is starting to dominate over global goals
+* Lean transformations — Hoshin Kanri is the strategy-layer counterpart to Kaizen at the operational layer
+* As an alternative to OKRs when the organization needs explicit cause-and-effect links and stronger accountability than quarterly self-set objectives provide
+
+[discrete]
+== *Related Anchors*:
+
+* <<kotter-8-step-change-model,Kotter's 8-Step Change Model>> — large-scale transformation framework; Hoshin Kanri is the recurring discipline that operationalizes a Kotter-style vision year after year
+* <<moscow,MoSCoW>> — tactical prioritization within the hoshin's improvement priorities
+* <<kano-model,Kano Model>> — feature classification that often feeds the customer-facing leg of the X-Matrix
+====

--- a/docs/anchors/hoshin-kanri.de.adoc
+++ b/docs/anchors/hoshin-kanri.de.adoc
@@ -1,0 +1,54 @@
+= Hoshin Kanri
+:categories: strategic-planning
+:roles: team-lead, consultant, product-owner
+:related: kotter-8-step-change-model, moscow, kano-model
+:proponents: Yoji Akao, Thomas L. Jackson
+:tags: strategy-deployment, lean, alignment, x-matrix, catchball
+:tier: 3
+
+[%collapsible]
+====
+Voller Name:: Hoshin Kanri (方針管理 — "Richtungs-Management")
+
+Auch bekannt als:: Policy Deployment, Strategy Deployment, Hoshin Planning
+
+[discrete]
+== *Kernkonzepte*:
+
+True North:: Die *Durchbruchsziele* der nächsten 3-5 Jahre — sparsam gewählt, damit das ganze Unternehmen in dieselbe Richtung zieht.
+
+Jahres-Hoshin:: Die 1-Jahres-Prioritäten, abgeleitet aus True North. Typisch 3-5 unternehmensweite Ziele; alles andere ist "Business as usual" und gehört nicht ins Hoshin.
+
+X-Matrix:: Einseitiges A3-Artefakt, das vier Schenkel verbindet — *Langzeitstrategie*, *Jahresziele*, *Verbesserungs-Schwerpunkte* und *Kennzahlen/Targets* — plus die verantwortlichen Owner. Wechselwirkungen zwischen den Schenkeln werden mit Symbolen (stark/mittel/schwach) explizit gemacht.
+
+Catchball:: Iterative *bidirektionale* Verhandlung der Ziele zwischen Ebenen. Leadership schlägt Targets vor; Teams antworten mit "was ist möglich und was wird gebraucht"; der Ball wandert hin und her, bis die Commitments realistisch *und* ambitioniert sind. Hier unterscheidet sich Hoshin Kanri vom reinen Top-Down-Cascade.
+
+PDCA für Strategie:: Plan-Do-Check-Act angewandt auf das Jahres-Hoshin selbst — monatliche oder quartalsweise *Check*-Reviews stellen sicher, dass die Strategie auf die Realität reagiert, nicht nur die Taktik.
+
+Cascade und Alignment:: Jede Ebene übersetzt die Ebene darüber in ihre eigene X-Matrix. Vertikales Alignment wird in jedem Schritt geprüft; horizontales Alignment quer über Peer-Teams verhindert lokale Optimierung.
+
+Bowling Chart / Hoshin Review:: Monatliches Status-Board, das Ist gegen Soll für jede KPI vergleicht; Rot/Gelb/Grün erzwingt Gespräche über Gegenmaßnahmen statt Ausreden.
+
+Wenige Wichtige, nicht viele Triviale:: Eine zentrale Disziplin — das Hoshin wird auf die wenigen Ziele beschränkt, die *Durchbruchsdenken* erfordern. Der Großteil der Organisationsarbeit läuft außerhalb des Hoshin-Prozesses weiter.
+
+
+Schlüsselvertreter:: Yoji Akao ("Hoshin Kanri: Policy Deployment for Successful TQM", 1991), Thomas L. Jackson ("Hoshin Kanri for the Lean Enterprise", 2006), Pascal Dennis ("Getting the Right Things Done", 2006)
+
+Historischer Kontext:: Entstand in der japanischen Fertigung in den 1960ern; Bridgestone Tire gilt als erster formalisierter Anwender, nachdem sie den Deming-Preis gewannen. Über Toyota, Komatsu und die TQM-Bewegung verbreitet; in den 1980ern in den Westen übertragen als Teil von Lean. Heute verbreitet in Lean-Unternehmen, Krankenhaussystemen (Virginia Mason) und zunehmend in Scaled-Agile-Kontexten.
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Jahres- oder Mehrjahres-Strategieplanung, wenn Alignment über viele Teams das kritische Risiko ist
+* Übersetzung einer Vision oder Mission in messbare, verantwortliche Arbeit
+* Skalierung einer Organisation, in der lokale Optimierung beginnt, globale Ziele zu dominieren
+* Lean-Transformationen — Hoshin Kanri ist das Strategie-Pendant zu Kaizen auf der operativen Ebene
+* Als Alternative zu OKRs, wenn die Organisation explizite Ursache-Wirkungs-Verknüpfungen und stärkere Accountability braucht als quartalsweise selbstgesetzte Ziele bieten
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<kotter-8-step-change-model,Kotter's 8-Step Change Model>> — Rahmenwerk für Großtransformationen; Hoshin Kanri ist die wiederkehrende Disziplin, die eine Kotter-Vision Jahr für Jahr operationalisiert
+* <<moscow,MoSCoW>> — taktische Priorisierung innerhalb der Verbesserungs-Schwerpunkte des Hoshin
+* <<kano-model,Kano Model>> — Feature-Klassifizierung, die oft den kunden-orientierten Schenkel der X-Matrix speist
+====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -2,6 +2,14 @@
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 
+== 2026-05-13
+
+*New anchors:*
+
+* *Hoshin Kanri* — Yoji Akao's Lean strategy-deployment discipline; 3-5 year True North objectives cascade into annual hoshin via the X-Matrix, with two-way *catchball* negotiation and monthly Bowling-Chart reviews; deliberately restricted to the few vital goals (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/468[#468])
+* *Double Diamond* — UK Design Council's design-process model (2005, expanded 2019); two divergent-convergent cycles — Discover/Define (problem space) and Develop/Deliver (solution space); "design the right thing, then design the thing right" (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/467[#467])
+* *Decisional Balance Sheet* — Janis & Mann's four-cell decision matrix (1977) extending Franklin's "moral algebra"; surfaces utilitarian and social trade-offs, used in decision coaching and Motivational Interviewing to resolve ambivalence (proposed by https://github.com/Mabla70[@Mabla70] in https://github.com/LLM-Coding/Semantic-Anchors/issues/448[#448])
+
 == 2026-05-08
 
 *New anchors:*

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -389,6 +389,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Mark Jason Dominus (coined the term in comp.lang.perl.misc, 2001), Eric S. Raymond ("How To Ask Questions The Smart Way")
 - **Core:** Communication anti-pattern — asker requests help with attempted solution Y when the real goal X is hidden; resolution by probing for X first ("What are you actually trying to accomplish?"); applies to support, code review, requirements clarification, and LLM dialogues; canonical references at xyproblem.info and Greg's Wiki
 
+### Double Diamond
+- **Also known as:** 4Ds Model, Design Council Double Diamond
+- **Proponents:** UK Design Council (2005; expanded as "Framework for Innovation", 2019)
+- **Core:** Two divergent-convergent cycles — Discover/Define (problem space) and Develop/Deliver (solution space); "design the right thing, then design the thing right"; explicit iteration; widely used in UX, service design, government innovation
+
 ## Requirements Engineering
 
 ### Cockburn Use Cases
@@ -589,6 +594,16 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Also known as:** MVP, Lean Startup MVP
 - **Proponents:** Eric Ries, Frank Robinson
 - **Core:** Smallest product that tests a single falsifiable hypothesis about user needs with the least effort; the defining output is *validated learning*, not a feature set or revenue; first turn of the build-measure-learn loop; distinct from a "small v1" — an MVP would be embarrassing to ship in production because its job is learning, not market entry; gives evidence for pivot-or-persevere decisions
+
+### Hoshin Kanri
+- **Also known as:** Policy Deployment, Strategy Deployment, Hoshin Planning
+- **Proponents:** Yoji Akao ("Hoshin Kanri: Policy Deployment for Successful TQM", 1991), Thomas L. Jackson ("Hoshin Kanri for the Lean Enterprise", 2006)
+- **Core:** Lean strategy-deployment discipline — 3-5 year True North breakthrough objectives cascade into annual hoshin via the X-Matrix (long-term strategy × annual objectives × improvement priorities × metrics, with explicit correlations); two-way *catchball* negotiation between levels prevents top-down imposition; monthly *Bowling Chart* reviews drive PDCA on the strategy itself; deliberately restricted to the few vital goals so "business as usual" stays outside the hoshin
+
+### Decisional Balance Sheet
+- **Also known as:** Benjamin Franklin Analysis, Moral Algebra, Pros-and-Cons Sheet
+- **Proponents:** Irving Janis & Leon Mann ("Decision Making: A Psychological Analysis of Conflict, Choice, and Commitment", 1977); Benjamin Franklin (1772 "moral algebra" letter to Joseph Priestley); adapted by Miller & Rollnick ("Motivational Interviewing", 1991)
+- **Core:** Four-cell decision matrix capturing utilitarian gains/losses for self and for significant others, plus self-approval and approval from others; weighted entries surface trade-offs and resolve ambivalence rather than mechanise the choice; simplified two-column pros/cons form is a degenerate case; used in decision coaching and Motivational Interviewing to elicit change-talk; deliberative — weak under time pressure or high uncertainty
 
 ## Creative Writing & Storytelling
 


### PR DESCRIPTION
Closes #468, #467, #448

## Summary

Three new anchors from community proposals — all well-established methodologies with stable LLM activation:

- **Hoshin Kanri** (#468, @jaoltr) — Lean strategy-deployment discipline; X-Matrix, catchball, Bowling Chart, True North → annual hoshin cascade
- **Double Diamond** (#467, @jaoltr) — UK Design Council's Discover/Define/Develop/Deliver model; "design the right thing, then design the thing right"
- **Decisional Balance Sheet** (#448, @Mabla70) — Janis & Mann's four-cell decision matrix; extends Franklin's "moral algebra"; used in Motivational Interviewing

## Test plan

- [x] Bilingual (EN + DE) anchor files for all three, formatted per template
- [x] AsciiDoc lint passes (pre-commit hook)
- [x] \`changelog.adoc\` entry under 2026-05-13 crediting proponents
- [x] AgentSkill \`catalog.md\` updated — Problem-Solving + Strategic Planning sections
- [x] \`npm run build\` succeeds; sitemap regenerates
- [x] All 89 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)