### PR TITLE
fix(modal): sub-anchor click closes the umbrella modal (E2E regression)

### DIFF
--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -289,12 +289,16 @@ export async function loadAnchorContent(anchorId) {
       details.setAttribute('open', '')
     })
 
-    // Convert internal AsciiDoc cross-reference links to router navigation
-    contentEl.querySelectorAll('a[href^="#"]').forEach((link) => {
+    // Convert internal AsciiDoc cross-reference links to router navigation.
+    // Exclude sub-anchor links (handled above) — they share the href="#" shape
+    // and would otherwise also fire navigate('/anchor/') with an empty id,
+    // which the router treats as a non-anchor route and closes the modal.
+    contentEl.querySelectorAll('a[href^="#"]:not([data-sub-anchor])').forEach((link) => {
       const href = link.getAttribute('href')
-      // Only process simple hash links (cross-references), not hash routes
+      // Only process real cross-references: a non-empty id, not a hash route.
       if (href && href.startsWith('#') && !href.startsWith('#/')) {
         const anchorId = href.substring(1) // Remove the '#'
+        if (!anchorId) return
         link.addEventListener('click', (e) => {
           e.preventDefault()
           // Navigate to the linked anchor


### PR DESCRIPTION
## Problem

`main`'s E2E suite is red: the *"Umbrella Anchors › navigate to sub-anchor / show back button"* tests fail because **clicking a sub-anchor inside an umbrella modal closes the whole modal**.

## Root cause (two bugs combine)

1. **Latent:** sub-anchor links render as `<a href="#" data-sub-anchor>`, which the AsciiDoc cross-reference handler (`a[href^="#"]`) *also* matched. A sub-anchor click thus fired both its own handler **and** a bogus `navigate('/anchor/')` (empty id).
2. **#565:** the modal now closes when a non-anchor route resolves. `handleRoute` strips the trailing slash so `'/anchor/'` → `'/anchor'`, which is **not** an anchor route → `closeOpenAnchorModal()` closed the umbrella modal.

Before #565 the bogus navigation was harmless, so this only surfaced now.

## Fix

Exclude `[data-sub-anchor]` links from the cross-reference handler and ignore empty ids. Sub-anchor clicks now only load the sub-anchor; the modal and its back button stay put.

```js
contentEl.querySelectorAll('a[href^="#"]:not([data-sub-anchor])').forEach(...)
// + skip empty anchorId
```

## Verification

- Reproduced the exact failure, then confirmed the fix in a preview: after a sub-anchor click the URL stays `/anchor/gof-design-patterns`, the modal stays open, the back button is visible.
- **Full E2E suite green locally (35/35)**, including the two tests that regressed. 98 unit tests pass; lint + prettier clean.

Priority: unblocks `main` (E2E currently failing) and the open analytics PR #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Verbesserte Behandlung von internen Anker-Links beim DOM-Scanning, um Konflikte mit separaten Sub-Anchor-Links zu vermeiden.
  * Verfeinerte Validierung von Anker-ID-Ausdrücken mit zusätzlichen Sicherheitsmechanismen gegen ungültige oder leere Werte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->