### PR TITLE
Add "Star on GitHub" link to the main intro link row

### DIFF
--- a/website/src/components/main-content.js
+++ b/website/src/components/main-content.js
@@ -96,6 +96,19 @@ export function renderMain() {
             </a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
+              href="https://github.com/LLM-Coding/Semantic-Anchors"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+              data-i18n="main.starGithub"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
+              </svg>
+              ${i18n.t('main.starGithub')}
+            </a>
+            <span class="text-gray-300 dark:text-gray-600">|</span>
+            <a
               href="#filters"
               class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline ml-auto"
               data-i18n="hero.skipToCatalog"

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -70,6 +70,7 @@
   "hero.skipToCatalog": "Zum Katalog ↓",
   "main.aboutLink": "Über",
   "main.proposeAnchor": "Neuen Anker vorschlagen",
+  "main.starGithub": "Stern auf GitHub",
   "main.documentation": "Dokumentation",
   "search.placeholder": "Anchors durchsuchen...",
   "search.fullText": "(Volltext)",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -70,6 +70,7 @@
   "hero.skipToCatalog": "Skip to catalog ↓",
   "main.aboutLink": "About",
   "main.proposeAnchor": "Propose New Anchor",
+  "main.starGithub": "Star on GitHub",
   "main.documentation": "Documentation",
   "search.placeholder": "Search anchors...",
   "search.fullText": "(full-text)",


### PR DESCRIPTION
## Summary

Adds a third link to the intro link row — `About | Propose New Anchor | Star on GitHub` — pointing to the GitHub repository, with a star icon. The link opens the repo in a new tab where visitors can star it.

Bilingual: `main.starGithub` added to both `en.json` ("Star on GitHub") and `de.json` ("Stern auf GitHub"). Styling reuses the existing sibling-link classes, so dark mode is handled identically.

## Test plan

- [x] Verified in the dev server — link renders in the row with star icon, correct order
- [ ] CI: lint + E2E + Lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Features

* "Star auf GitHub"-Link zur Hauptnavigation hinzugefügt, mit Icon und übersetztem Label
* Übersetzungsunterstützung für Deutsch und Englisch für das neue Navigationselement bereitgestellt

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->