### PR TITLE
fix(seo): list brownfield reports and contracts in sitemap and llms.txt

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -209,6 +209,8 @@ include::anchors/what-would-chuck-norris-do.adoc[leveloffset=+2]
 
 == Requirements Engineering
 
+include::anchors/cockburn-use-cases.adoc[leveloffset=+2]
+
 include::anchors/ears-requirements.adoc[leveloffset=+2]
 
 include::anchors/invest.adoc[leveloffset=+2]

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -220,7 +220,8 @@ function generateLlmsTxt() {
     {
       title: 'About',
       url: 'https://llm-coding.github.io/Semantic-Anchors/about',
-      summary: 'What semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
+      summary:
+        'What semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
     },
     {
       title: 'Spec-Driven Development',
@@ -272,7 +273,8 @@ function generateLlmsTxt() {
     {
       title: 'Full Reference',
       url: 'https://llm-coding.github.io/Semantic-Anchors/all-anchors',
-      summary: 'All semantic anchors in one long document — readable offline, linkable, easy to Ctrl-F.',
+      summary:
+        'All semantic anchors in one long document — readable offline, linkable, easy to Ctrl-F.',
     },
     {
       title: 'Changelog',
@@ -282,7 +284,8 @@ function generateLlmsTxt() {
     {
       title: 'Contributing',
       url: 'https://llm-coding.github.io/Semantic-Anchors/contributing',
-      summary: 'How to propose new semantic anchors, quality criteria, and the contribution workflow.',
+      summary:
+        'How to propose new semantic anchors, quality criteria, and the contribution workflow.',
     },
   ]
 

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -215,6 +215,86 @@ function generateLlmsTxt() {
     lines.push('')
   }
 
+  // Top-level documentation pages (each pre-rendered as a standalone HTML page)
+  const DOC_PAGES = [
+    {
+      title: 'About',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/about',
+      summary: 'What semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
+    },
+    {
+      title: 'Spec-Driven Development',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/spec-driven-development',
+      summary:
+        'Greenfield workflow — from requirements to specification to implementation, powered by semantic anchors.',
+    },
+    {
+      title: 'Brownfield Workflow',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/brownfield',
+      summary:
+        'Applying semantic anchors to brownfield codebases using a bounded-context approach with reverse-engineered safety nets.',
+    },
+    {
+      title: 'Brownfield Experiment 1a Report',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/brownfield-experiment-report',
+      summary:
+        'Controlled experiment: delete documentation from a greenfield project, regenerate from code, compare. Methodology, findings, and the Brownfield Preparation Checklist.',
+    },
+    {
+      title: 'Brownfield Fair Comparison',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/brownfield-fair-comparison',
+      summary:
+        'Three approaches (Direct, Socratic, Two-Phase) compared with identical team answers. Measures the structural value of the Question Tree, not the answers.',
+    },
+    {
+      title: 'Socratic Code-Theory Recovery Skill',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/socratic-recovery-skill',
+      summary:
+        'Installable Claude Code Skill that packages the brownfield documentation-recovery workflow as a two-phase Question Tree with Q-ID traceability.',
+    },
+    {
+      title: 'Semantic Contracts',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/contracts',
+      summary:
+        'Composable contracts that define what terms mean in your project — pick and copy into your AGENTS.md or CLAUDE.md.',
+    },
+    {
+      title: 'AgentSkill',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/agentskill',
+      summary:
+        'The semantic-anchor-translator AgentSkill — install semantic anchors into Claude Code, Codex, Cursor, and other coding agents.',
+    },
+    {
+      title: 'Evaluations',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/evaluations',
+      summary: 'Multiple-choice evaluations of semantic anchor recognition across 10 LLMs.',
+    },
+    {
+      title: 'Full Reference',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/all-anchors',
+      summary: 'All semantic anchors in one long document — readable offline, linkable, easy to Ctrl-F.',
+    },
+    {
+      title: 'Changelog',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/changelog',
+      summary: 'Chronological record of all semantic anchors added to the catalog.',
+    },
+    {
+      title: 'Contributing',
+      url: 'https://llm-coding.github.io/Semantic-Anchors/contributing',
+      summary: 'How to propose new semantic anchors, quality criteria, and the contribution workflow.',
+    },
+  ]
+
+  lines.push('## Documentation')
+  lines.push('')
+  for (const page of DOC_PAGES) {
+    lines.push(`- [${page.title}](${page.url}): ${page.summary}`)
+  }
+  lines.push('')
+  lines.push('---')
+  lines.push('')
+
   // Anchors by category
   for (const category of categories) {
     lines.push(`## ${category.name}`)

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -30,8 +30,6 @@ const BASE_URL = 'https://llm-coding.github.io/Semantic-Anchors'
 // shell to non-JS crawlers and claude.ai fetchers.
 //
 // Excluded on purpose:
-// - /contracts     — interactive JS page (localStorage, client-side data
-//                    fetching); no static content worth serving
 // - /anchor/:id    — rendered per entry via the anchor loop below
 //
 // priority: 1.0 homepage, 0.8 top-level content, 0.7 contributing/meta, 0.6 anchors
@@ -40,6 +38,10 @@ const PAGES = [
   { path: '/about', priority: '0.8', changefreq: 'monthly' },
   { path: '/spec-driven-development', priority: '0.8', changefreq: 'monthly' },
   { path: '/brownfield', priority: '0.8', changefreq: 'monthly' },
+  { path: '/brownfield-experiment-report', priority: '0.7', changefreq: 'monthly' },
+  { path: '/brownfield-fair-comparison', priority: '0.7', changefreq: 'monthly' },
+  { path: '/socratic-recovery-skill', priority: '0.7', changefreq: 'monthly' },
+  { path: '/contracts', priority: '0.7', changefreq: 'monthly' },
   { path: '/evaluations', priority: '0.8', changefreq: 'monthly' },
   { path: '/all-anchors', priority: '0.8', changefreq: 'weekly' },
   { path: '/agentskill', priority: '0.7', changefreq: 'monthly' },

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,6 +1,6 @@
 # Semantic Anchors — Complete Reference
 
-> 136 well-defined terms, methodologies, and frameworks
+> 137 well-defined terms, methodologies, and frameworks
 > that serve as precision reference points when communicating with LLMs.
 > Source: https://github.com/LLM-Coding/Semantic-Anchors
 > Website: https://llm-coding.github.io/Semantic-Anchors/
@@ -8,6 +8,39 @@
 ---
 
 # About Semantic Anchors
+
+++++
+<figure class="youtube-facade-wrapper">
+  <button
+    type="button"
+    class="youtube-facade"
+    data-video-id="Q_DWMayAQEQ"
+    data-video-title="LLM Coding with Semantic Anchors: From Vibe Coding to a Real Java App with Ralf D. Müller"
+    aria-label="Load and play video: LLM Coding with Semantic Anchors — From Vibe Coding to a Real Java App. YouTube only loads on click."
+  >
+    <img
+      src="https://i.ytimg.com/vi/Q_DWMayAQEQ/maxresdefault.jpg"
+      alt=""
+      loading="lazy"
+    />
+    <span class="youtube-facade-play">
+      <span class="youtube-facade-play-icon">
+        <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M8 5v14l11-7z"/>
+        </svg>
+      </span>
+    </span>
+    <span class="youtube-facade-title">
+      <strong>LLM Coding with Semantic Anchors — From Vibe Coding to a Real Java App</strong>
+      <em>YouTube only loads on click (GDPR)</em>
+    </span>
+  </button>
+  <figcaption>
+    Two-hour live coding session with Johannes Rabauer and Ralf D. Müller (May 2026).
+    Read Johannes' <a href="https://rabauer.dev/en/blog/semantic-anchors/" target="_blank" rel="noopener noreferrer">session summary on rabauer.dev</a>.
+  </figcaption>
+</figure>
+++++
 
 ## What are Semantic Anchors?
 
@@ -304,6 +337,23 @@ https://github.com/LLM-Coding/Semantic-Anchors
 ---
 
 Ready to explore? [Browse the catalog →](https://llm-coding.github.io/Semantic-Anchors/)
+
+---
+
+## Documentation
+
+- [About](https://llm-coding.github.io/Semantic-Anchors/about): What semantic anchors are, why they matter for LLM communication, and how the catalog is curated.
+- [Spec-Driven Development](https://llm-coding.github.io/Semantic-Anchors/spec-driven-development): Greenfield workflow — from requirements to specification to implementation, powered by semantic anchors.
+- [Brownfield Workflow](https://llm-coding.github.io/Semantic-Anchors/brownfield): Applying semantic anchors to brownfield codebases using a bounded-context approach with reverse-engineered safety nets.
+- [Brownfield Experiment 1a Report](https://llm-coding.github.io/Semantic-Anchors/brownfield-experiment-report): Controlled experiment: delete documentation from a greenfield project, regenerate from code, compare. Methodology, findings, and the Brownfield Preparation Checklist.
+- [Brownfield Fair Comparison](https://llm-coding.github.io/Semantic-Anchors/brownfield-fair-comparison): Three approaches (Direct, Socratic, Two-Phase) compared with identical team answers. Measures the structural value of the Question Tree, not the answers.
+- [Socratic Code-Theory Recovery Skill](https://llm-coding.github.io/Semantic-Anchors/socratic-recovery-skill): Installable Claude Code Skill that packages the brownfield documentation-recovery workflow as a two-phase Question Tree with Q-ID traceability.
+- [Semantic Contracts](https://llm-coding.github.io/Semantic-Anchors/contracts): Composable contracts that define what terms mean in your project — pick and copy into your AGENTS.md or CLAUDE.md.
+- [AgentSkill](https://llm-coding.github.io/Semantic-Anchors/agentskill): The semantic-anchor-translator AgentSkill — install semantic anchors into Claude Code, Codex, Cursor, and other coding agents.
+- [Evaluations](https://llm-coding.github.io/Semantic-Anchors/evaluations): Multiple-choice evaluations of semantic anchor recognition across 10 LLMs.
+- [Full Reference](https://llm-coding.github.io/Semantic-Anchors/all-anchors): All semantic anchors in one long document — readable offline, linkable, easy to Ctrl-F.
+- [Changelog](https://llm-coding.github.io/Semantic-Anchors/changelog): Chronological record of all semantic anchors added to the catalog.
+- [Contributing](https://llm-coding.github.io/Semantic-Anchors/contributing): How to propose new semantic anchors, quality criteria, and the contribution workflow.
 
 ---
 
@@ -3381,6 +3431,55 @@ GPT-5.3 Codex activates the decisiveness signal but **not** the character voice 
 
 ## Requirements Engineering
 
+### Cockburn Use Cases
+
+***Full Name***: Cockburn Use Cases (Writing Effective Use Cases)
+
+***Also known as***: Fully Dressed Use Cases, Goal-Level Use Cases, Cockburn Format
+
+[discrete]
+## **Core Concepts**:
+
+***Fully Dressed Format***
+A structured textual template for describing system behavior from the actor's perspective. Each use case includes: Primary Actor, Stakeholders & Interests, Preconditions, Trigger, Main Success Scenario (numbered steps), Extensions (alternative/failure paths with step references), Postconditions (success guarantee and minimal guarantee), and Technology & Data Variations.
+
+***Goal Levels***
+Three abstraction levels that organise use cases into a hierarchy:
+
+* **Summary** (Kite/Cloud) — business-process-level goals spanning multiple user sessions. Example: "Manage customer lifecycle."
+* **User Goal** (Sea Level) — the sweet spot: one actor, one sitting, one measurable outcome. Example: "Place an order." Most use cases live here.
+* **Subfunction** (Fish/Clam) — steps that support a user goal but are not goals in themselves. Example: "Authenticate user." Extract only when reused across multiple user-goal use cases.
+
+***Scope***
+Defines the system boundary — what is inside the "design scope" and what is an external actor. Cockburn uses icons (a box for the system, a person for actors) to make the boundary visual. Getting scope right prevents use cases from being either too vague (organisational scope) or too detailed (component scope).
+
+***Actor-Goal List***
+The discovery technique: list every actor and every goal they have against the system. This produces a candidate use case list before writing any prose. The goal level test: "Does the actor go home happy if this goal is achieved?" filters out subfunctions masquerading as user goals.
+
+**What Cockburn does **not** prescribe**
+Cockburn's format is deliberately **prose-based and notation-agnostic**. It does not mandate Activity Diagrams, Gherkin, EARS, or any formal syntax. Those are complementary representations that can be layered on top — Activity Diagrams for visual flow, Gherkin for executable acceptance criteria, EARS for structured requirement statements.
+
+***Key Proponents***: Alistair Cockburn (_Writing Effective Use Cases_, Addison-Wesley, 2001). The book remains the canonical reference; Cockburn also contributed to the Agile Manifesto and Crystal methodologies.
+
+[discrete]
+## **When to Use**:
+
+* Discovering what a system needs to do before deciding how to build it — the Actor-Goal List is a fast, structured brainstorm
+* Structuring requirements conversations with stakeholders who think in scenarios, not features
+* Decomposing a large system into manageable behavioural units at the right granularity (goal-level test)
+* Brownfield theory recovery: reconstructing what a system does by writing use cases from observed behaviour
+* Feeding downstream artifacts: each use case becomes a natural unit for Activity Diagrams, Gherkin scenarios, and test plans
+* Complementing arc42: use cases populate Section 6 (Runtime View) and inform Section 3 (Context and Scope)
+
+[discrete]
+## **Related Anchors**:
+
+* Gherkin - Executable acceptance criteria that can be derived from each extension path in a use case
+* BDD Given/When/Then - Formalises the scenario steps that Cockburn describes in prose
+* EARS Requirements - Structured syntax for individual requirement statements; complements Cockburn's scenario-level structure
+* arc42 - Use cases feed Section 6 (Runtime View) and inform Section 3 (Context and Scope)
+* ISO 25010 - Quality goals that use case extensions should address (error handling, performance, security)
+
 ### EARS-Requirements
 
 ***Full Name***: Easy Approach to Requirements Syntax
@@ -5537,11 +5636,14 @@ Select and download: https://llm-coding.github.io/Semantic-Anchors/#/contracts
 ## Specification
 
 When we talk about a "specification" or "spec", we mean:
-- Use Cases with Trigger, Main Flow, Alternative Flows, Postconditions, and Business Rules (BR-IDs)
+- Persona Use Cases in Cockburn's Fully Dressed format (Primary Actor, Trigger, Main Success Scenario, Extensions, Postconditions) at User Goal level, with Business Rules (BR-IDs)
+- System Use Cases for each technical interface (API endpoint, CLI command, event, file format): input/validation, processing, output/status codes, error responses
 - Activity Diagrams for all flows (not just the happy path)
 - Acceptance criteria in Gherkin format (Given/When/Then)
+- Individual requirements in EARS syntax where applicable (When/While/If/Shall)
+- Supplementary Specifications as needed: Entity Model, State Machines, Interface Contracts, Validation Rules
 
-*Referenced anchors: gherkin, bdd-given-when-then*
+*Referenced anchors: cockburn-use-cases, gherkin, bdd-given-when-then, ears-requirements*
 
 ## Requirements Discovery
 
@@ -5623,6 +5725,18 @@ Documentation follows Docs-as-Code according to Ralf D. Müller:
 - Plain English according to Strunk & White (or Gutes Deutsch nach Wolf Schneider)
 
 *Referenced anchors: docs-as-code, plain-english-strunk-white, gutes-deutsch-wolf-schneider*
+
+## Socratic Code Theory Recovery
+
+Recover a program's "theory" (Naur 1985) from source code through recursive question refinement.
+- Start with 5 high-level questions: Problem/Users, Specification, Architecture, Quality Goals, Risks
+- Decompose each question using Semantic Anchors as guides: arc42 (12 sub-questions), Cockburn Use Cases, ISO 25010, Nygard ADRs
+- Each leaf is either `[ANSWERED]` (with code evidence) or `[OPEN]` (with Category, Ask role, and why unanswerable)
+- The Question Tree is the primary artifact; documentation is synthesized from answered leaves
+- Open Questions are the handoff document: routed by role (Product Owner, Architect, Developer, Domain Expert, Operations)
+- Two-phase workflow: Phase 1 builds the tree, team answers Open Questions, Phase 2 produces documentation with Q-ID traceability
+
+*Referenced anchors: socratic-method, arc42, iso-25010, adr-according-to-nygard, mental-model-according-to-naur*
 
 ## Concise Response (TLDR)
 

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -2,70 +2,98 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/about</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://llm-coding.github.io/Semantic-Anchors/workflow</loc>
-    <lastmod>2026-04-21</lastmod>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/spec-driven-development</loc>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/brownfield</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/brownfield-experiment-report</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/brownfield-fair-comparison</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/socratic-recovery-skill</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/contracts</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/evaluations</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/all-anchors</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/agentskill</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/changelog</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/contributing</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/rejected-proposals</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -73,7 +101,7 @@
   <!-- Anchor: 4MAT -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/4mat</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -81,7 +109,7 @@
   <!-- Anchor: ADR according to Nygard -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/adr-according-to-nygard</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -89,7 +117,7 @@
   <!-- Anchor: arc42 Architecture Documentation -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/arc42</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -97,7 +125,7 @@
   <!-- Anchor: ATAM -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/atam</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -105,7 +133,7 @@
   <!-- Anchor: BDD (Behavior-Driven Development) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bdd-given-when-then</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -113,7 +141,7 @@
   <!-- Anchor: BEM Methodology -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bem-methodology</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -121,7 +149,7 @@
   <!-- Anchor: BLUF (Bottom Line Up Front) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/bluf</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -129,7 +157,7 @@
   <!-- Anchor: C4-Diagrams -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/c4-diagrams</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -137,7 +165,7 @@
   <!-- Anchor: Chain of Thought (CoT) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/chain-of-thought</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -145,7 +173,15 @@
   <!-- Anchor: Clean Architecture -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/clean-architecture</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Anchor: Cockburn Use Cases -->
+  <url>
+    <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cockburn-use-cases</loc>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -153,7 +189,7 @@
   <!-- Anchor: Code Smells -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/code-smells</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -161,7 +197,7 @@
   <!-- Anchor: Cohesion Criteria -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cohesion-criteria</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -169,7 +205,7 @@
   <!-- Anchor: Control Chart (Shewhart) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/control-chart-shewhart</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -177,7 +213,7 @@
   <!-- Anchor: Conventional Commits -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/conventional-commits</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -185,7 +221,7 @@
   <!-- Anchor: CQRS (Command Query Responsibility Segregation) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cqrs</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -193,7 +229,7 @@
   <!-- Anchor: CRC-Cards -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/crc-cards</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -201,7 +237,7 @@
   <!-- Anchor: Cynefin Framework -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/cynefin-framework</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -209,7 +245,7 @@
   <!-- Anchor: Definition of Done -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/definition-of-done</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -217,7 +253,7 @@
   <!-- Anchor: Devil’s Advocate -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/devils-advocate</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -225,7 +261,7 @@
   <!-- Anchor: Diátaxis Framework -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/diataxis-framework</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -233,7 +269,7 @@
   <!-- Anchor: Docs-as-Code according to Ralf D. Müller -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/docs-as-code</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -241,7 +277,7 @@
   <!-- Anchor: Domain-Driven Design according to Evans -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/domain-driven-design</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -249,7 +285,7 @@
   <!-- Anchor: EARS-Requirements -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/ears-requirements</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -257,7 +293,7 @@
   <!-- Anchor: Effective Go -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/effective-go</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -265,7 +301,7 @@
   <!-- Anchor: Event-Driven Architecture -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/event-driven-architecture</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -273,7 +309,7 @@
   <!-- Anchor: Fagan Inspection -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fagan-inspection</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -281,7 +317,7 @@
   <!-- Anchor: Feynman Technique -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/feynman-technique</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -289,7 +325,7 @@
   <!-- Anchor: Fichtean Curve -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fichtean-curve</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -297,7 +333,7 @@
   <!-- Anchor: Five Whys (Ohno) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/five-whys</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -305,7 +341,7 @@
   <!-- Anchor: Patterns of Enterprise Application Architecture (PEAA) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/fowler-patterns</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -313,7 +349,7 @@
   <!-- Anchor: Freytag’s Pyramid -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/freytags-pyramid</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -321,7 +357,7 @@
   <!-- Anchor: Gherkin -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gherkin</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -329,7 +365,7 @@
   <!-- Anchor: GitHub Flow -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/github-flow</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -337,7 +373,7 @@
   <!-- Anchor: GoF-Abstract Factory Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-abstract-factory-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -345,7 +381,7 @@
   <!-- Anchor: GoF-Adapter Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-adapter-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -353,7 +389,7 @@
   <!-- Anchor: GoF-Bridge Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-bridge-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -361,7 +397,7 @@
   <!-- Anchor: GoF-Builder Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-builder-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -369,7 +405,7 @@
   <!-- Anchor: GoF-Chain of Responsibility Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-chain-of-responsibility-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -377,7 +413,7 @@
   <!-- Anchor: GoF-Command Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-command-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -385,7 +421,7 @@
   <!-- Anchor: GoF-Composite Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-composite-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -393,7 +429,7 @@
   <!-- Anchor: GoF-Decorator Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-decorator-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -401,7 +437,7 @@
   <!-- Anchor: GoF Design Patterns -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-design-patterns</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -409,7 +445,7 @@
   <!-- Anchor: GoF-Facade Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-facade-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -417,7 +453,7 @@
   <!-- Anchor: GoF-Factory Method Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-factory-method-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -425,7 +461,7 @@
   <!-- Anchor: GoF-Flyweight Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-flyweight-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -433,7 +469,7 @@
   <!-- Anchor: GoF-Interpreter Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-interpreter-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -441,7 +477,7 @@
   <!-- Anchor: GoF-Iterator Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-iterator-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -449,7 +485,7 @@
   <!-- Anchor: GoF-Mediator Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-mediator-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -457,7 +493,7 @@
   <!-- Anchor: GoF-Memento Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-memento-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -465,7 +501,7 @@
   <!-- Anchor: GoF-Observer Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-observer-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -473,7 +509,7 @@
   <!-- Anchor: GoF-Prototype Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-prototype-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -481,7 +517,7 @@
   <!-- Anchor: GoF-Proxy Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-proxy-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -489,7 +525,7 @@
   <!-- Anchor: GoF-Singleton Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-singleton-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -497,7 +533,7 @@
   <!-- Anchor: GoF-State Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-state-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -505,7 +541,7 @@
   <!-- Anchor: GoF-Strategy Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-strategy-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -513,7 +549,7 @@
   <!-- Anchor: GoF-Template Method Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-template-method-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -521,7 +557,7 @@
   <!-- Anchor: GoF-Visitor Pattern -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gof-visitor-pattern</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -529,7 +565,7 @@
   <!-- Anchor: GoM -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gom</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -537,7 +573,7 @@
   <!-- Anchor: GRASP -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/grasp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -545,7 +581,7 @@
   <!-- Anchor: GTD — Getting Things Done -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gtd</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -553,7 +589,7 @@
   <!-- Anchor: Gutes Deutsch nach Wolf Schneider -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/gutes-deutsch-wolf-schneider</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -561,7 +597,7 @@
   <!-- Anchor: Hemingway Bridge -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/hemingway-bridge</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -569,7 +605,7 @@
   <!-- Anchor: Hero’s Journey -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/heros-journey</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -577,7 +613,7 @@
   <!-- Anchor: Hexagonal Architecture (Ports & Adapters) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/hexagonal-architecture</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -585,7 +621,7 @@
   <!-- Anchor: IEC 61508 SIL Levels -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/iec-61508-sil-levels</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -593,7 +629,7 @@
   <!-- Anchor: Impact Mapping -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/impact-mapping</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -601,7 +637,7 @@
   <!-- Anchor: INVEST -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/invest</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -609,7 +645,7 @@
   <!-- Anchor: ISO/IEC 25010 -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/iso-25010</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -617,7 +653,7 @@
   <!-- Anchor: Jobs To Be Done (JTBD) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/jobs-to-be-done</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -625,7 +661,7 @@
   <!-- Anchor: Kishōtenketsu -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/kishotenketsu</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -633,7 +669,7 @@
   <!-- Anchor: KISS Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/kiss-principle</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -641,7 +677,7 @@
   <!-- Anchor: LASR according to Toth/Zörner -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/lasr</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -649,7 +685,7 @@
   <!-- Anchor: Lehman’s Software Classification -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/lehmans-classification</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -657,7 +693,7 @@
   <!-- Anchor: LINDDUN -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/linddun</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -665,7 +701,7 @@
   <!-- Anchor: LLM-Evaluations -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/llm-evaluations</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -673,7 +709,7 @@
   <!-- Anchor: MADR -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/madr</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -681,7 +717,7 @@
   <!-- Anchor: MECE Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mece</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -689,7 +725,7 @@
   <!-- Anchor: Programming as Theory Building (Naur) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mental-model-according-to-naur</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -697,7 +733,7 @@
   <!-- Anchor: Mikado Method -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mikado-method</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -705,7 +741,7 @@
   <!-- Anchor: Morphological Box -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/morphological-box</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -713,7 +749,7 @@
   <!-- Anchor: MoSCoW -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/moscow</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -721,7 +757,7 @@
   <!-- Anchor: Mutation Testing -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mutation-testing</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -729,7 +765,7 @@
   <!-- Anchor: Minimum Viable Product (MVP) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/mvp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -737,7 +773,7 @@
   <!-- Anchor: Myers-Briggs Type Indicator (MBTI) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/myers-briggs-type-indicator</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -745,7 +781,7 @@
   <!-- Anchor: Nelson Rules -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/nelson-rules</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -753,7 +789,7 @@
   <!-- Anchor: Occam’s Razor -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/occams-razor</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -761,7 +797,7 @@
   <!-- Anchor: OWASP Top 10 -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/owasp-top-10</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -769,7 +805,7 @@
   <!-- Anchor: P.A.R.A. Method -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/para-method</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -777,7 +813,7 @@
   <!-- Anchor: PERT -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pert</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -785,7 +821,7 @@
   <!-- Anchor: Plain English according to Strunk & White -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/plain-english-strunk-white</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -793,7 +829,7 @@
   <!-- Anchor: PRD -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/prd</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -801,7 +837,7 @@
   <!-- Anchor: Nonviolent Communication (Rosenberg) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/problem-space-nvc</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -809,7 +845,7 @@
   <!-- Anchor: Property-Based Testing -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/property-based-testing</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -817,7 +853,7 @@
   <!-- Anchor: Pugh-Matrix -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pugh-matrix</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -825,7 +861,7 @@
   <!-- Anchor: Pyramid Principle according to Barbara Minto -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/pyramid-principle</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -833,7 +869,7 @@
   <!-- Anchor: Red/Green TDD -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/red-green-tdd</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -841,7 +877,7 @@
   <!-- Anchor: Regulated Environment -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/regulated-environment</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -849,7 +885,7 @@
   <!-- Anchor: Save the Cat! (15-Beat Sheet) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/save-the-cat</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -857,7 +893,7 @@
   <!-- Anchor: Semantic Versioning (SemVer) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/semantic-versioning</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -865,7 +901,7 @@
   <!-- Anchor: Single Level of Abstraction Principle (SLAP) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/single-level-of-abstraction-principle</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -873,7 +909,7 @@
   <!-- Anchor: Socratic Method -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/socratic-method</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -881,7 +917,7 @@
   <!-- Anchor: SOLID-Dependency Inversion Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-dip</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -889,7 +925,7 @@
   <!-- Anchor: SOLID-Interface Segregation Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-isp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -897,7 +933,7 @@
   <!-- Anchor: SOLID-Liskov Substitution Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-lsp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -905,7 +941,7 @@
   <!-- Anchor: SOLID-Open/Closed Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-ocp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -913,7 +949,7 @@
   <!-- Anchor: SOLID Principles -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-principles</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -921,7 +957,7 @@
   <!-- Anchor: SOLID-Single Responsibility Principle -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/solid-srp</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -929,7 +965,7 @@
   <!-- Anchor: SOTA (State-of-the-Art) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/sota</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -937,7 +973,7 @@
   <!-- Anchor: SPC (Statistical Process Control) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/spc</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -945,7 +981,7 @@
   <!-- Anchor: Spike Solution -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/spike-solution</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -953,7 +989,7 @@
   <!-- Anchor: SSOT (Single Source of Truth) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/ssot-principle</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -961,7 +997,7 @@
   <!-- Anchor: Story Circle (Dan Harmon) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/story-circle-dan-harmon</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -969,7 +1005,7 @@
   <!-- Anchor: STRIDE Threat Model -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/stride</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -977,7 +1013,7 @@
   <!-- Anchor: SWOT -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/swot</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -985,7 +1021,7 @@
   <!-- Anchor: TDD, Chicago School -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tdd-chicago-school</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -993,7 +1029,7 @@
   <!-- Anchor: TDD, London School -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tdd-london-school</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1001,7 +1037,7 @@
   <!-- Anchor: Test Double: Dummy (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-dummy</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1009,7 +1045,7 @@
   <!-- Anchor: Test Double: Fake (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-fake</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1017,7 +1053,7 @@
   <!-- Anchor: Test Double (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-meszaros</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1025,7 +1061,7 @@
   <!-- Anchor: Test Double: Mock (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-mock</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1033,7 +1069,7 @@
   <!-- Anchor: Test Double: Spy (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-spy</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1041,7 +1077,7 @@
   <!-- Anchor: Test Double: Stub (Meszaros) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/test-double-stub</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1049,7 +1085,7 @@
   <!-- Anchor: Testing Pyramid -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/testing-pyramid</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1057,7 +1093,7 @@
   <!-- Anchor: Thin Vertical Slice -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/thin-vertical-slice</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1065,7 +1101,7 @@
   <!-- Anchor: Three-Act Structure -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/three-act-structure</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1073,7 +1109,7 @@
   <!-- Anchor: TIMTOWTDI -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/timtowtdi</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1081,7 +1117,7 @@
   <!-- Anchor: todo.txt-flavoured Markdown -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/todotxt-flavoured-markdown</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1089,7 +1125,7 @@
   <!-- Anchor: Tracer Bullet -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/tracer-bullet</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1097,7 +1133,7 @@
   <!-- Anchor: User Story Mapping -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/user-story-mapping</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1105,7 +1141,7 @@
   <!-- Anchor: Vertical Slice Architecture (VSA) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/vertical-slice-architecture</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1113,7 +1149,7 @@
   <!-- Anchor: Walking Skeleton -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/walking-skeleton</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1121,7 +1157,7 @@
   <!-- Anchor: Wardley Mapping -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/wardley-mapping</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1129,7 +1165,7 @@
   <!-- Anchor: The Spectrum of Semantic Anchors -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/what-qualifies-as-a-semantic-anchor</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1137,7 +1173,7 @@
   <!-- Anchor: What Would Chuck Norris Do? (WWCND) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/what-would-chuck-norris-do</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1145,7 +1181,7 @@
   <!-- Anchor: YAGNI (You Aren’t Gonna Need It) -->
   <url>
     <loc>https://llm-coding.github.io/Semantic-Anchors/anchor/yagni</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## Summary

- Brownfield reports, the Socratic Recovery Skill page, and the contracts page are pre-rendered but were missing from `sitemap.xml` and `llms.txt` — so claude.ai and other fetchers had no way to discover them.
- Adds `/brownfield-experiment-report`, `/brownfield-fair-comparison`, `/socratic-recovery-skill`, `/contracts` to `scripts/generate-sitemap.js` (sitemap now lists 14 pages + 136 anchors).
- Adds a new "Documentation" section at the top of `llms.txt` listing every top-level doc page with a one-sentence summary, following the llms.txt convention.

## Test plan

- [ ] Verify generated `website/public/sitemap.xml` contains the four new URLs
- [ ] Verify generated `website/public/llms.txt` starts with a "Documentation" section listing all doc pages
- [ ] After deploy, check `https://llm-coding.github.io/Semantic-Anchors/sitemap.xml` and `…/llms.txt`
- [ ] Spot-check that claude.ai can now fetch `…/brownfield-experiment-report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Inhalte verfügbar

* **Dokumentation**
  * Neue Dokumentationssektion mit kuratierten Navigationslinks eingeführt
  * Cockburn Use Cases Anker mit detaillierter Beschreibung und Anwendungsrichtlinien hinzugefügt
  * Socratic Code Theory Recovery Workflow mit zweiphasiger Methodik dokumentiert
  * Semantic Anchors Katalog erweitert (137 Begriffe)
  * Verbesserte Spezifikationen für Semantic Contracts

* **Chores**
  * Website-Sitemap mit neuen Seiten aktualisiert

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/483)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->