### PR TITLE
feat: add AIDA Model anchor

### DIFF
--- a/docs/anchors/aida-model.adoc
+++ b/docs/anchors/aida-model.adoc
@@ -1,0 +1,52 @@
+= AIDA Model
+:categories: communication-presentation
+:roles: technical-writer, product-owner, consultant, ux-designer
+:related: inverted-pyramid-style, pyramid-principle, bluf
+:proponents: E. St. Elmo Lewis
+:tags: aida, marketing-funnel, copywriting, persuasion, advertising, conversion, attention-interest-desire-action
+
+[%collapsible]
+====
+Full Name:: Attention, Interest, Desire, Action
+
+Also known as:: AIDA Funnel, Hierarchy of Effects (AIDA branch); variants: AIDAS (+Satisfaction), AIDCA / AIDCAS (+Conviction), AIDA-R (+Retention)
+
+[discrete]
+== *Core Concepts*:
+
+Attention:: First *capture awareness* — a headline, hook, or visual that makes the audience stop and notice. Nothing else works until this stage lands.
+
+Interest:: *Hold engagement* by making the message relevant — speak to the reader's problem, curiosity, or benefit so they keep reading.
+
+Desire:: *Create wanting* — turn "this is relevant" into "I want this" through benefits, proof, emotion, and addressing objections.
+
+Action:: *Prompt a single, clear next step* — the call to action (buy, sign up, reply). Without an explicit ask, the funnel leaks at the end.
+
+A sequential funnel:: The stages are ordered and narrowing — each filters the audience to the next. The model's value is forcing copy to do each job in turn rather than jumping to the ask.
+
+A hierarchy-of-effects model:: AIDA is the best-known member of a family of step-models describing how persuasion moves a person from unaware to converted; it is a heuristic, not a measured cognitive law.
+
+Key Proponents:: Commonly attributed to E. St. Elmo Lewis (1898), an American advertising advocate; popularised in 20th-century advertising and sales literature
+
+[discrete]
+== *When to Use*:
+
+* Structuring marketing copy, landing pages, ads, cold emails, or pitch openings
+* Reviewing a draft for a missing stage — most often a weak hook (Attention) or an absent call to action (Action)
+* LLM prompting for persuasive text: "Write this product announcement using the AIDA model"
+* Sequencing a sales conversation from hook to close
+
+[discrete]
+== *When NOT to Use*:
+
+* Informational or reference writing where persuasion is not the goal — use BLUF or the Inverted Pyramid instead
+* As a measured model of buyer psychology — it is a copywriting heuristic, not validated cognitive science
+* Long, relationship-based B2B sales, where multi-touch journeys outgrow a single linear funnel
+
+[discrete]
+== *Related Anchors*:
+
+* <<inverted-pyramid-style,Inverted Pyramid Style>> - News structure front-loads the full story; AIDA deliberately withholds the ask until Desire is built
+* <<pyramid-principle,Pyramid Principle>> - Logical top-down argument for clarity; AIDA is an emotional persuasion sequence for conversion
+* <<bluf,BLUF (Bottom Line Up Front)>> - Leads with the conclusion; the opposite move to AIDA, which earns the conclusion across four stages
+====

