### PR TITLE
fix(docs): re-root relative image paths in rendered docs

### DIFF
--- a/website/src/components/doc-page.js
+++ b/website/src/components/doc-page.js
@@ -78,6 +78,18 @@ export async function loadDocContent(docPath) {
       link.setAttribute('rel', 'noopener noreferrer')
     })
 
+    // Re-root relative image paths. Rendered AsciiDoc emits paths like
+    // "docs/workflow-diagram.svg" relative to the document, but doc pages are
+    // served under clean URLs (e.g. /spec-driven-development/), so the browser
+    // resolves the relative path against the route and 404s. Prefix the site
+    // base so it points at the asset's real location. Absolute, protocol and
+    // data URLs are left untouched.
+    contentEl.querySelectorAll('img[src]').forEach((img) => {
+      const src = img.getAttribute('src')
+      if (!src || /^(https?:|data:|\/|#)/.test(src)) return
+      img.setAttribute('src', `${import.meta.env.BASE_URL}${src}`)
+    })
+
     // Attach click-to-load handlers for any YouTube placeholders in the doc.
     // Keeps us DSGVO-compliant: YouTube is only contacted after user consent.
     hydrateYouTubeFacades(contentEl)

--- a/website/src/components/doc-page.test.js
+++ b/website/src/components/doc-page.test.js
@@ -42,4 +42,22 @@ describe('doc-page', () => {
       'Failed to Load Documentation'
     )
   })
+
+  it('re-roots relative image paths to the site base, leaving absolute ones', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        '<h1>Spec</h1><img src="docs/workflow-diagram.svg" alt="d"><img src="https://x.test/a.png" alt="ext">',
+    })
+
+    await loadDocContent('docs/spec-driven-workflow.adoc')
+
+    const base = import.meta.env.BASE_URL
+    const rel = document.querySelector('#doc-content img[alt="d"]')
+    const ext = document.querySelector('#doc-content img[alt="ext"]')
+    // relative AsciiDoc image path must be re-rooted (clean-URL routes break it otherwise)
+    expect(rel.getAttribute('src')).toBe(`${base}docs/workflow-diagram.svg`)
+    // absolute/external sources are left untouched
+    expect(ext.getAttribute('src')).toBe('https://x.test/a.png')
+  })
 })


### PR DESCRIPTION
## Problem

The workflow diagram is missing on the **Spec-Driven Development** pages (EN + DE):
`https://llm-coding.github.io/Semantic-Anchors/spec-driven-development/docs/workflow-diagram.svg` → **404**.

The AsciiDoc source uses a relative image path (`image::docs/workflow-diagram.svg[...]`), which renders to `<img src="docs/workflow-diagram.svg">`. Doc pages are served under **clean URLs** (`/spec-driven-development/`), so the browser resolves the relative path against the route → `/spec-driven-development/docs/...` → 404. The asset actually lives at `/Semantic-Anchors/docs/workflow-diagram.svg` (HTTP 200).

## Fix

In `doc-page.js`, after injecting the rendered HTML, prefix **relative** `<img>` sources with the site base (`import.meta.env.BASE_URL`), matching the existing link/details post-processing. Absolute, `http(s):`, `data:` and `#` sources are left untouched. This fixes every doc-page image, not just this one.

## Tests

New unit test: relative `docs/workflow-diagram.svg` is re-rooted to `${BASE_URL}docs/workflow-diagram.svg`, while an external `https://…` src is left unchanged. All doc-page tests pass; lint + prettier clean.

## Verification (preview build)

Spec-Driven Development page: the diagram `<img>` now has `src="/Semantic-Anchors/docs/workflow-diagram.svg"`, `naturalWidth 1100`, fetch HTTP 200 — renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relative Bildpfade in geladenen Dokumenten werden nun korrekt mit der Basis-URL versehen, während absolute/externe und root-/Fragment‑Referenzen unverändert bleiben.

* **Tests**
  * Neuer Test zur Verifikation, dass relative Bilder umgerootet werden und externe/absolute Bild-URLs nicht verändert werden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->