### PR TITLE
docs: add LLM activation test field to proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-anchor.yml
+++ b/.github/ISSUE_TEMPLATE/propose-anchor.yml
@@ -57,6 +57,20 @@ body:
     validations:
       required: false
 
+  - type: textarea
+    id: activation-test
+    attributes:
+      label: LLM Activation Test Result
+      description: |
+        Paste the LLM's response to: "What concepts do you associate with '<your term>'?"
+        This front-loads the Precise/Rich/Consistent signal for reviewers.
+      placeholder: |
+        Model: [e.g., Claude, GPT-4, Gemini]
+        Prompt: "What concepts do you associate with '<term>'?"
+        Response: ...
+    validations:
+      required: true
+
   - type: checkboxes
     id: checklist
     attributes:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -117,6 +117,7 @@ Click the btn:[Propose New Anchor] button on the https://raifdmueller.github.io/
 *All you need to provide:*
 
 * The term or concept name
+* An LLM activation test result (required)
 * (Optional) Why you think it would be valuable
 
 === Step 2: Copilot Validation

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -56,6 +56,8 @@ Before proposing, test the anchor with this prompt in an LLM:
 What concepts do you associate with '<your semantic anchor name>'?
 ----
 
+NOTE: The proposal template includes a required *LLM Activation Test Result* field. Paste your test output there — it front-loads the Precise/Rich/Consistent signal for reviewers.
+
 Evaluate the response:
 
 * *Recognition:* Does the LLM recognize the term?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ Can be traced to key proponents, publications, or documented standards.
 What concepts do you associate with '<your anchor name>'?
 ```
 
+> **Note:** The proposal template includes a required **LLM Activation Test Result** field. Paste your test output there — it front-loads the Precise/Rich/Consistent signal for reviewers.
+
 ### Evaluate the Response
 
 Ask yourself:

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -74,6 +74,7 @@ Klicken Sie auf die btn:[Neuen Anker vorschlagen] Schaltfläche auf der https://
 *Alles, was Sie angeben müssen:*
 
 * Der Begriff oder Konzeptname
+* Ein LLM-Aktivierungstestergebnis (Pflichtfeld)
 * (Optional) Warum Sie denken, dass es wertvoll wäre
 
 === Schritt 2: Copilot-Validierung

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -54,6 +54,8 @@ Bevor Sie einen Vorschlag machen, testen Sie den Anker mit diesem Prompt in eine
 Welche Konzepte verbindest du mit '<Name Ihres semantischen Ankers>'?
 ----
 
+NOTE: Die Vorlagsvorlage enthält ein Pflichtfeld *LLM Activation Test Result*. Fügen Sie dort Ihre Testausgabe ein — es liefert Reviewern vorab das Precise/Rich/Consistent-Signal.
+
 Bewerten Sie die Antwort:
 
 * *Erkennung:* Erkennt das LLM den Begriff?


### PR DESCRIPTION
## Summary

Implements Part 1 of the phased approach agreed upon in #563.

### Changes

- **`.github/ISSUE_TEMPLATE/propose-anchor.yml`**: New required field *LLM Activation Test Result* — proposers must paste the LLM's response to the activation prompt before submitting.
- **`CONTRIBUTING.adoc` / `.md` / `docs/CONTRIBUTING.de.adoc`**: Added a NOTE referencing the new required field in the testing section.

### What was NOT included (by design)

Part 2 (`evaluations/specs/<id>.yaml` as merge gate) remains phased per Ralf's recommendation — tracked via `needs-eval-spec` label, not a hard block for community PRs.

### Tested

- YAML lint: template passes validation.
- EN + DE documentation updated consistently.

Closes #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Das Issue-Template zur Einreichung von Semantic Anchor Proposals wurde um ein erforderliches Feld zur Dokumentation von LLM-Aktivierungstestergebnissen erweitert, um die Proposal-Qualität zu verbessern.
  * Alle Beitragsrichtlinien wurden in mehreren Formaten und Sprachen aktualisiert und dokumentieren das neue erforderliche Vorlagenleifeld sowie dessen sachgemäße Anwendung.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->