### PR TITLE
Bump socratic-code-theory-recovery skill to 0.2 and plugin to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "semantic-anchors",
       "description": "Semantic anchor skills for translating established methodologies and installing persistent coding-agent context.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "LLM Coding",
         "url": "https://github.com/LLM-Coding"

--- a/plugins/semantic-anchors/plugin.json
+++ b/plugins/semantic-anchors/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-anchors",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Semantic anchor skills for translating terminology and installing persistent anchor context into coding agents.",
   "author": {
     "name": "LLM Coding",

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
@@ -3,7 +3,7 @@ name: socratic-code-theory-recovery
 description: Recover the "theory" (Naur 1985) of an existing codebase through recursive question refinement before writing documentation. Use on brownfield projects where the spec is missing — produces a Question Tree separating what is answerable from code (with evidence) from what must be asked of the team (routed by role). Phase 1 builds the tree; team answers the OPEN leaves; Phase 2 synthesizes PRD, Cockburn use cases, arc42 architecture, and Nygard ADRs from the answered tree.
 metadata:
   author: LLM-Coding
-  version: "0.1"
+  version: "0.2"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---

--- a/skill/socratic-code-theory-recovery/SKILL.md
+++ b/skill/socratic-code-theory-recovery/SKILL.md
@@ -3,7 +3,7 @@ name: socratic-code-theory-recovery
 description: Recover the "theory" (Naur 1985) of an existing codebase through recursive question refinement before writing documentation. Use on brownfield projects where the spec is missing — produces a Question Tree separating what is answerable from code (with evidence) from what must be asked of the team (routed by role). Phase 1 builds the tree; team answers the OPEN leaves; Phase 2 synthesizes PRD, Cockburn use cases, arc42 architecture, and Nygard ADRs from the answered tree.
 metadata:
   author: LLM-Coding
-  version: "0.1"
+  version: "0.2"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---


### PR DESCRIPTION
## Summary

The adaptive Question Tree depth and Q-ID wording fixes (#522, #524, merged in #525) changed the skill's behavior, but the version field was not bumped. This corrects that:

- `skill/socratic-code-theory-recovery/SKILL.md` — `0.1` → `0.2`
- `plugins/semantic-anchors/plugin.json` — `0.1.0` → `0.2.0`
- `.claude-plugin/marketplace.json` — `0.1.0` → `0.2.0`

The plugin bundles all Semantic Anchors skills; its content changed with #525, so it is brought to a consistent `0.2.0`. The synced plugin skill copy updates via the pre-commit hook.

## Test plan

- [x] `plugin.json` and `marketplace.json` validate as JSON
- [ ] CI: lint + E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionshinweise

* **Chores**
  * Versionsnummer auf 0.2.0 aktualisiert.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->