### PR TITLE
fix: remove onboarding-prompt claim from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "semantic-anchors",
-  "description": "Semantic anchor skills for LLM and coding-agent onboarding, including a first-start Claude onboarding prompt",
+  "description": "Semantic anchor skills for LLM and coding-agent onboarding",
   "owner": {
     "name": "LLM Coding",
     "url": "https://github.com/LLM-Coding"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "semantic-anchors",
-      "description": "Semantic anchor skills for translating established methodologies, prompting first-run Claude onboarding, and installing persistent coding-agent context.",
+      "description": "Semantic anchor skills for translating established methodologies and installing persistent coding-agent context.",
       "version": "0.1.0",
       "author": {
         "name": "LLM Coding",


### PR DESCRIPTION
## Summary
Follow-up to the SessionStart hook removal — marketplace.json still advertised the now-removed onboarding prompt in both the marketplace description and the plugin description. This PR cleans up both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)