### PR TITLE
feat: add Luhmann, Simon, and Systemic Consulting anchors (Tier 3)

### DIFF
--- a/docs/anchors/luhmann-system-theory.adoc
+++ b/docs/anchors/luhmann-system-theory.adoc
@@ -1,0 +1,58 @@
+= Luhmann's System Theory
+:categories: meta, problem-solving
+:roles: consultant, software-architect, team-lead, educator, systems-thinker
+:related: simon-constructivism, systemic-consulting
+:proponents: Niklas Luhmann, Dirk Baecker
+:tags: systems-theory, autopoiesis, operational-closure, structural-coupling, system-environment, double-contingency
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Luhmann's Sociological System Theory (Luhmannsche Systemtheorie)
+
+Also known as:: Theory of Autopoietic Social Systems, Functional-Structural Systems Theory
+
+[discrete]
+== *Core Concepts*:
+
+System/Environment Difference:: A system defines itself by drawing a distinction (*Differenz*) between itself and its environment. "Es gibt kein System ohne Umwelt. Hier ist das System, dort die Umwelt. Wer das sagt, unterscheidet zwischen diesen beiden." (Luhmann, *Einführung in die Systemtheorie*, Kap. II)
+
+Operational Closure:: Systems reproduce themselves through their own operations. Social systems operate through communication, psychic systems through thought. No operation crosses the boundary. "Selbstreferentielle Geschlossenheit ist nur in einer Umwelt, ist nur unter ökologischen Bedingungen möglich."
+
+Autopoiesis:: Systems produce and reproduce their own elements. A system exists as long as operations connect to operations. "Ein System erhält sich dadurch, dass Operationen aneinander anschließen."
+
+Structural Coupling:: Systems cannot directly interact, but they can build expectation structures that make them sensitive to specific irritations from their environment. Language couples psychic and social systems.
+
+Double Contingency:: The foundational paradox of social interaction: "I will do what you want if you do what I want" — resolved only through the emergence of social systems. "Das gesamte Soziale kann als Antwort auf das Problem der doppelten Kontingenz gesehen werden." (*Soziale Systeme*, Kap. IV)
+
+Self-Reference / Self-Observation:: Systems observe themselves by distinguishing self-reference from external reference (*Fremdreferenz*). "Beobachten heißt: unterscheiden (-> differenzieren)."
+
+Communication as Operation:: Social systems consist of communication, not of people. Communication is the synthesis of information, utterance, and understanding.
+
+Complexity Reduction:: Systems reduce environmental complexity through selection. "Sinn" (meaning) is the medium through which psychic and social systems process complexity.
+
+Functional Differentiation:: Modern society differentiates into function systems (economy, law, politics, science, religion) each with their own binary code.
+
+Key Proponents:: Niklas Luhmann (*Soziale Systeme*, 1984; *Einführung in die Systemtheorie*, Vorlesung 1991/92, hg. v. Dirk Baecker), Humberto Maturana (autopoiesis, biological roots)
+
+[discrete]
+== *When to Use*:
+
+* Analyzing complex socio-technical systems where boundaries are contested
+* Designing system architectures that respect operational closure of subsystems
+* Understanding why direct control often fails (systems can only be perturbed, not instructed)
+* Modeling emergent behavior in multi-agent or organizational systems
+* Identifying feedback loops and unintended consequences in automation design
+* Distinguishing between the system's perspective and the observer's perspective
+
+[discrete]
+== *Relationship to Other Anchors*:
+
+* Foundation for the System-Theoretic Semantic Anchors framework (see separate proposal)
+* Complements <<cynefin-framework,Cynefin Framework>> (complexity classification) with operational theory
+* Provides the theoretical basis for Semantic Contracts (structural coupling, see separate proposal)
+* Contrasts with simpler input-output models of systems (e.g., early cybernetics)
+* Related to <<feynman-technique,Feynman Technique>> at the meta-level: Luhmann demands understanding systems through their own logic
+
+Historical Context:: Luhmann developed his theory across 30+ books and 500+ articles. The *Einführung in die Systemtheorie* is a transcribed lecture course from 1991/92 and is considered the most accessible entry point. His work fundamentally challenges common-sense notions of communication, causality, and control.
+====

