### PR TITLE
fix(a11y): raise --color-text-secondary to gray-600 for WCAG AA contrast

### DIFF
--- a/website/src/components/footer.js
+++ b/website/src/components/footer.js
@@ -81,7 +81,7 @@ export function renderFooter(version) {
                 class="h-6 w-auto"
                 loading="lazy"
               />
-              <span class="text-xs text-[var(--color-text-secondary)]">HMZE <span class="opacity-60">(DE)</span></span>
+              <span class="text-xs text-[var(--color-text-secondary)]">HMZE (DE)</span>
             </a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
@@ -99,7 +99,7 @@ export function renderFooter(version) {
                 class="h-6 w-auto"
                 loading="lazy"
               />
-              <span class="text-xs text-[var(--color-text-secondary)]">rabauer.dev <span class="opacity-60">(EN)</span></span>
+              <span class="text-xs text-[var(--color-text-secondary)]">rabauer.dev (EN)</span>
             </a>
           </div>
         </div>

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -10,7 +10,8 @@
   --color-bg: #ffffff;
   --color-bg-secondary: #f3f4f6;
   --color-text: #1f2937;
-  --color-text-secondary: #6b7280;
+  /* gray-600, not gray-500: clears WCAG AA 4.5:1 on --color-bg-secondary */
+  --color-text-secondary: #4b5563;
   --color-border: #e5e7eb;
 }
 


### PR DESCRIPTION
Closes #492.

## Problem

The **Lighthouse CI** job has been red on every `main` run since 2026-05-14 (12+ runs). The homepage scored **0.97** on accessibility; the gate (`website/.lighthouserc.json`) requires **1.0**. The entire 0.97 came from the `color-contrast` audit.

## Fix

`--color-text-secondary` was gray-500 (`#6b7280`). On `--color-bg-secondary` (`#f3f4f6`) — the hero's "without semantic anchor" example card — that is ~4.1:1, below the WCAG AA 4.5:1 threshold. Raised to gray-600 (`#4b5563`), which clears 4.5:1 on both `--color-bg` and `--color-bg-secondary`. Dark mode already passed and is unchanged.

Also dropped `opacity-60` from the footer's "(DE)" / "(EN)" language tags, which pushed those spans below the threshold regardless of the token.

Verified locally with the exact CI setup (desktop preset, Lighthouse 12.6.1): **accessibility 1.0**, `color-contrast` passes, 90 unit tests green.

## Out of scope

The `label-content-name-mismatch` audit still flags the anchor cards, but it carries **weight 0** in Lighthouse's accessibility score and does not affect the gate. Its root cause is the card's `role="button"` wrapping nested interactive elements (copy/edit buttons) — an architectural fix that deserves its own PR rather than being bundled here.

## Test plan

- [ ] Lighthouse CI job passes (accessibility = 1.0)
- [ ] Hero "without" example text and footer language tags are still legible, now at AA contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Diese Version enthält Verbesserungen der Benutzeroberfläche und der Barrierefreiheit. Die Farbkontraste wurden angepasst um die Lesbarkeit zu erhöhen, und die Sprachkennzeichnungen in der Fußzeile wurden vereinfacht dargestellt.

* **Bug Fixes**
  * Erhöhte Farbkontraste für bessere Lesbarkeit

* **Style**
  * Vereinfachte Sprachkennzeichen in der Fußzeile

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->