### PR TITLE
docs: list YOLO on the Rejected Proposals page (#443)

### DIFF
--- a/docs/rejected-proposals.adoc
+++ b/docs/rejected-proposals.adoc
@@ -45,6 +45,11 @@ A real methodology but too specialized for reliable activation across different 
 | Not in training data
 | A real UX framework with defined methodology, but not widely enough documented for LLMs to reliably recognize it and activate the correct concepts.
 
+| *YOLO* (https://github.com/LLM-Coding/Semantic-Anchors/issues/443[#443])
+| Structurally unsuitable
+| Ambiguous and not a methodology: either "You Only Look Once" (a computer-vision model, too narrow) or the "You Only Live Once" motto (a pure sentiment, like TLDR). No consistent activation, no actionable structure. +
+The "rapid exploration / permission to bypass" idea raised in the thread is better expressed by composing existing anchors (link:#/anchor/spike-solution[Spike Solution], link:#/anchor/walking-skeleton[Walking Skeleton], link:#/anchor/mvp[MVP]) within the link:#/anchor/cynefin-framework[Cynefin] Complex/Chaotic domains.
+
 |===
 
 [TIP]

--- a/docs/rejected-proposals.de.adoc
+++ b/docs/rejected-proposals.de.adoc
@@ -45,6 +45,11 @@ Eine echte Methodik, aber zu spezialisiert für zuverlässige Aktivierung über 
 | Nicht in Trainingsdaten
 | Ein echtes UX-Framework mit definierter Methodik, aber nicht weit genug dokumentiert, damit LLMs es zuverlässig erkennen und die richtigen Konzepte aktivieren.
 
+| *YOLO* (https://github.com/LLM-Coding/Semantic-Anchors/issues/443[#443])
+| Strukturell ungeeignet
+| Mehrdeutig und keine Methodik: entweder „You Only Look Once" (ein Computer-Vision-Modell, zu eng) oder das Motto „You Only Live Once" (reines Sentiment, wie TLDR). Keine konsistente Aktivierung, keine umsetzbare Struktur. +
+Die im Thread genannte Idee „rapid exploration / permission to bypass" lässt sich besser durch Komposition bestehender Anker ausdrücken (link:#/anchor/spike-solution[Spike Solution], link:#/anchor/walking-skeleton[Walking Skeleton], link:#/anchor/mvp[MVP]) innerhalb der Complex-/Chaotic-Domänen des link:#/anchor/cynefin-framework[Cynefin-Frameworks].
+
 |===
 
 [TIP]


### PR DESCRIPTION
Records **YOLO** (#443) on the Rejected Proposals page (EN + DE).

Per the verification and the discussion in #443, YOLO fails the anchor quality criteria: it is ambiguous ("You Only Look Once" CV model vs. the "You Only Live Once" motto), not a methodology, and has no consistent activation — a counter-example in the same class as TLDR/ELI5.

The entry also points readers to the constructive path raised in the thread: the "rapid exploration / permission to bypass" intent is better expressed by composing existing anchors (Spike Solution, Walking Skeleton, MVP) within the Cynefin Complex/Chaotic domains, rather than as a new anchor.

Closes #443 once merged (and the issue can be closed as not planned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Die Dokumentation der abgelehnten Vorschläge wurde aktualisiert. Ein neuer Eintrag erklärt, warum der Proposal „YOLO" als strukturell ungeeignet klassifiziert wurde, und verweist auf alternative Ansätze innerhalb bestehender Frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->