--- a/docs/anchors/luhmann-system-theory.de.adoc
+++ b/docs/anchors/luhmann-system-theory.de.adoc
@@ -1,0 +1,57 @@
+= Luhmanns Systemtheorie
+:categories: meta, problem-solving
+:roles: consultant, software-architect, team-lead, educator, systems-thinker
+:related: simon-constructivism, systemic-consulting
+:proponents: Niklas Luhmann, Dirk Baecker
+:tags: systems-theory, autopoiesis, operational-closure, structural-coupling, system-environment, double-contingency
+:tier: 3
+
+[%collapsible]
+====
+Vollständiger Name:: Luhmannsche Systemtheorie
+
+Auch bekannt als:: Theorie autopoietischer sozialer Systeme, funktional-strukturelle Systemtheorie
+
+[discrete]
+== *Kernkonzepte*:
+
+System/Umwelt-Differenz:: Ein System definiert sich durch die Unterscheidung (*Differenz*) zwischen sich selbst und seiner Umwelt. "Es gibt kein System ohne Umwelt. Hier ist das System, dort die Umwelt. Wer das sagt, unterscheidet zwischen diesen beiden." (Luhmann, *Einführung in die Systemtheorie*, Kap. II)
+
+Operative Geschlossenheit:: Systeme reproduzieren sich durch ihre eigenen Operationen. Soziale Systeme operieren durch Kommunikation, psychische Systeme durch Gedanken. Keine Operation überschreitet die Grenze. "Selbstreferentielle Geschlossenheit ist nur in einer Umwelt, ist nur unter ökologischen Bedingungen möglich."
+
+Autopoiesis:: Systeme erzeugen und reproduzieren ihre eigenen Elemente. Ein System existiert, solange Operationen an Operationen anschließen. "Ein System erhält sich dadurch, dass Operationen aneinander anschließen."
+
+Strukturelle Kopplung:: Systeme können nicht direkt interagieren, aber sie können Erwartungsstrukturen aufbauen, die sie für bestimmte Irritationen aus ihrer Umwelt sensitiv machen. Sprache koppelt psychische und soziale Systeme.
+
+Doppelte Kontingenz:: Die fundamentale Paradoxie sozialer Interaktion: "Ich tue, was du willst, wenn du tust, was ich will" — aufgelöst nur durch die Emergenz sozialer Systeme. "Das gesamte Soziale kann als Antwort auf das Problem der doppelten Kontingenz gesehen werden." (*Soziale Systeme*, Kap. IV)
+
+Selbstreferenz / Selbstbeobachtung:: Systeme beobachten sich selbst, indem sie Selbstreferenz von Fremdreferenz unterscheiden. "Beobachten heißt: unterscheiden (-> differenzieren)."
+
+Kommunikation als Operation:: Soziale Systeme bestehen aus Kommunikation, nicht aus Menschen. Kommunikation ist die Synthese von Information, Mitteilung und Verstehen.
+
+Komplexitätsreduktion:: Systeme reduzieren Umweltkomplexität durch Selektion. "Sinn" ist das Medium, durch das psychische und soziale Systeme Komplexität verarbeiten.
+
+Funktionale Differenzierung:: Die moderne Gesellschaft differenziert in Funktionssysteme (Wirtschaft, Recht, Politik, Wissenschaft, Religion) mit jeweils eigenem binärem Code.
+
+Schlüsselvertreter:: Niklas Luhmann (*Soziale Systeme*, 1984; *Einführung in die Systemtheorie*, Vorlesung 1991/92, hg. v. Dirk Baecker), Humberto Maturana (Autopoiesis, biologische Wurzeln)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Analyse komplexer sozio-technischer Systeme, in denen Grenzen umstritten sind
+* Entwurf von Systemarchitekturen, die die operative Geschlossenheit von Subsystemen respektieren
+* Verstehen, warum direkte Steuerung oft scheitert (Systeme können nur perturbiert, nicht instruiert werden)
+* Modellierung emergenten Verhaltens in Multi-Agenten- oder Organisationssystemen
+* Identifikation von Feedback-Schleifen und unbeabsichtigten Folgen in Automatisierungsdesigns
+* Unterscheidung zwischen der Perspektive des Systems und der Perspektive des Beobachters
+
+[discrete]
+== *Verhältnis zu anderen Ankern*:
+
+* Fundament für das System-Theoretische Semantische Anker Framework (siehe separater Vorschlag)
+* Ergänzt <<cynefin-framework,Cynefin Framework>> (Komplexitätsklassifikation) um operative Theorie
+* Liefert die theoretische Basis für Semantische Kontrakte (strukturelle Kopplung, siehe separater Vorschlag)
+* Kontrastiert mit einfacheren Input-Output-Modellen von Systemen (z. B. frühe Kybernetik)
+
+Historischer Kontext:: Luhmann entwickelte seine Theorie über 30+ Bücher und 500+ Artikel. Die *Einführung in die Systemtheorie* ist eine transkribierte Vorlesung aus dem WS 1991/92 und gilt als der zugänglichste Einstieg. Sein Werk hinterfragt grundlegend alltägliche Vorstellungen von Kommunikation, Kausalität und Kontrolle.
+====

