### PR TITLE
fix(docs): readable admonition text in dark mode (#516)

### DIFF
--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -402,6 +402,15 @@ html {
   background: #1f2937;
 }
 
+/* The asciidoctor stylesheet hardcodes the admonition body text to
+   rgba(0,0,0,.6); on the dark admonition background that renders black-on-dark
+   and is unreadable. Override the content text and its light divider for dark
+   mode. (#516) */
+.dark .asciidoc-content .admonitionblock > table td.content {
+  color: var(--color-text);
+  border-left-color: #374151;
+}
+
 .dark .asciidoc-content hr {
   border-color: #374151;
 }


### PR DESCRIPTION
Fixes #516.

## Problem

On rendered AsciiDoc doc pages (e.g. **Spec-Driven Development**), admonition callouts show **black text on a dark panel** in dark mode — effectively unreadable. The asciidoctor stylesheet hardcodes the admonition body to `color: rgba(0, 0, 0, .6)`; the existing dark-mode override only set the block **background** to `#1f2937`, so the text stayed black (measured contrast ~1.1:1).

## Fix

Add a `.dark`-scoped rule overriding the admonition **content** text to `var(--color-text)` (and its light left divider to `#374151`). Dark-mode contrast goes to ~13:1. Light mode is untouched (the rule is `.dark`-scoped).

```css
.dark .asciidoc-content .admonitionblock > table td.content {
  color: var(--color-text);
  border-left-color: #374151;
}
```

## Verification

Built + previewed the Spec-Driven Development page in dark mode: the "Working on an existing codebase?" note body now renders near-white (`rgb(249,250,251)`) on the dark panel — measured via computed styles. The bold lead and inline text inherit the fix; links were already blue/visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bugfixes**
  * Verbesserte Darstellung von Warn- und Hinweisblöcken im Dark Mode für bessere Textlesbarkeit und konsistente visuelle Darstellung in Tabellen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->