### PR TITLE
docs(sre): mirror DE anchor attributes + sync plugins catalog

### DIFF
--- a/docs/anchors/site-reliability-engineering.de.adoc
+++ b/docs/anchors/site-reliability-engineering.de.adoc
@@ -1,7 +1,11 @@
 = Site Reliability Engineering
 :categories: development-workflow
 :roles: devops-engineer, software-architect, team-lead, software-developer
+:related: five-whys, spc, control-chart-shewhart
 :proponents: Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
+:tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil
+:tier: 3
+
 [%collapsible]
 ====
 Vollständiger Name:: Site Reliability Engineering (SRE)

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -604,6 +604,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Kent Beck
 - **Core:** Time-boxed, disposable experiment written to answer one specific technical question before committing to an approach; output is a decision, not a deliverable; deliberately rough quality — no tests, no review, no polish; time-boxing is mandatory or the spike becomes speculative development
 
+### Site Reliability Engineering (SRE)
+- **Also known as:** Operations as a software problem, Google SRE
+- **Proponents:** Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
+- **Core:** Apply software engineering to operations; SLI/SLO/SLA; error budgets balance reliability vs. feature velocity (100% is the wrong target); eliminate toil with ~50% ops cap; blameless postmortems; four golden signals (latency, traffic, errors, saturation); release & capacity engineering
+
 ## Statistical Methods
 
 ### SPC (Statistical Process Control)


### PR DESCRIPTION
Small consistency follow-up to #561 (Site Reliability Engineering).

## Changes

1. **German anchor attribute parity** — `site-reliability-engineering.de.adoc` carried only `:categories:`, `:roles:`, `:proponents:`; mirrored `:related:`, `:tags:`, `:tier:` (and the blank line before the collapsible block) from the English file so the EN/DE headers match the rest of the catalog. Functionally a no-op (metadata is derived from the English `.adoc`), purely source consistency.
2. **Plugins catalog sync** — the pre-commit hook synced the SRE entry into `plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md`. #561 added the SRE entry to `skill/.../catalog.md` but the `plugins/` mirror wasn't synced (the hook wasn't run on that commit), leaving the two copies drifted. This brings them back in sync.

No metadata regeneration needed. Rendered the DE file with asciidoctor (valid) and confirmed EN/DE attribute headers are now identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dokumentation**
  * Umfassende Dokumentation zu Site Reliability Engineering (SRE) hinzugefügt mit Erklärungen zu Kern-Prinzipien einschließlich SLI/SLO/SLA, Error Budgets, Toil-Reduktion und blameless Postmortems.
  * Dokumentations-Metadaten erweitert für verbesserte Auffindbarkeit und Kategorisierung von SRE-Inhalten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->