--- a/docs/anchors/aida-model.de.adoc
+++ b/docs/anchors/aida-model.de.adoc
@@ -1,0 +1,52 @@
+= AIDA Model
+:categories: communication-presentation
+:roles: technical-writer, product-owner, consultant, ux-designer
+:related: inverted-pyramid-style, pyramid-principle, bluf
+:proponents: E. St. Elmo Lewis
+:tags: aida, marketing-funnel, copywriting, persuasion, advertising, conversion, attention-interest-desire-action
+
+[%collapsible]
+====
+Vollständiger Name:: Attention, Interest, Desire, Action
+
+Auch bekannt als:: AIDA-Funnel, Hierarchy of Effects (AIDA-Zweig); Varianten: AIDAS (+Satisfaction), AIDCA / AIDCAS (+Conviction), AIDA-R (+Retention)
+
+[discrete]
+== *Kernkonzepte*:
+
+Attention:: Zuerst *Aufmerksamkeit gewinnen* — eine Headline, ein Hook oder ein Bild, das den Leser innehalten lässt. Vorher wirkt nichts anderes.
+
+Interest:: *Engagement halten*, indem die Botschaft relevant wird — das Problem, die Neugier oder den Nutzen des Lesers ansprechen, damit er weiterliest.
+
+Desire:: *Verlangen erzeugen* — aus „das ist relevant" ein „das will ich" machen, über Nutzen, Belege, Emotion und das Ausräumen von Einwänden.
+
+Action:: *Einen einzigen, klaren nächsten Schritt auslösen* — der Call to Action (kaufen, anmelden, antworten). Ohne expliziten Aufruf verliert der Funnel am Ende.
+
+Ein sequenzieller Funnel:: Die Stufen sind geordnet und verengen sich — jede filtert das Publikum zur nächsten. Der Wert des Modells liegt darin, den Text jede Aufgabe der Reihe nach erledigen zu lassen, statt direkt zum Aufruf zu springen.
+
+Ein Hierarchy-of-Effects-Modell:: AIDA ist das bekannteste Mitglied einer Familie von Stufenmodellen, die beschreiben, wie Überzeugung eine Person von „unbekannt" zu „konvertiert" führt; eine Heuristik, kein gemessenes kognitives Gesetz.
+
+Key Proponents:: Üblicherweise E. St. Elmo Lewis (1898) zugeschrieben, einem amerikanischen Werbe-Vordenker; popularisiert in der Werbe- und Vertriebsliteratur des 20. Jahrhunderts
+
+[discrete]
+== *Verwendung*:
+
+* Strukturierung von Marketing-Copy, Landingpages, Anzeigen, Cold E-Mails oder Pitch-Einstiegen
+* Review eines Entwurfs auf eine fehlende Stufe — meist ein schwacher Hook (Attention) oder ein fehlender Call to Action (Action)
+* LLM-Prompting für überzeugende Texte: „Schreibe diese Produktankündigung nach dem AIDA-Modell"
+* Ein Verkaufsgespräch vom Hook bis zum Abschluss sequenzieren
+
+[discrete]
+== *Nicht verwenden*:
+
+* Informations- oder Referenztexte, bei denen Überzeugung nicht das Ziel ist — dann BLUF oder Inverted Pyramid nutzen
+* Als gemessenes Modell der Käuferpsychologie — es ist eine Copywriting-Heuristik, keine validierte Kognitionswissenschaft
+* Lange, beziehungsbasierte B2B-Verkäufe, deren Multi-Touch-Reisen einen einzelnen linearen Funnel sprengen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<inverted-pyramid-style,Inverted Pyramid Style>> - Die News-Struktur stellt die ganze Story nach vorn; AIDA hält den Aufruf bewusst zurück, bis Desire aufgebaut ist
+* <<pyramid-principle,Pyramid Principle>> - Logisches Top-down-Argument für Klarheit; AIDA ist eine emotionale Überzeugungssequenz für Conversion
+* <<bluf,BLUF (Bottom Line Up Front)>> - Beginnt mit dem Fazit; der Gegenzug zu AIDA, das das Fazit über vier Stufen erarbeitet
+====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -7,6 +7,7 @@ A chronological record of all semantic anchors added to the catalog. Community c
 *New anchors:*
 
 * *IOSP (Integration Operation Segregation Principle)* — a function shall either contain logic (Operation) or call other functions (Integration), but never both; the formal refinement of SRP at function level; separates integration (coordination/sequencing) from operation (business logic/computation); eliminates mock-heavy tests by avoiding new'ing in functions that contain logic; formally checkable via IospAnalyzer (Roslyn); reduces the need for Dependency Injection (DIP) at the function level (Ralf Westphal, 2022; Stefan Lieser, 2025; proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/556[#556])
+* *AIDA Model* — the classic copywriting/advertising funnel: Attention → Interest → Desire → Action; a sequential hierarchy-of-effects model that makes persuasive copy do each job in turn (hook, relevance, wanting, call to action) instead of jumping to the ask; pins the canonical four-stage form and notes variants (AIDAS, AIDCA, AIDA-R); fills the persuasion/copywriting gap in the communication cluster (commonly attributed to E. St. Elmo Lewis, 1898)
 
 *New contracts:*
 

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -269,6 +269,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Kent Beck, Robert C. Martin
 - **Core:** All statements inside a function should live at one abstraction level; mixing orchestration with mechanics is the main driver of unreadable code; refactor by extracting low-level details into named helpers so the outer function reads like a table of contents; formal expression of Beck's Composed Method pattern, codified as a Clean Code function-design rule by Martin
 
+### IOSP (Integration Operation Segregation Principle)
+- **Also known as:** IOSP, Ralf Westphal's IOSP
+- **Proponents:** Ralf Westphal, Stefan Lieser
+- **Core:** A function shall either contain logic (Operation) or call other functions (Integration), but never both; the formal refinement of SRP at function level; separates integration (coordination/sequencing) from operation (business logic/computation); eliminates mock-heavy tests by avoiding new'ing in functions that contain logic; formally checkable via IospAnalyzer (Roslyn); reduces the need for Dependency Injection (DIP) at the function level; narrows the Applicator/Alternator distinction in IODA Architecture
+
 ### Code Smells
 - **Also known as:** Bad Smells in Code, Refactoring Smells
 - **Proponents:** Kent Beck (coined term), Martin Fowler, Robert C. Martin
