### PR TITLE
docs(skill): add on-invocation guard to socratic-code-theory-recovery

### DIFF
--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
@@ -12,6 +12,20 @@ license: MIT
 
 Reverse-engineer a bounded context into documentation without hallucinating the parts the code cannot tell you.
 
+## On invocation
+
+When this skill is invoked:
+
+1. **Check whether the user named a bounded context.** Look at the same message that invoked the skill and at the immediately preceding messages. A valid bounded-context pointer is a path (relative or absolute) to a directory, plus a short human-readable name for what the context is (e.g. `src/auth`, "Authentication"). If both are present, proceed to Phase 1.
+
+2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE.adoc`, `OPEN_QUESTIONS.adoc`) and running it on the wrong directory wastes work. Ask exactly:
+
+   > Which bounded context should I apply Socratic Code-Theory Recovery to? Give me a directory path (the bounded context's code root) and a short human-readable name. If you want the whole current repo treated as one bounded context, say so explicitly.
+
+3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path. Do not change the leaf classification, Q-ID scheme, or output files.
+
+4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+
 ## When to use this skill
 
 Use this skill on a brownfield codebase when:

--- a/skill/socratic-code-theory-recovery/SKILL.md
+++ b/skill/socratic-code-theory-recovery/SKILL.md
@@ -12,6 +12,20 @@ license: MIT
 
 Reverse-engineer a bounded context into documentation without hallucinating the parts the code cannot tell you.
 
+## On invocation
+
+When this skill is invoked:
+
+1. **Check whether the user named a bounded context.** Look at the same message that invoked the skill and at the immediately preceding messages. A valid bounded-context pointer is a path (relative or absolute) to a directory, plus a short human-readable name for what the context is (e.g. `src/auth`, "Authentication"). If both are present, proceed to Phase 1.
+
+2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE.adoc`, `OPEN_QUESTIONS.adoc`) and running it on the wrong directory wastes work. Ask exactly:
+
+   > Which bounded context should I apply Socratic Code-Theory Recovery to? Give me a directory path (the bounded context's code root) and a short human-readable name. If you want the whole current repo treated as one bounded context, say so explicitly.
+
+3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path. Do not change the leaf classification, Q-ID scheme, or output files.
+
+4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+
 ## When to use this skill
 
 Use this skill on a brownfield codebase when:


### PR DESCRIPTION
Follow-up to #478 / #479.

## Problem

When a user invokes \`/semantic-anchors:socratic-code-theory-recovery\`, the LLM loads the SKILL.md content but has no clear instruction on what to do next. Symptom seen in practice: the slash command's output is displayed, and the model defaults to a meta-conversation about the skill ("here's what it does, give it a try sometime") instead of actually starting Phase 1.

## Fix

Prepend an \"On invocation\" section to \`SKILL.md\` with four explicit steps:

1. Check whether the same message that invoked the skill (or the immediately preceding context) names a bounded-context path + name.
2. If not, ask a single specific question for it. Do not default to the current working directory — Phase 1 produces files and a wrong target wastes work.
3. Run Phase 1 with the user's path (using the existing \`prompts/phase-1-question-tree.md\` prompt).
4. Stop after Phase 1. Phase 2 needs team answers; do not run it silently in the same session.

This converts the skill from a passive document into an active behaviour spec without changing the methodology or any of the references.

## Affected files

- \`skill/socratic-code-theory-recovery/SKILL.md\` — canonical source
- \`plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md\` — auto-mirrored by the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)