### PR TITLE
feat: add copy keyword button to cards and modal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,23 +139,29 @@ cd Semantic-Anchors
 
 ### Install Dependencies
 
+Both `website/` and `scripts/` have their own `package.json`. Install both:
+
 ```bash
-# Website dependencies
-cd website
+# Script dependencies (needed for anchor syncing and doc rendering)
+cd scripts
 npm install
 
-# Script dependencies
-cd ../scripts
+# Website dependencies
+cd ../website
 npm install
 ```
 
 ### Run Development Server
 
+Always use `npm run dev` (not `npx vite` directly). The `predev` hook syncs anchor `.adoc` files from `docs/anchors/` into `website/public/docs/anchors/`. Without this step, clicking anchor cards results in a 404 error.
+
 ```bash
 cd website
 npm run dev
-# → http://localhost:5173/
+# → http://localhost:5173/Semantic-Anchors/
 ```
+
+> **Note:** The dev server URL includes `/Semantic-Anchors/` because of the Vite `base` configuration. This matches the GitHub Pages deployment path.
 
 ### Run Tests
 
@@ -165,6 +171,8 @@ npm run test
 ```
 
 ### Build for Production
+
+The `prebuild` hook runs three steps automatically: syncing anchors, rendering docs, and rendering contracts. Then Vite builds the bundle and pre-renders static routes.
 
 ```bash
 cd website

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -33,7 +33,14 @@ export function createModal() {
   modal.innerHTML = `
     <div class="bg-[var(--color-bg)] rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col border border-[var(--color-border)]">
       <div class="flex items-center justify-between p-6 border-b border-[var(--color-border)]">
-        <h2 id="modal-title" class="text-2xl font-bold text-[var(--color-text)]"></h2>
+        <div class="flex items-center gap-2">
+          <h2 id="modal-title" class="text-2xl font-bold text-[var(--color-text)]"></h2>
+          <button id="modal-copy-keyword" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors p-1.5 rounded hover:bg-[var(--color-bg-secondary)]" data-i18n-aria="card.copyKeyword" aria-label="${i18n.t('card.copyKeyword')}">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
+            </svg>
+          </button>
+        </div>
         <div class="flex items-center gap-2">
           <button id="modal-share" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors p-2" data-i18n-aria="modal.share" aria-label="${i18n.t('modal.share')}">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -77,6 +84,15 @@ export function createModal() {
   // Close handlers
   const closeBtn = modal.querySelector('#modal-close')
   closeBtn.addEventListener('click', closeModal)
+
+  // Copy keyword handler
+  const copyKeywordBtn = modal.querySelector('#modal-copy-keyword')
+  copyKeywordBtn.addEventListener('click', () => {
+    const title = modal.querySelector('#modal-title').textContent
+    if (title) {
+      window.copyAnchorKeyword(title)
+    }
+  })
 
   // Share handler
   const shareBtn = modal.querySelector('#modal-share')

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -132,6 +132,17 @@ function renderAnchorCard(anchor, categoryColor, categoryId) {
         <h3 id="${cardTitleId}" class="anchor-card-title">${escapeHtml(anchor.title)}</h3>
         <div class="flex gap-1">
           <button
+            class="anchor-copy-keyword-btn"
+            title="${escapeHtml(i18n.t('card.copyKeyword'))}"
+            data-copy-keyword="${escapeHtml(anchor.title)}"
+            data-i18n-title="card.copyKeyword"
+            aria-label="${escapeHtml(i18n.t('card.copyKeyword'))}"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"></path>
+            </svg>
+          </button>
+          <button
             class="anchor-copy-link-btn"
             title="${escapeHtml(copyLinkTitle)}"
             data-copy-link="${safeId}"
@@ -247,6 +258,16 @@ export function initCardGrid() {
 
   // Click handler using event delegation
   clickHandler = (e) => {
+    if (e.target.closest('.anchor-copy-keyword-btn')) {
+      const button = e.target.closest('.anchor-copy-keyword-btn')
+      const keyword = button?.dataset.copyKeyword
+      if (keyword) {
+        e.stopPropagation()
+        window.copyAnchorKeyword(keyword)
+      }
+      return
+    }
+
     if (e.target.closest('.anchor-copy-link-btn')) {
       const button = e.target.closest('.anchor-copy-link-btn')
       const anchorId = button?.dataset.copyLink

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -40,6 +40,15 @@ window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   }
 }
 
+window.copyAnchorKeyword = async function copyAnchorKeyword(keyword) {
+  try {
+    await navigator.clipboard.writeText(keyword)
+    window.showToast(i18n.t('card.keywordCopied'))
+  } catch (err) {
+    console.error('Failed to copy keyword:', err)
+  }
+}
+
 window.showToast = function showToast(message) {
   const toast = document.createElement('div')
   toast.className =

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -145,7 +145,8 @@ body {
 }
 
 .anchor-edit-btn,
-.anchor-copy-link-btn {
+.anchor-copy-link-btn,
+.anchor-copy-keyword-btn {
   @apply flex-shrink-0 p-1 rounded;
   @apply text-gray-400 hover:text-blue-500;
   @apply hover:bg-gray-100 dark:hover:bg-gray-700;
@@ -154,7 +155,8 @@ body {
 }
 
 .anchor-edit-btn:hover,
-.anchor-copy-link-btn:hover {
+.anchor-copy-link-btn:hover,
+.anchor-copy-keyword-btn:hover {
   @apply scale-110;
 }
 
@@ -277,12 +279,14 @@ body {
 
   /* Make buttons more touch-friendly on mobile */
   .anchor-edit-btn,
-  .anchor-copy-link-btn {
+  .anchor-copy-link-btn,
+  .anchor-copy-keyword-btn {
     @apply p-2;
   }
 
   .anchor-edit-btn svg,
-  .anchor-copy-link-btn svg {
+  .anchor-copy-link-btn svg,
+  .anchor-copy-keyword-btn svg {
     @apply w-5 h-5;
   }
 

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -102,6 +102,8 @@
   "categories.strategic-planning": "Strategische Planung & Entscheidungsfindung",
   "categories.testing-quality": "Testing & Qualitätssicherung",
   "card.edit": "Auf GitHub bearbeiten",
+  "card.copyKeyword": "Schlüsselwort in Zwischenablage kopieren",
+  "card.keywordCopied": "Schlüsselwort kopiert!",
   "card.copyLink": "Link zu diesem Anker kopieren",
   "card.linkCopied": "Link kopiert!",
   "card.roles": "Rolle",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -102,6 +102,8 @@
   "categories.strategic-planning": "Strategic Planning & Decision Making",
   "categories.testing-quality": "Testing & Quality Practices",
   "card.edit": "Edit on GitHub",
+  "card.copyKeyword": "Copy keyword to clipboard",
+  "card.keywordCopied": "Keyword copied!",
   "card.copyLink": "Copy link to this anchor",
   "card.linkCopied": "Link copied!",
   "card.roles": "role",


### PR DESCRIPTION
## Summary

Add a clipboard button that copies the anchor keyword to the clipboard:

- **Card grid**: clipboard icon on each anchor card header (next to edit/link buttons)
- **Anchor modal**: clipboard icon directly beside the anchor title

Both trigger a toast notification on success.

## Changes

- `website/src/components/card-grid.js` — new copy-keyword button in card header
- `website/src/components/anchor-modal.js` — new copy-keyword button beside modal title
- `website/src/main.js` — `copyAnchorKeyword()` global function
- `website/src/styles/main.css` — styling for new button class
- `website/src/translations/en.json` / `de.json` — i18n keys
- `CONTRIBUTING.md` — clarify dev setup (predev hook, base URL, dual npm install)

## Testing

- All 90 unit tests pass
- Verified locally via `npm run dev` at `http://localhost:5173/Semantic-Anchors/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Features**
  * Neue „Schlüsselwort kopieren"-Schaltfläche zu Ankarkarten und Modal-Dialogen hinzugefügt.
  * Ankerschlüsselwörter können jetzt direkt in die Zwischenablage kopiert werden.
  * Toast-Benachrichtigung bestätigt erfolgreiche Kopieraktion.
  * Konsistentes Styling und mobile Optimierung für neue Schaltfläche.
  * Vollständige Lokalisierung für Englisch und Deutsch implementiert.

* **Dokumentation**
  * Entwicklungs- und Build-Setup-Anleitung aktualisiert.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLM-Coding/Semantic-Anchors/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->