@@ -500,6 +505,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 ### BLUF (Bottom Line Up Front)
 - **Proponents:** US Military
 - **Core:** Lead with conclusion/recommendation, then details
+
+### AIDA Model
+- **Also known as:** AIDA Funnel; variants AIDAS (+Satisfaction), AIDCA (+Conviction), AIDA-R (+Retention)
+- **Proponents:** E. St. Elmo Lewis (1898)
+- **Core:** Copywriting/advertising funnel — Attention → Interest → Desire → Action; a sequential hierarchy-of-effects model that makes persuasive copy do each job in turn (hook, relevance, wanting, call to action); a heuristic, not measured cognitive science; for persuasion, not informational writing (use BLUF/Inverted Pyramid there)
 
 ### Pyramid Principle
 - **Proponents:** Barbara Minto

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -506,6 +506,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** US Military
 - **Core:** Lead with conclusion/recommendation, then details
 
+### AIDA Model
+- **Also known as:** AIDA Funnel; variants AIDAS (+Satisfaction), AIDCA (+Conviction), AIDA-R (+Retention)
+- **Proponents:** E. St. Elmo Lewis (1898)
+- **Core:** Copywriting/advertising funnel — Attention → Interest → Desire → Action; a sequential hierarchy-of-effects model that makes persuasive copy do each job in turn (hook, relevance, wanting, call to action); a heuristic, not measured cognitive science; for persuasion, not informational writing (use BLUF/Inverted Pyramid there)
+
 ### Pyramid Principle
 - **Proponents:** Barbara Minto
 - **Core:** Start with answer, group supporting arguments, logical order

