### PR TITLE
fix(analytics): attribute referrer to the entry page only

### DIFF
--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -155,7 +155,18 @@ function trackPageview() {
   }
   const gc = typeof window !== 'undefined' ? window.goatcounter : null
   if (gc && typeof gc.count === 'function') {
-    gc.count({ path: window.location.pathname, title: document.title })
+    gc.count({
+      path: window.location.pathname,
+      title: document.title,
+      // Report the referrer only on the initial load (handled by count.js).
+      // document.referrer is fixed for the whole SPA session, so without this
+      // every in-app view would be re-credited to the entry referrer (e.g.
+      // heise), inflating that referrer's page list. A callback returning ''
+      // drops the referrer for client-side navigations.
+      referrer: function () {
+        return ''
+      },
+    })
   }
 }
 


### PR DESCRIPTION
## Why

Follow-up to #562/#565. Now that in-app navigation is counted, the **referrer breakdown over-attributed** external sources: `document.referrer` stays fixed for the whole SPA session, so a single visitor arriving from **heise** and clicking through ~20 anchors made heise's referrer list show all 20 paths (mostly count 1) — even though heise only links 3-4 pages.

## What

Send the referrer **only on the initial load** (handled by `count.js`). Client-side route changes now pass a `referrer` callback returning `''`, so in-app anchor/page views carry no referrer. External referrers are credited to the **landing page only** — matching the intuitive "where did this visit come from" meaning.

(We may revisit "full journey" attribution later — it's a nice engagement signal — but entry-only is the expected default.)

## Verification (preview, GoatCounter `get_data`, faked `document.referrer = heise`)

- Landing vars → `r = "https://www.heise.de"` (entry credited to heise)
- SPA anchor view vars → `r = ""` (no referrer)

Router tests pass; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verfeinerte Seitenaufruf-Erfassung: Bei internen (Client-)Navigationen werden keine vorherigen Seiten mehr als Referrer weitergegeben, wodurch Analytics-Daten präziser sind. Der initiale Seitenaufruf wird weiterhin automatisch erfasst.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->