### PR TITLE
fix(docs): visible admonition icons in dark mode

### DIFF
--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -411,6 +411,26 @@ html {
   border-left-color: #374151;
 }
 
+/* The asciidoctor stylesheet hardcodes dark admonition icon colors (note
+   #19407c, tip #111, important #bf0000, …) that nearly vanish on the dark
+   panel (contrast ~1.3-2.3:1, below the 3:1 needed for non-text). Lift each to
+   a light, semantic colour for dark mode. (#516 follow-up) */
+.dark .asciidoc-content .admonitionblock td.icon .icon-note::before {
+  color: #60a5fa;
+}
+.dark .asciidoc-content .admonitionblock td.icon .icon-tip::before {
+  color: #4ade80;
+}
+.dark .asciidoc-content .admonitionblock td.icon .icon-warning::before {
+  color: #fbbf24;
+}
+.dark .asciidoc-content .admonitionblock td.icon .icon-caution::before {
+  color: #fb923c;
+}
+.dark .asciidoc-content .admonitionblock td.icon .icon-important::before {
+  color: #f87171;
+}
+
 .dark .asciidoc-content hr {
   border-color: #374151;
 }


### PR DESCRIPTION
Follow-up to #516 / #550.

## Problem

After fixing the admonition *body text* in dark mode (#550), the **admonition icons** are still nearly invisible: the asciidoctor stylesheet hardcodes dark icon colours (note `#19407c`, tip `#111`, important `#bf0000`, warning/caution dark warm tones) that sit on the dark `#1f2937` panel. Measured contrast **1.3–2.3:1**, below the 3:1 WCAG threshold for non-text — the "i" note icon and the tip bulb in particular are barely there.

## Fix

`.dark`-scoped overrides lifting each icon to a light, semantic colour:

| Admonition | was | now | dark contrast |
|---|---|---|---|
| note ℹ | `#19407c` | `#60a5fa` blue | 1.44 → **5.77** |
| tip 💡 | `#111` | `#4ade80` green | 1.29 → **8.42** |
| important ❗ | `#bf0000` | `#f87171` red | 2.25 → **5.31** |
| warning ⚠ | `#bf6900` | `#fbbf24` amber | — |
| caution 🔥 | `#bf3400` | `#fb923c` orange | — |

Light mode unchanged (rules are `.dark`-scoped).

## Note on Lighthouse

The site's dark mode is a **class toggle** (`.dark` + localStorage), not `prefers-color-scheme`. Lighthouse / the CI audit only ever sees the default **light** theme, so it reports Accessibility 100 while these dark-mode contrast failures go undetected. Verified here by computing WCAG contrast directly in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Stil**
  * Die Sichtbarkeit der Admonition-Symbole (Hinweis, Tipp, Warnung, Vorsicht, Wichtig) wurde im Dark-Mode verbessert, um eine bessere Lesbarkeit auf dunklem Hintergrund zu gewährleisten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->