--- a/website/public/data/anchors.json
+++ b/website/public/data/anchors.json
@@ -47,6 +47,37 @@
     "tier": 3
   },
   {
+    "id": "aida-model",
+    "title": "AIDA Model",
+    "categories": [
+      "communication-presentation"
+    ],
+    "roles": [
+      "technical-writer",
+      "product-owner",
+      "consultant",
+      "ux-designer"
+    ],
+    "related": [
+      "inverted-pyramid-style",
+      "pyramid-principle",
+      "bluf"
+    ],
+    "proponents": [
+      "E. St. Elmo Lewis"
+    ],
+    "tags": [
+      "aida",
+      "marketing-funnel",
+      "copywriting",
+      "persuasion",
+      "advertising",
+      "conversion",
+      "attention-interest-desire-action"
+    ],
+    "filePath": "docs/anchors/aida-model.adoc"
+  },
+  {
     "id": "arc42",
     "title": "arc42 Architecture Documentation",
     "categories": [
@@ -2270,6 +2301,44 @@
     ],
     "filePath": "docs/anchors/invest.adoc",
     "tier": 3
+  },
+  {
+    "id": "iosp",
+    "title": "Integration Operation Segregation Principle (IOSP)",
+    "categories": [
+      "design-principles"
+    ],
+    "roles": [
+      "software-developer",
+      "software-architect",
+      "consultant",
+      "educator"
+    ],
+    "related": [
+      "single-level-of-abstraction-principle",
+      "solid-principles",
+      "solid-srp",
+      "cohesion-criteria",
+      "grasp",
+      "solid-dip",
+      "clean-architecture"
+    ],
+    "proponents": [
+      "Ralf Westphal",
+      "Stefan Lieser"
+    ],
+    "tags": [
+      "iosp",
+      "integration",
+      "operation",
+      "testability",
+      "flow-design",
+      "function-design",
+      "clean-code",
+      "functional-dependency"
+    ],
+    "filePath": "docs/anchors/iosp.adoc",
+    "tier": 2
   },
   {
     "id": "iso-25010",

--- a/website/public/data/categories.json
+++ b/website/public/data/categories.json
@@ -4,6 +4,7 @@
     "name": "Communication & Presentation",
     "anchors": [
       "4mat",
+      "aida-model",
       "blooms-taxonomy",
       "bluf",
       "gutes-deutsch-wolf-schneider",
@@ -62,6 +63,7 @@
       "gof-template-method-pattern",
       "gof-visitor-pattern",
       "grasp",
+      "iosp",
       "kiss-principle",
       "law-of-demeter",
       "postels-law",

--- a/website/public/data/metadata.json
+++ b/website/public/data/metadata.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-06-02T13:34:34.825Z",
+  "generatedAt": "2026-06-03T20:37:49.817Z",
   "version": "1.0.0",
   "counts": {
-    "anchors": 159,
+    "anchors": 161,
     "categories": 14,
     "roles": 14
   },
   "statistics": {
-    "averageRolesPerAnchor": "3.27",
+    "averageRolesPerAnchor": "3.28",
     "averageCategoriesPerAnchor": "1.06",
-    "anchorsWithTags": 119,
-    "anchorsWithRelated": 90
+    "anchorsWithTags": 121,
+    "anchorsWithRelated": 92
   }
 }

--- a/website/public/data/roles.json
+++ b/website/public/data/roles.json
@@ -42,6 +42,7 @@
     "name": "Consultant / Coach",
     "anchors": [
       "4mat",
+      "aida-model",
       "blooms-taxonomy",
       "bluf",
       "c4-diagrams",
@@ -66,6 +67,7 @@
       "hoshin-kanri",
       "iec-61508-sil-levels",
       "impact-mapping",
+      "iosp",
       "kishotenketsu",
       "kiss-principle",
       "kotter-8-step-change-model",
@@ -167,6 +169,7 @@
       "hemingway-bridge",
       "heros-journey",
       "inverted-pyramid-style",
+      "iosp",
       "kishotenketsu",
       "kiss-principle",
       "law-of-demeter",
@@ -197,6 +200,7 @@
     "id": "product-owner",
     "name": "Product Owner / Product Manager",
     "anchors": [
+      "aida-model",
       "atam",
       "bdd-given-when-then",
       "cockburn-use-cases",
@@ -330,6 +334,7 @@
       "grasp",
       "hexagonal-architecture",
       "iec-61508-sil-levels",
+      "iosp",
       "iso-25010",
       "kiss-principle",
       "lasr",
@@ -429,6 +434,7 @@
       "hexagonal-architecture",
       "iec-61508-sil-levels",
       "invest",
+      "iosp",
       "kiss-principle",
       "lasr",
       "law-of-demeter",
@@ -566,6 +572,7 @@
     "name": "Technical Writer / Documentation Specialist",
     "anchors": [
       "4mat",
+      "aida-model",
       "arc42",
       "blooms-taxonomy",
       "bluf",
@@ -594,6 +601,7 @@
     "id": "ux-designer",
     "name": "UX Designer / Researcher",
     "anchors": [
+      "aida-model",
       "bem-methodology",
       "double-diamond",
       "jobs-to-be-done",


### PR DESCRIPTION
Adds **AIDA Model** — Attention → Interest → Desire → Action — the classic copywriting/advertising funnel. Verified against the four quality criteria and the recognition test.

## Why it qualifies
- **Attributable:** commonly attributed to E. St. Elmo Lewis (1898), documented in advertising/sales literature.
- **Consistent:** strong recognition ("what concepts do you associate with AIDA?" → the four stages + marketing funnel).
- **Rich:** its weakest axis — a mnemonic more than a deep framework — but it activates the funnel/conversion/copywriting domain, comparable to existing thin-but-accepted anchors (BLUF, Inverted Pyramid). It fills a real gap: the communication cluster had structure/clarity anchors but nothing for **persuasion/copywriting**.
- **Precise:** titled `AIDA Model` to disambiguate from AIDA Cruises / Verdi's opera, and pins the canonical four-stage form while noting variants (AIDAS, AIDCA, AIDA-R) — same disambiguation discipline we used for Bloom's Revised Taxonomy.

## Changes
- `docs/anchors/aida-model.adoc` + `.de.adoc` (EN + DE)
- Regenerated `website/public/data/*.json` (additive — 160 → 161 anchors)
- `docs/changelog.adoc` — 2026-06-03 section
- `skill/.../catalog.md` (+ synced `plugins/` copy)

Category: Communication & Presentation. Related: Inverted Pyramid, Pyramid Principle, BLUF. Includes a *When NOT to Use* (informational writing, validated buyer psychology, long B2B journeys).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dokumentation**
  * Zwei neue Ankerpunkte zur Bibliothek hinzugefügt: AIDA Model (für Copywriting und Werbekommunikation) und IOSP (Design-Prinzipien)
  * Umfassende Dokumentation mit Kernkonzepten, Anwendungsfällen und Verweisen auf verwandte Modelle erweitert
  * Metadaten und Kategorisierungen aktualisiert; Rollen- und Kategorieverknüpfungen erweitert

<!-- end of auto-generated comment: release notes by coderabbit.ai -->