--- a/docs/anchors/simon-constructivism.adoc
+++ b/docs/anchors/simon-constructivism.adoc
@@ -1,0 +1,62 @@
+= Simon's Constructivism
+:categories: meta, problem-solving
+:roles: consultant, educator, team-lead, systems-thinker
+:related: luhmann-system-theory, systemic-consulting
+:proponents: Fritz B. Simon, Humberto Maturana, Gregory Bateson
+:tags: constructivism, cybernetics, viability, perturbation, structural-determinism, circular-questions
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Simon's Introduction to System Theory and Constructivism
+
+Also known as:: Simon's Systemic Epistemology, Clinical Epistemology
+
+[discrete]
+== *Core Concepts*:
+
+Systemic Thinking = System-Theoretic Explanation:: "Systemtheorie beschäftigt sich mit der 'Welt der Objekte'; aber sie isoliert sie nicht aus ihren realen Zusammenhängen, sondern setzt sie in Beziehung zueinander." Systemisches Denken ist systemtheoretisches Erklären — nicht nur Beschreiben. (Simon, *Einführung in Systemtheorie und Konstruktivismus*, Vorbemerkung)
+
+Emergent Properties:: "Systeme sind aus mehreren Teilen zusammengesetzte Einheiten, deren Eigenschaften emergent, d.h. nicht durch die schlichte Addition der Eigenschaften ihrer Teile herstellbar waren." (Kap. 1)
+
+Trivial vs. Non-Trivial Machines:: Trivial machines are predictable (same input → same output). Non-trivial machines depend on internal state — they are history-dependent and not fully predictable. Social systems are non-trivial machines. (Kap. 3.1)
+
+Cybernetics of Cybernetics (2nd Order):: The observer is always part of the observed system. "Die Kybernetik der Kybernetik — der Beobachter wird in die Beobachtung einbezogen." (Kap. 3.2)
+
+Viability vs. Truth:: "Wahrheit vs. Viabilität — Die 'Passung' zwischen Landschaft und Landkarte." Knowledge is not "true" in an absolute sense, but viable if it enables successful operation in a given environment. (Kap. 4.5)
+
+Information as "Differences that Make a Difference":: (Gregory Bateson) Information is not transmitted but created by the receiver. "Unterschiede, die Unterschiede machen." The Sender-Receiver model is replaced by circular causality. (Kap. 4.1)
+
+Beobachtung = Unterscheiden und Bezeichnen:: Every observation draws a distinction and names one side. The other side remains unmarked. (Kap. 4.3, following George Spencer-Brown)
+
+Operational Closure:: "Systeme sind operativ geschlossen und können nur nach ihrer eigenen Logik operieren." (Kap. 3.4)
+
+Perturbation vs. Instruction:: "Systeme können nicht instruiert, nur irritiert (perturbiert) werden." — A crucial principle for any intervention design. (Kap. 3.5)
+
+Structural Coupling + Co-Evolution:: Systems shape each other's environments over time, leading to coordinated structural drift without direct causality. (Kap. 5.1)
+
+Meaning Dimensions (Social, Factual, Temporal):: Every communication (in Luhmann's sense) operates simultaneously in three dimensions: social (who), factual (what), temporal (when). (Kap. 6.4, following Luhmann)
+
+Key Proponents:: Fritz B. Simon (*Einführung in Systemtheorie und Konstruktivismus*, 2006, 8. Aufl. 2017), Humberto Maturana (autopoiesis), Gregory Bateson (cybernetics), Heinz von Foerster (constructivism), Ernst von Glasersfeld (radical constructivism)
+
+[discrete]
+== *When to Use*:
+
+* Training teams in systemic thinking for complex problem-solving
+* Designing interventions where direct control is impossible (organizations, families, ecosystems)
+* Understanding why the same input produces different results in human systems
+* Developing feedback-aware designs for socio-technical systems
+* Distinguishing between explanation, description, and evaluation in requirements
+* Building awareness of observer bias in system design and analysis
+
+[discrete]
+== *Relationship to Other Anchors*:
+
+* Pedagogical bridge between <<luhmann-system-theory,Luhmann's System Theory>> and practical application
+* Theoretical foundation for <<systemic-consulting,Systemic Consulting>> methods
+* Provides the epistemological basis for the System-Theoretic Semantic Anchors framework (see separate proposal)
+* "Ten Commandments of Systemic Thinking" (Kap. 7) are a direct precursor to Semantic Contracts (see separate proposal)
+* Contrasts with purely technical systems theory (e.g., general systems theory, Bertalanffy)
+
+Quote:: "Regeln kann man leichter verändern als Menschen." (Fritz B. Simon)
+====

--- a/docs/anchors/simon-constructivism.de.adoc
+++ b/docs/anchors/simon-constructivism.de.adoc
@@ -1,0 +1,62 @@
+= Simons Konstruktivismus
+:categories: meta, problem-solving
+:roles: consultant, educator, team-lead, systems-thinker
+:related: luhmann-system-theory, systemic-consulting
+:proponents: Fritz B. Simon, Humberto Maturana, Gregory Bateson
+:tags: constructivism, cybernetics, viability, perturbation, structural-determinism, circular-questions
+:tier: 3
+
+[%collapsible]
+====
+Vollständiger Name:: Simons Einführung in Systemtheorie und Konstruktivismus
+
+Auch bekannt als:: Simons systemische Epistemologie, Klinische Epistemologie
+
+[discrete]
+== *Kernkonzepte*:
+
+Systemisches Denken = Systemtheoretisches Erklären:: "Systemtheorie beschäftigt sich mit der 'Welt der Objekte'; aber sie isoliert sie nicht aus ihren realen Zusammenhängen, sondern setzt sie in Beziehung zueinander." Systemisches Denken ist systemtheoretisches Erklären — nicht nur Beschreiben. (Simon, *Einführung in Systemtheorie und Konstruktivismus*, Vorbemerkung)
+
+Emergente Eigenschaften:: "Systeme sind aus mehreren Teilen zusammengesetzte Einheiten, deren Eigenschaften emergent, d.h. nicht durch die schlichte Addition der Eigenschaften ihrer Teile herstellbar waren." (Kap. 1)
+
+Triviale vs. nichttriviale Maschinen:: Triviale Maschinen sind vorhersagbar (gleicher Input → gleicher Output). Nichttriviale Maschinen hängen vom inneren Zustand ab — sie sind geschichtsabhängig und nicht vollständig vorhersagbar. Soziale Systeme sind nichttriviale Maschinen. (Kap. 3.1)
+
+Kybernetik der Kybernetik (2. Ordnung):: Der Beobachter ist immer Teil des beobachteten Systems. "Die Kybernetik der Kybernetik — der Beobachter wird in die Beobachtung einbezogen." (Kap. 3.2)
+
+Viabilität vs. Wahrheit:: "Wahrheit vs. Viabilität — Die 'Passung' zwischen Landschaft und Landkarte." Wissen ist nicht "wahr" im absoluten Sinne, sondern viabel, wenn es erfolgreiches Operieren in einer gegebenen Umwelt ermöglicht. (Kap. 4.5)
+
+Information als "Unterschiede, die Unterschiede machen":: (Gregory Bateson) Information wird nicht übertragen, sondern vom Empfänger erzeugt. "Unterschiede, die Unterschiede machen." Das Sender-Empfänger-Modell wird durch zirkuläre Kausalität ersetzt. (Kap. 4.1)
+
+Beobachtung = Unterscheiden und Bezeichnen:: Jede Beobachtung zieht eine Unterscheidung und benennt eine Seite. Die andere Seite bleibt unbezeichnet. (Kap. 4.3, nach George Spencer-Brown)
+
+Operationale Schließung:: "Systeme sind operativ geschlossen und können nur nach ihrer eigenen Logik operieren." (Kap. 3.4)
+
+Perturbation vs. Instruktion:: "Systeme können nicht instruiert, nur irritiert (perturbiert) werden." — Ein zentrales Prinzip für jedes Interventionsdesign. (Kap. 3.5)
+
+Strukturelle Kopplung + Koevolution:: Systeme prägen gegenseitig ihre Umwelten über Zeit, was zu koordinierter struktureller Drift ohne direkte Kausalität führt. (Kap. 5.1)
+
+Sinndimensionen (Sozial-, Sach-, Zeitdimension):: Jede Kommunikation (im Luhmannschen Sinne) operiert gleichzeitig in drei Dimensionen: sozial (wer), sachlich (was), zeitlich (wann). (Kap. 6.4, nach Luhmann)
+
+Schlüsselvertreter:: Fritz B. Simon (*Einführung in Systemtheorie und Konstruktivismus*, 2006, 8. Aufl. 2017), Humberto Maturana (Autopoiesis), Gregory Bateson (Kybernetik), Heinz von Foerster (Konstruktivismus), Ernst von Glasersfeld (Radikaler Konstruktivismus)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Schulung von Teams in systemischem Denken für komplexe Problemlösungen
+* Entwurf von Interventionen, wo direkte Steuerung unmöglich ist (Organisationen, Familien, Ökosysteme)
+* Verstehen, warum gleicher Input in menschlichen Systemen zu unterschiedlichen Ergebnissen führt
+* Entwicklung feedback-bewusster Designs für sozio-technische Systeme
+* Unterscheidung zwischen Beschreiben, Erklären und Bewerten in Anforderungsdefinitionen
+* Aufbau von Bewusstsein für Beobachter-Bias in Systemdesign und -analyse
+
+[discrete]
+== *Verhältnis zu anderen Ankern*:
+
+* Pädagogische Brücke zwischen <<luhmann-system-theory,Luhmanns Systemtheorie>> und praktischer Anwendung
+* Theoretische Grundlage für <<systemic-consulting,Systemische Beratung>>-Methoden
+* Liefert die erkenntnistheoretische Basis für das System-Theoretische Semantische Anker Framework (siehe separater Vorschlag)
+* "Zehn Gebote des systemischen Denkens" (Kap. 7) sind ein direkter Vorläufer von Semantischen Kontrakten (siehe separater Vorschlag)
+* Kontrastiert mit rein technischer Systemtheorie (z. B. allgemeine Systemtheorie, Bertalanffy)
+
+Zitat:: "Regeln kann man leichter verändern als Menschen." (Fritz B. Simon)
+====

--- a/docs/anchors/systemic-consulting.adoc
+++ b/docs/anchors/systemic-consulting.adoc
@@ -1,0 +1,58 @@
+= Systemic Consulting (Heidelberg School)
+:categories: problem-solving, dialogue-interaction
+:roles: consultant, team-lead, educator, systems-thinker
+:related: simon-constructivism, luhmann-system-theory
+:proponents: Fritz B. Simon, Helm Stierlin, Gunthard Weber, Gregory Bateson, Paul Watzlawick
+:tags: systemic-consulting, circular-questions, neutrality, all-partiality, perturbation, intervention, heidelberg-school
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Systemic Consulting according to the Heidelberg School
+
+Also known as:: Systemische Beratung, Systemic Therapy and Consulting, Heidelberg Model
+
+[discrete]
+== *Core Concepts*:
+
+Consulting as Communication:: "Was all diese Beratungsansätze miteinander verbindet: Es sind Formen der Kommunikation." (Simon, *Einführung in die (System-)Theorie der Beratung*, 2014) — The consulting process is analyzed through the lens of communication theory.
+
+All-Partiality (Allparteilichkeit):: The consultant takes no side but is partial to *all* sides simultaneously. "Rollenklärung des Therapeuten sowie Allparteilichkeit und das Prinzip der Neutralität." (Simon/Rech-Simon, *Zirkuläres Fragen*)
+
+Neutrality:: The consultant remains neutral toward persons, toward the problem, and toward change. Not cold distance, but active multiperspectivity.
+
+Circular Questions:: Instead of linear cause-effect questions ("Why did X happen?"), circular questions explore relationships, differences, and feedback loops: "What would Y say about X's behavior?" "What needs to happen for the pattern to change?" "Zirkuläres Fragen zielt darauf, die gegenseitige Bedingtheit des Verhaltens von Menschen zu verdeutlichen."
+
+Context Clarification:: "Die Kontextklärung für Therapeuten ist immer klarer als für Patienten." — Before any intervention, the context must be clarified: who referred, what are the expectations, what is the mandate?
+
+Problem as Emergent Pattern:: Problems arise from relational patterns, not from individual deficiencies. Changing the pattern changes the problem.
+
+No Instruction, Only Irritation:: The consultant cannot dictate changes (systems are operatively closed) but can offer perturbations that the system may or may not integrate.
+
+Reframing / Positive Connotation:: Every behavior that appears dysfunctional is reframed as having a positive function for the system. "Which adaptive function does the status quo serve?"
+
+Hypothesizing:: Before meeting a client, the team generates hypotheses about the system's dynamics. Hypotheses are treated as provisional and falsifiable.
+
+Systemic Interview Structure:: Clarify referral context → define goals → explore attempted solutions → identify resources → hypothesize patterns → offer intervention.
+
+Key Proponents:: Fritz B. Simon (*Einführung in die (System-)Theorie der Beratung*, 2014), Helm Stierlin, Gunthard Weber (Heidelberg School), Paul Watzlawick, Jay Haley, John Weakland (MRI Palo Alto), Mara Selvini Palazzoli (Milan Group)
+
+[discrete]
+== *When to Use*:
+
+* Facilitating organizational change where linear approaches have failed
+* Mediating conflicts between stakeholders with incompatible perspectives
+* Designing human-centered automation that respects user autonomy
+* Coaching teams through complex adaptive challenges
+* Any situation where the interventionist is part of the system (no external vantage point)
+* Evaluating whether a proposed technical solution addresses relational dynamics
+
+[discrete]
+== *Relationship to Other Anchors*:
+
+* Operationalizes <<simon-constructivism,Simon's Constructivism>> into concrete practice
+* Provides the "how" for the System-Theoretic Semantic Anchors framework (especially Stakeholder and Trust anchors, see separate proposal)
+* Direct precursor to Semantic Contracts — the consulting mandate functions as a semantic contract between consultant and client (see separate proposal)
+* Complements <<cynefin-framework,Cynefin Framework>> by providing intervention methods for the Complex domain
+* Contrasts with expert-driven consulting (which assumes instruction is possible)
+====

--- a/docs/anchors/systemic-consulting.de.adoc
+++ b/docs/anchors/systemic-consulting.de.adoc
@@ -1,0 +1,58 @@
+= Systemische Beratung (Heidelberger Schule)
+:categories: problem-solving, dialogue-interaction
+:roles: consultant, team-lead, educator, systems-thinker
+:related: simon-constructivism, luhmann-system-theory
+:proponents: Fritz B. Simon, Helm Stierlin, Gunthard Weber, Gregory Bateson, Paul Watzlawick
+:tags: systemic-consulting, circular-questions, neutrality, all-partiality, perturbation, intervention, heidelberg-school
+:tier: 3
+
+[%collapsible]
+====
+Vollständiger Name:: Systemische Beratung nach der Heidelberger Schule
+
+Auch bekannt als:: Systemische Therapie und Beratung, Heidelberger Modell
+
+[discrete]
+== *Kernkonzepte*:
+
+Beratung als Kommunikation:: "Was all diese Beratungsansätze miteinander verbindet: Es sind Formen der Kommunikation." (Simon, *Einführung in die (System-)Theorie der Beratung*, 2014) — Der Beratungsprozess wird durch die Linse der Kommunikationstheorie analysiert.
+
+Allparteilichkeit:: Der Berater ergreift keine Partei, ist aber *allen* Seiten gleichzeitig zugewandt. "Rollenklärung des Therapeuten sowie Allparteilichkeit und das Prinzip der Neutralität." (Simon/Rech-Simon, *Zirkuläres Fragen*)
+
+Neutralität:: Der Berater bleibt neutral gegenüber Personen, gegenüber dem Problem und gegenüber Veränderung. Nicht kalte Distanz, sondern aktive Multiperspektivität.
+
+Zirkuläre Fragen:: Statt linearer Ursache-Wirkungs-Fragen ("Warum ist X passiert?") erkunden zirkuläre Fragen Beziehungen, Unterschiede und Feedback-Schleifen: "Was würde Y über Xs Verhalten sagen?" "Was müsste passieren, damit sich das Muster ändert?" "Zirkuläres Fragen zielt darauf, die gegenseitige Bedingtheit des Verhaltens von Menschen zu verdeutlichen."
+
+Kontextklärung:: "Die Kontextklärung für Therapeuten ist immer klarer als für Patienten." — Vor jeder Intervention muss der Kontext geklärt werden: wer hat überwiesen, welche Erwartungen gibt es, was ist der Auftrag?
+
+Problem als emergentes Muster:: Probleme entstehen aus Beziehungsmustern, nicht aus individuellen Defiziten. Das Muster zu ändern, ändert das Problem.
+
+Keine Instruktion, nur Irritation:: Der Berater kann Veränderungen nicht vorschreiben (Systeme sind operativ geschlossen), aber er kann Perturbationen anbieten, die das System integrieren kann oder nicht.
+
+Reframing / Positive Konnotation:: Jedes Verhalten, das dysfunktional erscheint, wird als potenziell funktional für das System umgedeutet. "Welche adaptive Funktion erfüllt der Status Quo?"
+
+Hypothetisieren:: Vor dem Klientenkontakt generiert das Team Hypothesen über die Systemdynamik. Hypothesen werden als vorläufig und falsifizierbar behandelt.
+
+Systemischer Interviewverlauf:: Überweisungskontext klären → Ziele definieren → bisherige Lösungsversuche explorieren → Ressourcen identifizieren → Muster hypothesieren → Intervention anbieten.
+
+Schlüsselvertreter:: Fritz B. Simon (*Einführung in die (System-)Theorie der Beratung*, 2014), Helm Stierlin, Gunthard Weber (Heidelberger Schule), Paul Watzlawick, Jay Haley, John Weakland (MRI Palo Alto), Mara Selvini Palazzoli (Mailänder Gruppe)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Begleitung organisationaler Veränderung, wenn lineare Ansätze gescheitert sind
+* Mediation von Konflikten zwischen Stakeholdern mit inkompatiblen Perspektiven
+* Gestaltung menschenzentrierter Automatisierung, die Nutzerautonomie respektiert
+* Coaching von Teams durch komplexe adaptive Herausforderungen
+* Jede Situation, in der der Interventionist Teil des Systems ist (kein externer Standpunkt)
+* Bewertung, ob eine vorgeschlagene technische Lösung relationale Dynamiken adressiert
+
+[discrete]
+== *Verhältnis zu anderen Ankern*:
+
+* Operationalisiert <<simon-constructivism,Simons Konstruktivismus>> in konkrete Praxis
+* Liefert das "Wie" für das System-Theoretische Semantische Anker Framework (insbesondere Stakeholder- und Vertrauensanker, siehe separater Vorschlag)
+* Direkter Vorläufer von Semantischen Kontrakten — der Beratungsauftrag fungiert als semantischer Kontrakt zwischen Berater und Klient (siehe separater Vorschlag)
+* Ergänzt <<cynefin-framework,Cynefin Framework>> um Interventionsmethoden für die komplexe Domäne
+* Kontrastiert mit expertengesteuerter Beratung (die Instruktion für möglich hält)
+====


### PR DESCRIPTION
Three system-theoretic method anchors with bilingual EN/DE versions, split from #514 as requested.

## Anchors

| Anchor | Description |
|--------|-------------|
| `luhmann-system-theory` | Sociological System Theory (autopoiesis, operational closure, structural coupling, double contingency) |
| `simon-constructivism` | Introduction to System Theory and Constructivism (viability, perturbation, non-trivial machines, 2nd order cybernetics) |
| `systemic-consulting` | Heidelberg School (all-partiality, circular questions, neutrality, reframing, context clarification) |

## Fixes from CodeRabbit review on #514

- Fix typo: `Viabilitiy` → `Viability`
- Fix stray U+27E9 characters after `<<...>>` links
- Remove forward references to anchors not yet in catalog (`system-theoretic-semantic-anchors`, `semantic-contract`) — replaced with plaintext notes pointing to separate proposals

## What's NOT in this PR (deferred per maintainer feedback)

- `system-theoretic-semantic-anchors` + `semantic-contract` → separate issue (naming collision + framing discussion)
- `docs/meta/enriching-existing-anchors.adoc` → separate issue (taxonomy change)
- `docs/examples/*-enriched.adoc` → dropped (shadow copies)
- `systems-thinker` role → separate issue (after this lands)

Ref: #514 (original PR with full discussion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Neue Dokumentationen zu drei theoretischen Ansätzen hinzugefügt: Luhmanns Systemtheorie, Simons Konstruktivismus und Systemische Beratung (Heidelberger Schule).
  * Jedes Thema wurde strukturiert mit Kernkonzepten, praktischen Anwendungshinweisen und Beziehungen zu anderen konzeptionellen Ankern dokumentiert.
  * Vollständige Inhalte in Englisch und Deutsch verfügbar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->