### PR TITLE
feat(analytics): count anchor opens via card click + fix modal back-button

### DIFF
--- a/website/src/main.js
+++ b/website/src/main.js
@@ -368,7 +368,10 @@ function bindAnchorSelection() {
 
 function handleAnchorSelection(event) {
   const { anchorId } = event.detail
-  getAnchorModalModule().then(({ showAnchorDetails }) => showAnchorDetails(anchorId))
+  // Navigate to the anchor route instead of opening the modal directly: the
+  // URL then reflects the open anchor (deep-linkable, Back closes it), and the
+  // router records it as a pageview so we can see which anchors are opened.
+  navigate(`/anchor/${anchorId}`)
 }
 
 function initCardGridVisualization() {

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -159,6 +159,16 @@ function trackPageview() {
   }
 }
 
+// Close the anchor modal if it is open. Called when a non-anchor route is
+// resolved so the modal doesn't linger over the page after Back/forward or
+// in-app navigation. On a non-anchor route closeModal() does not touch the URL.
+function closeOpenAnchorModal() {
+  const modal = typeof document !== 'undefined' ? document.getElementById('anchor-modal') : null
+  if (modal && !modal.classList.contains('hidden')) {
+    import('../components/anchor-modal.js').then(({ closeModal }) => closeModal())
+  }
+}
+
 function handleRoute() {
   let path = getCurrentRoute()
 
@@ -201,6 +211,10 @@ function handleRoute() {
     })
     return
   }
+
+  // Leaving an anchor route: close any open anchor modal so Back/forward and
+  // in-app navigation don't leave it stranded as an overlay over the page.
+  closeOpenAnchorModal()
 
   const handler = routes.get(path)
 


### PR DESCRIPTION
## Why

Follow-up to #562. Opening an anchor by **clicking a card** — the most common interaction — was **not counted**: `handleAnchorSelection` called `showAnchorDetails()` directly without changing the route, so `handleRoute`/pageview tracking never ran. Only deep-links and in-modal cross-references were counted, making the per-anchor stats nearly empty.

## What

- **Card click now routes** through `navigate('/anchor/:id')`. The URL reflects the open anchor (deep-linkable, shareable, Back closes it) and the router records the pageview → **real per-anchor view counts**.
- **Fixes a latent bug** this would otherwise make the norm: leaving an anchor route (Back/forward or in-app navigation) left the modal stranded as an overlay over the page. `handleRoute` now closes an open anchor modal whenever a **non-anchor** route resolves (on a non-anchor route `closeModal()` doesn't touch the URL).

Privacy unchanged: path only, no query, no PII.

## Verification (preview, real card click)

Clicked the first catalog card (`4mat`):
- URL → `/Semantic-Anchors/anchor/4mat`, modal open
- GoatCounter counted `{ path: "/Semantic-Anchors/anchor/4mat", title: "4mat — Semantic Anchors" }`
- **Back** → URL `/Semantic-Anchors/`, **modal closed** (previously stayed open)

All 98 unit tests pass; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Ankerpunkte können jetzt direkt über URLs aufgerufen und verlinkt werden.
  * Verbesserte Navigation: Das Ankerfenster wird beim Wechsel zu anderen Seiten automatisch geschlossen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->