### PR TITLE
refactor(contract): split architecture-documentation into vocabulary contract + arc42-authoring skill

### DIFF
--- a/skill/arc42-authoring/SKILL.md
+++ b/skill/arc42-authoring/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: arc42-authoring
+description: Produce and maintain arc42 architecture documentation with cross-section traceability, structured quality scenarios, and decision–risk wiring. Use when scaffolding a new arc42 document, extending an existing one, or verifying traceability between chapters.
+metadata:
+  author: LLM-Coding
+  version: "0.1"
+  source: https://github.com/LLM-Coding/Semantic-Anchors
+license: MIT
+---
+
+# arc42 Authoring
+
+Procedural guidance for producing arc42 architecture documentation that goes beyond the template's built-in help text.
+
+## On invocation
+
+When this skill is invoked:
+
+1. **Check whether an arc42 document already exists.** Look for `src/docs/` or `docs/arc42/` in the project. If found, work incrementally — do not re-scaffold.
+
+2. **If no arc42 exists, scaffold first.** Use docToolchain `downloadTemplate` to create the "with-help" template into `src/docs/`. Each chapter's help text is its structural spec — fill and then replace it.
+
+3. **Apply the traceability rules** from [references/traceability-rules.md](references/traceability-rules.md) as you produce or review each chapter. These rules are the project's value-add over plain arc42.
+
+4. **For Chapter 10 quality scenarios**, use the six-part Quality Attribute Scenario format from [references/chapter-10-quality-scenarios.md](references/chapter-10-quality-scenarios.md).
+
+5. **For Chapter 11 Risks and Technical Debt**, follow [references/chapter-11-structure.md](references/chapter-11-structure.md).
+
+6. **For Chapter 8 Crosscutting Concepts**, follow [references/chapter-8-baseline.md](references/chapter-8-baseline.md).
+
+7. **For ADR–Risk wiring**, apply the rules in [references/adr-risk-wiring.md](references/adr-risk-wiring.md).
+
+## When to use this skill
+
+- Scaffolding a new arc42 document for a greenfield project
+- Extending an arc42 document after architecture decisions change
+- Reviewing arc42 documentation for completeness and cross-section traceability
+- Producing Chapter 10 quality scenarios in the six-part form
+- Structuring Chapter 11 with the Risks/Technical-Debt split
+
+## When NOT to use this skill
+
+- For reverse-engineering existing code into documentation — use `socratic-code-theory-recovery` instead (Phase 2 of that skill produces arc42 from an answered Question Tree)
+- For the vocabulary of what arc42, ADRs, C4, and QAS *are* — that is the `architecture-documentation` contract (always-on)

--- a/skill/arc42-authoring/references/adr-risk-wiring.md
+++ b/skill/arc42-authoring/references/adr-risk-wiring.md
@@ -1,0 +1,47 @@
+# ADR–Risk Wiring
+
+## Rule
+
+Each ADR's **Consequences** section names the risks the decision creates:
+
+- If the risk is already tracked in Chapter 11: reference its ID (e.g., "introduces R-003").
+- If the risk is new: either add it to Chapter 11 with a new R-NNN ID, or record the consequence as "explicitly accepted without a tracked risk" (for trivial consequences).
+
+## Inverse direction
+
+Conversely, Chapter 11 risks that are *caused by* a decision reference the ADR that introduced them.
+
+## Unconfirmed decisions
+
+When the rationale behind a decision is inferred (not confirmed by the team):
+
+- ADR Status: **"Accepted (inferred)"**
+- Pugh Matrix cells needing team judgment: marked `?` rather than guessed
+
+This preserves honesty — the documentation records what is known vs. what is assumed.
+
+## Scaffolding
+
+When creating a new ADR, use this template:
+
+```
+# ADR-NNN: <Title>
+
+## Status
+Accepted | Accepted (inferred) | Proposed | Superseded by ADR-NNN
+
+## Context
+<Why this decision is needed>
+
+## Decision
+<What was decided>
+
+## Pugh Matrix
+| Criterion | Option A | Option B (Baseline) | Option C |
+|-----------|----------|---------------------|----------|
+| ...       | +1       | 0                   | -1       |
+
+## Consequences
+- <Positive consequence>
+- <Negative consequence → R-NNN>
+```

--- a/skill/arc42-authoring/references/chapter-10-quality-scenarios.md
+++ b/skill/arc42-authoring/references/chapter-10-quality-scenarios.md
@@ -1,0 +1,28 @@
+# Chapter 10 — Quality Scenarios
+
+## Format: Six-Part Quality Attribute Scenario (Bass/Clements/Kazman)
+
+Every Chapter 10 quality scenario is written in this form:
+
+| Part | Description | Example |
+|------|-------------|---------|
+| **Source** | Who or what triggers the stimulus | End user, CI pipeline, attacker |
+| **Stimulus** | The event or condition | 1000 concurrent requests, node failure, SQL injection attempt |
+| **Artifact** | What is affected | Order Service, API Gateway, Database |
+| **Environment** | Under what conditions | Normal operation, peak load, degraded mode |
+| **Response** | What the system does | Queues excess requests, fails over, rejects input |
+| **Response Measure** | Literal, testable figure | p99 < 200ms, failover < 30s, zero data exposure |
+
+The **Response Measure** carries a literal figure, so the requirement is testable rather than an adjective ("fast", "secure", "available").
+
+## Chapter 1.2 vs. Chapter 10
+
+- **Chapter 1.2** lists only the top 3–5 quality goals — the ones that drive architecture decisions.
+- **Chapter 10** may elaborate further quality characteristics beyond those top goals.
+- Each Chapter 10 scenario is marked as either:
+  - **Concretising** a Chapter 1.2 top goal (cross-link which one), or
+  - **Derived** — a quality requirement that does not trace to a top goal but matters for the system.
+
+## Deriving scenarios from code
+
+When evidence exists in code (timeouts, budgets, SLOs, test thresholds), derive scenarios as `[ANSWERED]` with `file:line` evidence. Never invent target numbers — only the quality-goal *ranking* is a team decision.

--- a/skill/arc42-authoring/references/chapter-11-structure.md
+++ b/skill/arc42-authoring/references/chapter-11-structure.md
@@ -1,0 +1,36 @@
+# Chapter 11 — Risks and Technical Debt
+
+## Structure
+
+Chapter 11 separates into two subsections:
+
+### 11.1 Risks
+
+Each risk carries:
+
+| Column | Description |
+|--------|-------------|
+| **ID** | R-NNN (stable identifier for cross-referencing from ADRs) |
+| **Risk** | What could go wrong |
+| **Probability** | Low / Medium / High |
+| **Impact** | Low / Medium / High |
+| **Priority** | Derived from probability × impact |
+| **Mitigation** | Cross-reference to Chapter 8 concept or quality scenario that mitigates it |
+
+Risks are ordered by priority (highest first).
+
+### 11.2 Technical Debt
+
+Each debt item:
+
+| Column | Description |
+|--------|-------------|
+| **ID** | TD-NNN |
+| **Debt** | What the shortcut is |
+| **Building Block** | Cross-reference to specific Chapter 5 building block it burdens |
+| **Impact** | What happens if not addressed |
+| **Effort** | Estimated effort to resolve |
+
+## ADR ↔ Risk wiring
+
+See [adr-risk-wiring.md](adr-risk-wiring.md) for how ADR Consequences connect to Risk IDs.

--- a/skill/arc42-authoring/references/chapter-8-baseline.md
+++ b/skill/arc42-authoring/references/chapter-8-baseline.md
@@ -1,0 +1,21 @@
+# Chapter 8 — Crosscutting Concepts Baseline
+
+## Required baseline concepts
+
+arc42 leaves Chapter 8 open. This skill requires five baseline crosscutting concepts, in this order:
+
+| Section | Concept | Key rule |
+|---------|---------|----------|
+| 8.1 | **Threat Model** | STRIDE; threats get IDs (T-001…) |
+| 8.2 | **Security** | Every mitigation references the T-IDs it closes |
+| 8.3 | **Test** | Testing pyramid; tests trace to Use Cases and Business Rules |
+| 8.4 | **Observability** | Logs, metrics, traces, audit trails |
+| 8.5 | **Error Handling** | Retry, circuit breaker, fallback, recovery |
+
+## Extension rule
+
+Add further Chapter 8.x concepts (persistence, i18n, accessibility, configuration, performance) **only when the system actually has that concern**. Do not add empty sections.
+
+## Back-referencing
+
+Chapter 8 concepts back-reference the Chapter 9 ADR that decided them. If no ADR exists for a concept, either create one or note the concept as "established practice, no decision required."

--- a/skill/arc42-authoring/references/scaffolding.md
+++ b/skill/arc42-authoring/references/scaffolding.md
@@ -1,0 +1,19 @@
+# Scaffolding
+
+## Initial setup with docToolchain
+
+Scaffold the arc42 "with-help" template into the project's `src/docs/` directory:
+
+```bash
+docToolchain downloadTemplate
+```
+
+Each chapter's help text is its structural spec — fill and then replace the help text as the documentation matures.
+
+## Diagram conventions
+
+- **Format**: PlantUML, not Mermaid
+- **Building blocks**: C4 via PlantUML's bundled C4-PlantUML standard library
+- **Include form**: `!include <C4/...>` (angle brackets = stdlib), never the remote `https://` URL, never vendored file copies
+- **Style**: C4 containers and components, not generic boxes
+- **Coverage**: Every context, building-block, and runtime chapter carries at least one diagram

--- a/skill/arc42-authoring/references/traceability-rules.md
+++ b/skill/arc42-authoring/references/traceability-rules.md
@@ -1,0 +1,26 @@
+# Cross-Section Traceability Rules
+
+arc42 templates do not enforce these connections between chapters. This skill does.
+
+## The five rules
+
+1. **Quality Goal → Strategy**: Every Chapter 1.2 quality goal maps to a named approach in Chapter 4 (Solution Strategy).
+
+2. **Context ↔ Building Blocks**: The external systems in Chapter 3 (System Scope and Context) and the Chapter 5 Level-1 building-block view are the same set — one system boundary in both.
+
+3. **Building Block → Runtime**: Every Chapter 5 building block appears in at least one Chapter 6 runtime scenario. Chapter 6 includes at least one error/recovery scenario, not only the happy path.
+
+4. **ADR Index**: Chapter 9 carries an in-document ADR index (ADR | Title | Status), even when the ADRs live in a separate register.
+
+5. **Building Block Completeness**: Each Chapter 5 building block states responsibility, interface, and source location.
+
+## Verification checklist
+
+After producing or updating chapters, verify:
+
+- [ ] Every Chapter 1.2 goal appears by name in Chapter 4
+- [ ] Chapter 3 external systems = Chapter 5 Level-1 boundary elements
+- [ ] No Chapter 5 building block is absent from Chapter 6
+- [ ] Chapter 6 contains ≥1 error/recovery scenario
+- [ ] Chapter 9 index is up to date
+- [ ] Every Chapter 5 block has: responsibility, interface, source location

--- a/website/public/data/contracts.json
+++ b/website/public/data/contracts.json
@@ -5,7 +5,12 @@
     "titleDe": "Spezifikation",
     "description": "What we mean when we say 'spec'",
     "descriptionDe": "Was wir meinen, wenn wir 'Spec' sagen",
-    "anchors": ["cockburn-use-cases", "gherkin", "bdd-given-when-then", "ears-requirements"],
+    "anchors": [
+      "cockburn-use-cases",
+      "gherkin",
+      "bdd-given-when-then",
+      "ears-requirements"
+    ],
     "template": "When we talk about a \"specification\" or \"spec\", we mean:\n- Persona Use Cases in Cockburn's Fully Dressed format (Primary Actor, Trigger, Main Success Scenario, Extensions, Postconditions) at User Goal level, with Business Rules (BR-IDs)\n- System Use Cases for each technical interface (API endpoint, CLI command, event, file format): input/validation, processing, output/status codes, error responses\n- Activity Diagrams for all flows (not just the happy path)\n- Acceptance criteria in Gherkin format (Given/When/Then)\n- Individual requirements in EARS syntax where applicable (When/While/If/Shall)\n- Supplementary Specifications as needed: Entity Model, State Machines, Interface Contracts, Validation Rules",
     "templateDe": "Wenn wir von einer \"Spezifikation\" oder \"Spec\" sprechen, meinen wir:\n- Persona Use Cases im Cockburn Fully Dressed Format (Primary Actor, Trigger, Main Success Scenario, Extensions, Nachbedingungen) auf User-Goal-Ebene, mit Geschäftsregeln (BR-IDs)\n- System Use Cases für jede technische Schnittstelle (API-Endpunkt, CLI-Befehl, Event, Dateiformat): Input/Validierung, Verarbeitung, Output/Statuscodes, Fehlerantworten\n- Activity Diagrams für alle Abläufe (nicht nur der Happy Path)\n- Akzeptanzkriterien im Gherkin-Format (Given/When/Then)\n- Einzelanforderungen in EARS-Syntax wo passend (When/While/If/Shall)\n- Ergänzende Spezifikationen nach Bedarf: Entity Model, State Machines, Interface Contracts, Validierungsregeln",
     "category": "requirements"
@@ -16,7 +21,13 @@
     "titleDe": "Anforderungsermittlung",
     "description": "How we clarify requirements before writing specs",
     "descriptionDe": "Wie wir Anforderungen klären, bevor wir Specs schreiben",
-    "anchors": ["socratic-method", "mece", "prd", "impact-mapping", "user-story-mapping"],
+    "anchors": [
+      "socratic-method",
+      "mece",
+      "prd",
+      "impact-mapping",
+      "user-story-mapping"
+    ],
     "template": "Clarify requirements using the Socratic Method:\n- Ask at most 3 questions at a time, challenge assumptions\n- Use MECE to ensure questions cover all areas without overlap\n- Keep asking until you fully understand the requirements\n\nFrame the scope before writing it down:\n- Impact Mapping connects deliverables to business goals and actors — so you build what moves a goal, not just what was asked.\n- User Story Mapping lays stories along the user's journey and exposes a coherent first slice.\n\nDocument the result as a PRD (problem, goals, personas, success criteria, scope).",
     "templateDe": "Anforderungen mit der Sokratischen Methode klären:\n- Höchstens 3 Fragen gleichzeitig, Annahmen hinterfragen\n- MECE nutzen, um alle Bereiche überlappungsfrei abzudecken\n- Weiterfragen bis die Anforderungen vollständig verstanden sind\n\nDen Scope rahmen, bevor er aufgeschrieben wird:\n- Impact Mapping verbindet Lieferobjekte mit Geschäftszielen und Akteuren — damit man baut, was ein Ziel bewegt, nicht nur was gefragt wurde.\n- User Story Mapping ordnet Stories entlang der Nutzerreise an und legt eine sinnvolle erste Scheibe offen.\n\nDas Ergebnis als PRD dokumentieren (Problem, Ziele, Personas, Erfolgskriterien, Scope).",
     "category": "requirements"
@@ -27,20 +38,15 @@
     "titleDe": "Architekturdokumentation",
     "description": "How we document architecture with diagrams, ADRs, and decision evaluation",
     "descriptionDe": "Wie wir Architektur mit Diagrammen, ADRs und Entscheidungsbewertung dokumentieren",
-    "anchors": ["arc42", "c4-diagrams", "adr-according-to-nygard", "pugh-matrix", "quality-attribute-scenario"],
-    "template": "Architecture documentation follows arc42. Scaffold the arc42 \"with-help\" template into the project's `src/docs/` via docToolchain `downloadTemplate` rather than restating chapter structure here — each chapter's help text is its structural spec, which the process fills and then replaces.\n\nEvery context, building-block and runtime chapter carries at least one diagram. Diagrams are PlantUML, not Mermaid; building blocks use C4 via PlantUML's bundled C4-PlantUML standard library — the `!include <C4/...>` stdlib form (angle brackets), never the remote `https://` URL and never vendored file copies. Not generic boxes.\n\nDecisions are ADRs (Nygard) with a 3-point Pugh Matrix (-1/0/+1). When the rationale is unconfirmed, ADR Status is \"Accepted (inferred)\" and Pugh cells needing team judgment are marked `?` rather than guessed. Each ADR's Consequences name the risks the decision creates, referencing the Chapter 11 risk IDs (R-NNN); a decision that creates a risk not yet in Chapter 11 either adds it there or records the consequence as explicitly accepted without a tracked risk. Conversely, Chapter 8 concepts back-reference the ADR that decided them.\n\nCross-section traceability — arc42 templates do not enforce these, so the contract does:\n- Every Chapter 1.2 quality goal maps to a named approach in Chapter 4.\n- The external systems in Chapter 3 (context) and the Chapter 5 Level-1 building-block view are the same set — one system boundary in both.\n- Every Chapter 5 building block appears in at least one Chapter 6 runtime scenario; Chapter 6 includes at least one error/recovery scenario, not only the happy path.\n- Chapter 9 carries an in-document ADR index (ADR | Title | Status), even when the ADRs live in a separate register.\n- Each Chapter 5 building block states responsibility, interface, and source location.\n\nChapter 1.2 lists only the top 3-5 quality goals — the ones that drive architecture decisions. Chapter 10 may elaborate further quality characteristics beyond those top goals; that is correct arc42, not a defect. The Chapter 10 quality tree marks each characteristic as either concretising a Chapter 1.2 top goal or as a derived quality requirement, and each Chapter 10 quality scenario cross-links back to the Chapter 1.2 goal it concretises (or is marked \"derived\"). Each Chapter 10 scenario is written in the six-part quality attribute scenario form (Source, Stimulus, Artifact, Environment, Response, Response Measure); the Response Measure carries a literal figure, so the requirement is testable rather than an adjective.\n\nChapter 11 separates Risks from Technical Debt into two subsections. Each Risk carries probability, impact, a derived priority, and a mitigation/action cross-referencing an existing mitigation in Chapter 8 or a quality scenario where one exists; risks are ordered by priority. Each Technical Debt item references the specific Chapter 5 building block it burdens.",
-    "templateDe": "Architekturdokumentation folgt arc42. Das arc42-\"with-help\"-Template per docToolchain `downloadTemplate` in das `src/docs/`-Verzeichnis des Projekts scaffolden, statt die Kapitelstruktur hier zu wiederholen — der Hilfetext jedes Kapitels ist seine Struktur-Spezifikation, die der Prozess füllt und dann ersetzt.\n\nJedes Kontext-, Baustein- und Laufzeit-Kapitel enthält mindestens ein Diagramm. Diagramme sind PlantUML, nicht Mermaid; Bausteine als C4 über PlantUMLs gebündelte C4-PlantUML Standard Library — die `!include <C4/...>`-stdlib-Form (spitze Klammern), nie die Remote-`https://`-URL und nie ins Repo kopierte Dateien. Keine generischen Kästen.\n\nEntscheidungen sind ADRs (Nygard) mit einer 3-Punkt-Pugh-Matrix (-1/0/+1). Wenn die Begründung unbestätigt ist, lautet der ADR-Status \"Accepted (inferred)\", und Pugh-Zellen, die Team-Urteil erfordern, werden mit `?` markiert statt geraten. Die Consequences jedes ADR benennen die Risiken, die die Entscheidung erzeugt, mit Verweis auf die Risiko-IDs aus Kapitel 11 (R-NNN); erzeugt eine Entscheidung ein Risiko, das noch nicht in Kapitel 11 steht, wird es dort ergänzt oder die Konsequenz ausdrücklich als akzeptiert ohne verfolgtes Risiko vermerkt. Umgekehrt verweisen Kapitel-8-Konzepte zurück auf das ADR, das sie entschieden hat.\n\nQuerschnitts-Traceability — arc42-Templates erzwingen das nicht, der Contract tut es:\n- Jedes Qualitätsziel aus Kapitel 1.2 wird auf einen benannten Ansatz in Kapitel 4 abgebildet.\n- Die externen Systeme in Kapitel 3 (Kontext) und die Level-1-Bausteinsicht in Kapitel 5 sind dieselbe Menge — eine Systemgrenze in beiden.\n- Jeder Baustein aus Kapitel 5 erscheint in mindestens einem Laufzeitszenario in Kapitel 6; Kapitel 6 enthält mindestens ein Fehler-/Recovery-Szenario, nicht nur den Happy Path.\n- Kapitel 9 trägt ein dokumentinternes ADR-Verzeichnis (ADR | Titel | Status), auch wenn die ADRs in einem separaten Register liegen.\n- Jeder Baustein aus Kapitel 5 nennt Verantwortlichkeit, Schnittstelle und Quellort.\n\nKapitel 1.2 listet nur die obersten 3-5 Qualitätsziele — die, die Architekturentscheidungen treiben. Kapitel 10 darf weitere Qualitätsmerkmale über diese Top-Ziele hinaus ausführen; das ist korrektes arc42, kein Mangel. Der Qualitätsbaum in Kapitel 10 markiert jedes Merkmal entweder als Konkretisierung eines Kapitel-1.2-Top-Ziels oder als abgeleitete Qualitätsanforderung, und jedes Qualitätsszenario in Kapitel 10 verweist zurück auf das Kapitel-1.2-Ziel, das es konkretisiert (oder ist als \"abgeleitet\" markiert). Jedes Kapitel-10-Szenario wird in der sechsteiligen Quality-Attribute-Scenario-Form geschrieben (Source, Stimulus, Artifact, Environment, Response, Response Measure); das Response Measure trägt einen literalen Wert, sodass die Anforderung testbar ist statt ein Adjektiv.\n\nKapitel 11 trennt Risiken und technische Schuld in zwei Unterabschnitte. Jedes Risiko trägt Eintrittswahrscheinlichkeit, Auswirkung, eine abgeleitete Priorität und eine Mitigation/Maßnahme mit Verweis auf eine bestehende Mitigation in Kapitel 8 oder ein Qualitätsszenario, sofern vorhanden; Risiken sind nach Priorität geordnet. Jeder Posten technischer Schuld verweist auf den konkreten Baustein aus Kapitel 5, den er belastet.",
-    "category": "architecture"
-  },
-  {
-    "id": "crosscutting-concepts",
-    "title": "Crosscutting Concepts",
-    "titleDe": "Querschnittliche Konzepte",
-    "description": "Baseline arc42 Chapter 8 concepts every system documents: threat model, security, test, observability, error handling",
-    "descriptionDe": "Basis-Konzepte für arc42 Kapitel 8, die jedes System dokumentiert: Threat Model, Security, Test, Observability, Error Handling",
-    "anchors": ["arc42", "stride", "testing-pyramid"],
-    "template": "arc42 leaves Chapter 8 open. We require five baseline crosscutting concepts, in this order:\n\n- 8.1 Threat Model — STRIDE; threats get IDs (T-001…).\n- 8.2 Security — every mitigation references the T-IDs it closes.\n- 8.3 Test — testing pyramid; tests trace to Use Cases and Business Rules.\n- 8.4 Observability — logs, metrics, traces, audit trails.\n- 8.5 Error Handling — retry, circuit breaker, fallback, recovery.\n\nAdd further Chapter 8.x concepts (persistence, i18n, accessibility, configuration, performance) only when the system actually has that concern.",
-    "templateDe": "arc42 lässt Kapitel 8 offen. Wir verlangen fünf querschnittliche Basis-Konzepte, in dieser Reihenfolge:\n\n- 8.1 Threat Model — STRIDE; Bedrohungen erhalten IDs (T-001…).\n- 8.2 Security — jede Mitigation referenziert die T-IDs, die sie schließt.\n- 8.3 Test — Testpyramide; Tests verweisen auf Use Cases und Business Rules.\n- 8.4 Observability — Logs, Metriken, Traces, Audit-Trails.\n- 8.5 Error Handling — Retry, Circuit Breaker, Fallback, Recovery.\n\nWeitere Kapitel-8.x-Konzepte (Persistenz, i18n, Barrierefreiheit, Konfiguration, Performance) nur aufnehmen, wenn das System diesen Belang tatsächlich hat.",
+    "anchors": [
+      "arc42",
+      "c4-diagrams",
+      "adr-according-to-nygard",
+      "pugh-matrix",
+      "quality-attribute-scenario"
+    ],
+    "template": "Architecture documentation follows arc42. Diagrams are C4 via PlantUML's bundled C4-PlantUML stdlib (`!include <C4/...>`). Decisions are Nygard ADRs with a 3-point Pugh Matrix (-1/0/+1). Quality requirements are six-part Quality Attribute Scenarios (Bass/Clements/Kazman). For procedural detail — traceability rules, chapter structure, scaffolding — invoke the `arc42-authoring` skill.",
+    "templateDe": "Architekturdokumentation folgt arc42. Diagramme sind C4 über PlantUMLs gebundelte C4-PlantUML-Stdlib (`!include <C4/...>`). Entscheidungen sind Nygard-ADRs mit einer 3-Punkte Pugh-Matrix (-1/0/+1). Qualitätsanforderungen sind sechsteilige Quality Attribute Scenarios (Bass/Clements/Kazman). Für prozedurale Details — Traceability-Regeln, Kapitelstruktur, Scaffolding — den `arc42-authoring`-Skill aufrufen.",
     "category": "architecture"
   },
   {
@@ -66,7 +72,10 @@
     "titleDe": "Backlog-Verwaltung",
     "description": "How we create and prioritize implementation tasks",
     "descriptionDe": "Wie wir Implementierungsaufgaben erstellen und priorisieren",
-    "anchors": ["invest", "moscow"],
+    "anchors": [
+      "invest",
+      "moscow"
+    ],
     "template": "Create EPICs and User Stories as GitHub issues from the specification.\n- User Stories follow INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable)\n- Prioritize with MoSCoW (Must/Should/Could/Won't)\n- Mark dependencies between issues\n- Groom the backlog regularly as the project evolves",
     "templateDe": "EPICs und User Stories als GitHub Issues aus der Spezifikation erstellen.\n- User Stories folgen den INVEST-Kriterien (Independent, Negotiable, Valuable, Estimable, Small, Testable)\n- Priorisierung mit MoSCoW (Must/Should/Could/Won't)\n- Abhängigkeiten zwischen Issues markieren\n- Backlog regelmäßig groomen",
     "category": "development"
@@ -77,7 +86,12 @@
     "titleDe": "Vertikale Schnitte",
     "description": "How we build the first increment and grow the system in thin end-to-end slices",
     "descriptionDe": "Wie wir das erste Inkrement bauen und das System in dünnen End-to-End-Scheiben wachsen lassen",
-    "anchors": ["walking-skeleton", "tracer-bullet", "thin-vertical-slice", "spike-solution"],
+    "anchors": [
+      "walking-skeleton",
+      "tracer-bullet",
+      "thin-vertical-slice",
+      "spike-solution"
+    ],
     "template": "Build the first increment as a walking skeleton: a deployable end-to-end slice that wires every architectural layer together and does almost nothing else.\n\nGrow the system as thin vertical slices — each slice cuts through all layers and delivers one small piece of user value. Slices are tracer bullets: kept and refined, never thrown away.\n\nWhen a technical unknown blocks a slice, run a spike solution first — a timeboxed, throwaway experiment that removes the risk. Spike code is discarded; only its lesson carries into the slice.",
     "templateDe": "Das erste Inkrement als Walking Skeleton bauen: eine deploybare End-to-End-Scheibe, die alle Architekturschichten verbindet und sonst fast nichts tut.\n\nDas System in dünnen vertikalen Scheiben wachsen lassen — jede Scheibe geht durch alle Schichten und liefert ein kleines Stück Nutzerwert. Scheiben sind Tracer Bullets: behalten und verfeinert, nie weggeworfen.\n\nWenn ein technisches Unbekanntes eine Scheibe blockiert, zuerst eine Spike Solution durchführen — ein zeitlich begrenztes Wegwerf-Experiment, das das Risiko beseitigt. Spike-Code wird verworfen; nur seine Erkenntnis fließt in die Scheibe ein.",
     "category": "development"
@@ -104,7 +118,10 @@
     "titleDe": "Refactoring",
     "description": "How we identify and execute refactorings safely",
     "descriptionDe": "Wie wir Refactorings sicher identifizieren und durchführen",
-    "anchors": ["code-smells", "mikado-method"],
+    "anchors": [
+      "code-smells",
+      "mikado-method"
+    ],
     "template": "Refactoring targets are named code smells, not a vague urge to \"clean up\".\n\nFor any refactoring that does not complete in one step, use the Mikado Method: attempt the change, note what breaks, revert, and do the prerequisites first — never leave the build broken while you dig.\n\nRefactoring commits change structure only. Behaviour changes go in separate commits, and the test suite stays green at every commit.",
     "templateDe": "Refactoring-Ziele sind benannte Code Smells, kein vager Drang \"aufzuräumen\".\n\nFür jedes Refactoring, das nicht in einem Schritt fertig wird, die Mikado-Methode nutzen: die Änderung versuchen, notieren was bricht, zurücksetzen und zuerst die Voraussetzungen erledigen — den Build nie kaputt lassen, während man gräbt.\n\nRefactoring-Commits ändern nur Struktur. Verhaltensänderungen kommen in separate Commits, und die Testsuite bleibt bei jedem Commit grün.",
     "category": "development"
@@ -115,7 +132,12 @@
     "titleDe": "Code-Qualität",
     "description": "Coding conventions and design principles",
     "descriptionDe": "Coding-Konventionen und Design-Prinzipien",
-    "anchors": ["solid-principles", "dry", "kiss-principle", "domain-driven-design"],
+    "anchors": [
+      "solid-principles",
+      "dry",
+      "kiss-principle",
+      "domain-driven-design"
+    ],
     "template": "Our code follows:\n- SOLID principles\n- DRY, KISS\n- Ubiquitous Language from Domain-Driven Design (same terms in code as in the specification)",
     "templateDe": "Unser Code folgt:\n- SOLID-Prinzipien\n- DRY, KISS\n- Ubiquitous Language aus Domain-Driven Design (gleiche Begriffe im Code wie in der Spezifikation)",
     "category": "development"
@@ -126,7 +148,11 @@
     "titleDe": "Qualitätsprüfung",
     "description": "How we review code and check for security issues",
     "descriptionDe": "Wie wir Code reviewen und Sicherheitsprobleme prüfen",
-    "anchors": ["fagan-inspection", "owasp-top-10", "atam"],
+    "anchors": [
+      "fagan-inspection",
+      "owasp-top-10",
+      "atam"
+    ],
     "template": "Quality assurance follows three layers:\n- Code review using Fagan Inspection (structured, systematic, with defined phases)\n- Security review based on OWASP Top 10\n- Architecture review using ATAM (scenario-based tradeoff analysis against quality goals)\n- Use a different AI model or fresh session for reviews to avoid blind spots",
     "templateDe": "Qualitätssicherung folgt drei Schichten:\n- Code-Review mit Fagan Inspection (strukturiert, systematisch, mit definierten Phasen)\n- Security-Review basierend auf OWASP Top 10\n- Architektur-Review mit ATAM (szenariobasierte Tradeoff-Analyse gegen Qualitätsziele)\n- Anderes KI-Modell oder frische Session für Reviews nutzen, um blinde Flecken zu vermeiden",
     "category": "quality"
@@ -137,7 +163,11 @@
     "titleDe": "Docs-as-Code",
     "description": "How we write and build documentation",
     "descriptionDe": "Wie wir Dokumentation schreiben und bauen",
-    "anchors": ["docs-as-code", "plain-english-strunk-white", "gutes-deutsch-wolf-schneider"],
+    "anchors": [
+      "docs-as-code",
+      "plain-english-strunk-white",
+      "gutes-deutsch-wolf-schneider"
+    ],
     "template": "Documentation follows Docs-as-Code according to Ralf D. Müller:\n- AsciiDoc as format, PlantUML for inline diagrams, built by docToolchain\n- Version-controlled, peer-reviewed, and built automatically\n- Plain English according to Strunk & White (or Gutes Deutsch nach Wolf Schneider)\n- Projects following this contract include the `dtcw` wrapper and `docToolchainConfig.groovy` so PlantUML / AsciiDoc actually render.",
     "templateDe": "Dokumentation folgt Docs-as-Code nach Ralf D. Müller:\n- AsciiDoc als Format, PlantUML für Inline-Diagramme, gebaut von docToolchain\n- Versioniert, reviewt und automatisch gebaut\n- Gutes Deutsch nach Wolf Schneider (oder Plain English nach Strunk & White)\n- Projekte, die diesem Contract folgen, enthalten den `dtcw`-Wrapper und `docToolchainConfig.groovy`, damit PlantUML / AsciiDoc tatsächlich gerendert werden.",
     "category": "documentation"
@@ -165,7 +195,10 @@
     "titleDe": "Knappe Antwort (TLDR)",
     "description": "How responses should be structured for brevity",
     "descriptionDe": "Wie Antworten für Kürze strukturiert sein sollen",
-    "anchors": ["bluf", "plain-english-strunk-white"],
+    "anchors": [
+      "bluf",
+      "plain-english-strunk-white"
+    ],
     "template": "Responses lead with the conclusion first (BLUF). Keep to essential points. No filler, no preamble. Use short sentences, active voice, and no unnecessary words (Strunk & White).",
     "templateDe": "Antworten beginnen mit der Schlussfolgerung (BLUF). Nur das Wesentliche. Kein Fülltext, keine Einleitung. Kurze Sätze, aktive Sprache, keine überflüssigen Wörter (Wolf Schneider).",
     "category": "communication"
@@ -176,7 +209,9 @@
     "titleDe": "Einfache Erklärung (ELI5)",
     "description": "How to explain complex concepts simply",
     "descriptionDe": "Wie man komplexe Konzepte einfach erklärt",
-    "anchors": ["feynman-technique"],
+    "anchors": [
+      "feynman-technique"
+    ],
     "template": "Explain complex concepts using simple language and everyday analogies. When the explanation feels hard to write, that reveals gaps in understanding — study those areas first (Feynman Technique).",
     "templateDe": "Komplexe Konzepte mit einfacher Sprache und Alltagsanalogien erklären. Wenn die Erklärung schwerfällt, zeigt das Wissenslücken — diese zuerst vertiefen (Feynman-Technik).",
     "category": "communication"
@@ -187,7 +222,14 @@
     "titleDe": "Erklären und Lehren",
     "description": "How to teach a topic until understanding is verified, not just explained",
     "descriptionDe": "Wie man ein Thema lehrt, bis das Verständnis geprüft ist — nicht nur erklärt",
-    "anchors": ["4mat", "mental-model-according-to-naur", "socratic-method", "feynman-technique", "blooms-taxonomy", "definition-of-done"],
+    "anchors": [
+      "4mat",
+      "mental-model-according-to-naur",
+      "socratic-method",
+      "feynman-technique",
+      "blooms-taxonomy",
+      "definition-of-done"
+    ],
     "template": "When asked to explain or teach something (including \"why does X…\"), act as a teacher running a dialogue, not a lecture — your goal is that the learner can apply it afterwards, not that you delivered it.\n\nStart by having the learner restate what they already understand (Socratic Method), so you teach the gap, not the whole topic; adjust depth on request (ELI5 / ELI-intern). Keep a short running checklist of what they must grasp — the problem and why it exists, the solution with its design decisions and edge cases, and why it matters — a Definition of Done for understanding, worked one item at a time; for a long or multi-session explanation, persist that checklist as a file so it survives context loss and can be resumed.\n\nTake one small step per turn: fill the gap with questions, not answers; ask, or explain the next smallest piece in a few sentences and then check it — then stop and wait. Never stack several steps in one turn. Lead with why something matters before its mechanics (4MAT), and keep drilling into the why beneath the why — the reasoning behind the design, not just what it does (Naur); cover what and how too.\n\nCheck by quizzing, never \"makes sense?\" — open or multiple-choice questions; for multiple choice, vary which option is correct and don't reveal the answer until the learner has committed. The sharpest check is having them explain it back in their own words (Feynman Technique) or apply it to a fresh case; use a concrete artifact (an example, code, a trace) when it helps. React to the actual answer: if they've got it, advance; if not, give a short targeted hint and re-ask. \"Understood\" means they can use it on a new case, not recite it (Bloom's Apply, not recall) — don't move on, and don't end, until they've shown that.\n\nDon't announce or walk through the method you're using — let it shape what you do, not what you say. Scale to the question: a small factual ask gets a one-line answer, and the learner can say \"just tell me\" anytime. If you're unsure of the topic, learn it before teaching.",
     "templateDe": "Wenn du etwas erklären oder lehren sollst (auch „warum macht X…“), agiere als Lehrperson, die einen Dialog führt, keine Vorlesung hält — dein Ziel ist, dass die lernende Person es danach anwenden kann, nicht dass du es geliefert hast.\n\nBeginne damit, die lernende Person ihr aktuelles Verständnis zurückerklären zu lassen (Socratic Method), damit du die Lücke lehrst, nicht das ganze Thema; passe die Tiefe auf Wunsch an (ELI5 / ELI-intern). Führe eine kurze laufende Checkliste, was verstanden sein muss — das Problem und warum es existiert, die Lösung mit ihren Design-Entscheidungen und Edge Cases, und warum es zählt — eine Definition of Done fürs Verständnis, Punkt für Punkt abgearbeitet; bei einer langen oder über mehrere Sitzungen laufenden Erklärung halte diese Checkliste als Datei fest, damit sie Kontextverlust übersteht und wieder aufgenommen werden kann.\n\nGeh einen kleinen Schritt pro Zug: fülle die Lücke mit Fragen, nicht mit Antworten; frage, oder erkläre das nächstkleinere Stück in wenigen Sätzen und prüfe es dann — dann stopp und warte. Nie mehrere Schritte in einem Zug stapeln. Beginne mit dem Warum, bevor du zur Mechanik kommst (4MAT), und bohre weiter ins Warum hinter dem Warum — die Begründung hinter dem Design, nicht bloß was es tut (Naur); decke auch das Was und Wie ab.\n\nPrüfe durch Quizzen, nie „passt das?“ — offene oder Multiple-Choice-Fragen; bei Multiple Choice variiere, welche Option richtig ist, und verrate die Antwort erst, wenn die Person sich festgelegt hat. Die schärfste Probe ist das Zurückerklären in eigenen Worten (Feynman Technique) oder das Anwenden auf einen neuen Fall; nutze ein konkretes Artefakt (ein Beispiel, Code, einen Trace), wenn es hilft. Reagiere auf die tatsächliche Antwort: sitzt es, geh weiter; sitzt es nicht, gib einen kurzen gezielten Hinweis und frag erneut. „Verstanden“ heißt, sie kann es auf einen neuen Fall anwenden, nicht abrufen (Blooms Apply, nicht Abrufen) — geh nicht weiter und beende nicht, bis sie das gezeigt hat.\n\nKündige die Methode, die du benutzt, nicht an und arbeite sie nicht vor — lass sie formen, was du tust, nicht was du sagst. Passe dich an die Frage an: eine kleine Faktfrage bekommt eine einzeilige Antwort, und die lernende Person darf jederzeit sagen „sag’s mir einfach“. Wenn du beim Thema selbst unsicher bist, lerne es, bevor du lehrst.",
     "category": "communication"
@@ -198,7 +240,10 @@
     "titleDe": "Schreibstil",
     "description": "How we write technical texts — language, tone, and structure",
     "descriptionDe": "Wie wir technische Texte schreiben — Sprache, Ton und Struktur",
-    "anchors": ["gutes-deutsch-wolf-schneider", "plain-english-strunk-white"],
+    "anchors": [
+      "gutes-deutsch-wolf-schneider",
+      "plain-english-strunk-white"
+    ],
     "template": "Writing follows Gutes Deutsch nach Wolf Schneider (or Plain English according to Strunk & White).\n\nAdditionally:\n- Technical terms stay in English (LLM, Prompt, Token, Spec, etc.)\n- Address the reader directly, use first person sparingly but deliberately\n- Use analogies to human thinking to explain technical concepts\n- One thought per paragraph (5-8 sentences is fine)\n- Section headings are statements, not topic announcements\n- First sentence says what the paragraph is about\n- Show code and prompts, don't just claim things work\n- Conclusions make a clear statement — never end with 'it remains exciting'",
     "templateDe": "Schreibstil folgt Gutes Deutsch nach Wolf Schneider (oder Plain English nach Strunk & White).\n\nZusätzlich:\n- Fachbegriffe auf Englisch lassen (LLM, Prompt, Token, Spec, etc.)\n- Leser direkt ansprechen, Ich-Perspektive sparsam aber gezielt\n- Analogien zum menschlichen Denken für technische Konzepte\n- Ein Gedanke pro Absatz (5-8 Sätze OK)\n- Zwischenüberschriften als Aussagen, nicht Themenankündigungen\n- Erster Satz sagt sofort worum es geht\n- Code/Prompts zeigen, nicht nur behaupten\n- Fazit: klare Aussage, kein 'es bleibt spannend'",
     "category": "communication"
@@ -209,20 +254,14 @@
     "titleDe": "TDD, Hamburg Style",
     "description": "Design-led TDD recipe by Ralf Westphal — close the requirements/logic gap before writing code, then test at service boundaries with minimal mocking",
     "descriptionDe": "Design-geführtes TDD-Rezept nach Ralf Westphal — die Lücke zwischen Anforderungen und Logik vor dem Codieren schließen, dann an Servicegrenzen mit minimalem Mocking testen",
-    "anchors": ["red-green-tdd", "tdd-london-school", "tdd-chicago-school", "iosp"],
+    "anchors": [
+      "red-green-tdd",
+      "tdd-london-school",
+      "tdd-chicago-school",
+      "iosp"
+    ],
     "template": "Design-led TDD recipe by Ralf Westphal — close the requirements/logic gap before writing code, then test at service boundaries with minimal mocking. Use it when the problem is too complex for pure micro-step Red-Green-Refactor.\n\n- **ACD cycle (Analyze → Design → Code)** precedes the test loop: first model the solution to close the gap between requirements and logic, only then code.\n- **\"Right from the start\" philosophy** — implement correctly the first time so refactoring is a correction, not routine cleanup.\n- **Service-level testing** — test behind the public API, independent of API technology.\n- **Minimal mocking** — closer to *TDD, Chicago School* than *London School*.\n- **IOSP (Integration Operation Segregation Principle)** — a function is either composition (Integration) or logic (Operation), never both; structural support for simple unit tests.\n- **Deep Work over Small Steps** — accept that some problems can't be sliced into tiny green increments; stay red longer when the design demands it.\n\nComposes: *TDD, London School*, *TDD, Chicago School*, *Red-Green-Refactor*, *IOSP*.\nSources: https://ralfw.de/hamburg-style-tdd/, https://ralfw.de/tdd-how-it-can-be-done-right/",
     "templateDe": "Design-geführtes TDD-Rezept nach Ralf Westphal — die Lücke zwischen Anforderungen und Logik vor dem Codieren schließen, dann an Servicegrenzen mit minimalem Mocking testen. Anwenden, wenn das Problem zu komplex für reines micro-step Red-Green-Refactor ist.\n\n- **ACD-Zyklus (Analyze → Design → Code)** geht dem Test-Loop voraus: zuerst die Lösung modellieren, um die Lücke zwischen Anforderungen und Logik zu schließen, erst dann codieren.\n- **\"Right from the start\"-Philosophie** — beim ersten Mal korrekt implementieren, sodass Refactoring eine Korrektur ist, keine Routinebereinigung.\n- **Service-Level-Testing** — hinter der öffentlichen API testen, unabhängig von der API-Technologie.\n- **Minimales Mocking** — näher an *TDD, Chicago School* als an *London School*.\n- **IOSP (Integration Operation Segregation Principle)** — eine Funktion ist entweder Komposition (Integration) oder Logik (Operation), niemals beides; strukturelle Unterstützung für einfache Unit-Tests.\n- **Deep Work statt Small Steps** — akzeptieren, dass manche Probleme nicht in kleine grüne Inkremente zerlegt werden können; länger rot bleiben, wenn das Design es erfordert.\n\nKomponiert: *TDD, London School*, *TDD, Chicago School*, *Red-Green-Refactor*, *IOSP*.\nQuellen: https://ralfw.de/hamburg-style-tdd/, https://ralfw.de/tdd-how-it-can-be-done-right/",
     "category": "development"
-  },
-  {
-    "id": "strategic-architecture-analysis",
-    "title": "Strategic Architecture Analysis",
-    "titleDe": "Strategische Architekturanalyse",
-    "description": "How we analyze architecture strategically — mapping evolution, classifying complexity, exploring the option space, and weighing tradeoffs",
-    "descriptionDe": "Wie wir Architektur strategisch analysieren — Evolution kartieren, Komplexität einordnen, den Optionsraum erkunden und Tradeoffs abwägen",
-    "anchors": ["wardley-mapping", "cynefin-framework", "morphological-box", "atam", "five-whys"],
-    "template": "Strategic architecture analysis combines four lenses, each for a different question. Reach for it when evaluating build-vs-buy, assessing architecture fitness for changing requirements, or running a strategic technology-radar review.\n\nMap the value chain with Wardley Mapping to see how each component evolves — what is commodity, what is genesis, and where the strategic differentiation actually sits.\n\nClassify each challenge with the Cynefin Framework — Clear, Complicated, Complex, or Chaotic — so the response fits the domain instead of forcing one playbook onto every problem.\n\nWhen a decision has a wide solution space, lay the dimensions and their options out in a Morphological Box and combine them deliberately, rather than anchoring on the first design that comes to mind.\n\nEvaluate the shortlisted architectures against the quality goals with ATAM, naming the sensitivity points, the tradeoff points, and the risks each option carries.\n\nWhen the root cause of a problem stays unclear, drill down with the Five Whys before committing to a direction.",
-    "templateDe": "Strategische Architekturanalyse kombiniert vier Perspektiven, jede für eine andere Frage. Anwenden bei Build-vs-Buy-Entscheidungen, bei der Bewertung der Architektur-Eignung für sich ändernde Anforderungen oder bei einem strategischen Technologie-Radar-Review.\n\nDie Wertschöpfungskette mit Wardley Mapping kartieren, um zu sehen, wie sich jede Komponente entwickelt — was Commodity ist, was Genesis, und wo die strategische Differenzierung tatsächlich liegt.\n\nJede Herausforderung mit dem Cynefin Framework einordnen — Clear, Complicated, Complex oder Chaotic — damit die Reaktion zur Domäne passt, statt jedem Problem dasselbe Vorgehen aufzuzwingen.\n\nHat eine Entscheidung einen weiten Lösungsraum, die Dimensionen und ihre Optionen in einem Morphologischen Kasten ausbreiten und bewusst kombinieren, statt sich am erstbesten Entwurf festzubeißen.\n\nDie verbleibenden Architekturen mit ATAM gegen die Qualitätsziele bewerten und dabei Sensitivitätspunkte, Tradeoff-Punkte und die Risiken jeder Option benennen.\n\nBleibt die Ursache eines Problems unklar, mit den Five Whys nachbohren, bevor eine Richtung festgelegt wird.",
-    "category": "architecture"
   }
 ]


### PR DESCRIPTION
## refactor(contract): split architecture-documentation into vocabulary contract + arc42-authoring skill

*(German version below)*

Splits the over-grown `architecture-documentation` contract (2922 chars) into:
1. A **vocabulary contract** (~340 chars) — declares *which* anchors apply
2. A **procedural skill** `arc42-authoring/` — carries the *how-to*

Closes #529. Absorbs `crosscutting-concepts` into the skill.

---

### Assessment against project taxonomy

#### Contract/Skill boundary — catalog evidence

| Characteristic | Contract (vocabulary) | Skill (procedure) |
|---|---|---|
| **Purpose** | Pin shared vocabulary — always-on | On-demand workflow machinery |
| **Structure** | `template` field in `contracts.json` | `SKILL.md` + `references/` + `prompts/` |
| **Invocation** | Loaded into every session | Invoked when the task calls for it |
| **Size norm (observed)** | Median 450 chars, max 1200 | Unbounded (Socratic: full SKILL.md) |
| **Naming** | Noun-phrase (`architecture-documentation`) | Verb-phrase (`arc42-authoring`) |

#### Size analysis — the outlier

| Contract | Size | Pattern |
|----------|------|---------|
| `architecture-documentation` | **2922** | DECLARES + PRODUCES + CONSTRAINS |
| `socratic-code-theory-recovery` | 2513 | DECLARES + CONSTRAINS (has companion skill) |
| `explaining-teaching` | 1226 | CONSTRAINS + DELEGATES |
| `tdd-hamburg-style` | 1191 | CONSTRAINS + COMPOSES |
| All others (14) | 141–708 | DECLARES or CONSTRAINS |

`architecture-documentation` is the only contract >1200 chars that has **no companion skill**. `socratic-code-theory-recovery` is similarly long but justified as a condensed reminder of its companion skill — the procedural depth lives in the skill, not the contract alone.

#### Precedent: "invoke a skill for depth" pattern

The `explaining-teaching` contract (#573) proves this pattern works:
- Contract composes vocabulary (Bloom's, 4MAT, Feynman, Socratic)
- Procedural depth lives in the `socratic-code-theory-recovery` skill
- Contract stays at 1226 chars

#### Consistency with Harness Inventory

The Harness Inventory page (`docs/harness-inventory.adoc`) separates "what a layer checks" (definition) from "how to deploy it" (procedure). Same lens: contract = the *what*, skill = the *how*.

---

### Changes

#### 1. New skill: `skill/arc42-authoring/`

```
skill/arc42-authoring/
├── SKILL.md
└── references/
    ├── traceability-rules.md
    ├── chapter-10-quality-scenarios.md
    ├── chapter-11-structure.md
    ├── chapter-8-baseline.md
    ├── adr-risk-wiring.md
    └── scaffolding.md
```

Content extracted 1:1 from the current `architecture-documentation` and `crosscutting-concepts` contracts. No information lost — only relocated.

#### 2. Shrunken contract: `architecture-documentation`

From 2922 chars → ~340 chars:

> Architecture documentation follows arc42. Diagrams are C4 via PlantUML's bundled C4-PlantUML stdlib (`!include <C4/...>`). Decisions are Nygard ADRs with a 3-point Pugh Matrix (-1/0/+1). Quality requirements are six-part Quality Attribute Scenarios (Bass/Clements/Kazman). For procedural detail — traceability rules, chapter structure, scaffolding — invoke the `arc42-authoring` skill.

#### 3. Absorbed: `crosscutting-concepts`

Moved to `skill/arc42-authoring/references/chapter-8-baseline.md`. The contract entry is removed from `contracts.json`.

#### 4. Socratic overlap resolution

The `socratic-code-theory-recovery` skill's `references/arc42.md` contains a **Phase 1 decomposition guide** (Q-IDs, when to stop decomposing) — this is specific to the Socratic workflow, not to arc42 authoring. No overlap — both skills coexist without duplication:

| Skill | arc42 content | Purpose |
|---|---|---|
| `arc42-authoring` | Traceability rules, chapter structure, scaffolding | *Producing* documentation |
| `socratic-code-theory-recovery` | Q3 decomposition hints, leaf-vs-branch criteria | *Recovering* documentation from code |

---

### Tradeoff acknowledged

The traceability rules move from always-on to on-demand. For architecture work the skill is invoked anyway — no loss. For someone only reading the contract as a reminder, the detail was already too large for always-on context — this is a correction, not a regression (as #529 states).

---

---

<details>
<summary><strong>Deutsche Version</strong></summary>

## refactor(contract): architecture-documentation in Vokabular-Contract + arc42-authoring-Skill aufteilen

Teilt den überwachsenen `architecture-documentation`-Contract (2922 Zeichen) auf in:
1. Einen **Vokabular-Contract** (~340 Zeichen) — deklariert *welche* Anchors gelten
2. Einen **prozeduralen Skill** `arc42-authoring/` — enthält das *Wie*

Schließt #529. Absorbiert `crosscutting-concepts` in den Skill.

---

### Bewertung gegen die Projekt-Taxonomie

#### Contract/Skill-Grenze — Katalog-Evidenz

| Eigenschaft | Contract (Vokabular) | Skill (Prozedur) |
|---|---|---|
| **Zweck** | Geteiltes Vokabular pinnen — always-on | On-demand Workflow-Maschinerie |
| **Struktur** | `template`-Feld in `contracts.json` | `SKILL.md` + `references/` + `prompts/` |
| **Aufruf** | In jeder Session geladen | Aufgerufen wenn die Aufgabe es erfordert |
| **Größennorm (beobachtet)** | Median 450 Zeichen, Maximum 1200 | Unbegrenzt (Socratic: vollständige SKILL.md) |
| **Benennung** | Nomen-Phrase (`architecture-documentation`) | Verb-Phrase (`arc42-authoring`) |

#### Größenanalyse — der Ausreißer

| Contract | Größe | Pattern |
|----------|-------|---------|
| `architecture-documentation` | **2922** | DECLARES + PRODUCES + CONSTRAINS |
| `socratic-code-theory-recovery` | 2513 | DECLARES + CONSTRAINS (hat Begleit-Skill) |
| `explaining-teaching` | 1226 | CONSTRAINS + DELEGATES |
| `tdd-hamburg-style` | 1191 | CONSTRAINS + COMPOSES |
| Alle anderen (14) | 141–708 | DECLARES oder CONSTRAINS |

`architecture-documentation` ist der einzige Contract >1200 Zeichen **ohne Begleit-Skill**. `socratic-code-theory-recovery` ist ähnlich lang, aber gerechtfertigt als kondensierte Erinnerung seines Begleit-Skills — die prozedurale Tiefe lebt im Skill, nicht allein im Contract.

#### Präzedenzfall: „invoke a skill for depth"-Pattern

Der `explaining-teaching`-Contract (#573) beweist, dass dieses Pattern funktioniert:
- Contract komponiert Vokabular (Bloom's, 4MAT, Feynman, Socratic)
- Prozedurale Tiefe lebt im `socratic-code-theory-recovery`-Skill
- Contract bleibt bei 1226 Zeichen

#### Konsistenz mit der Harness Inventory

Die Harness-Inventory-Seite (`docs/harness-inventory.adoc`) trennt „was eine Schicht prüft" (Definition) von „wie man sie deployt" (Prozedur). Gleiche Linse: Contract = das *Was*, Skill = das *Wie*.

---

### Änderungen

#### 1. Neuer Skill: `skill/arc42-authoring/`

```
skill/arc42-authoring/
├── SKILL.md
└── references/
    ├── traceability-rules.md
    ├── chapter-10-quality-scenarios.md
    ├── chapter-11-structure.md
    ├── chapter-8-baseline.md
    ├── adr-risk-wiring.md
    └── scaffolding.md
```

Inhalt 1:1 extrahiert aus den aktuellen Contracts `architecture-documentation` und `crosscutting-concepts`. Keine Information geht verloren — nur umgezogen.

#### 2. Eingedampfter Contract: `architecture-documentation`

Von 2922 Zeichen → ~340 Zeichen:

> Architekturdokumentation folgt arc42. Diagramme sind C4 über PlantUMLs gebundelte C4-PlantUML-Stdlib (`!include <C4/...>`). Entscheidungen sind Nygard-ADRs mit einer 3-Punkte Pugh-Matrix (-1/0/+1). Qualitätsanforderungen sind sechsteilige Quality Attribute Scenarios (Bass/Clements/Kazman). Für prozedurale Details — Traceability-Regeln, Kapitelstruktur, Scaffolding — den `arc42-authoring`-Skill aufrufen.

#### 3. Absorbiert: `crosscutting-concepts`

Verschoben nach `skill/arc42-authoring/references/chapter-8-baseline.md`. Der Contract-Eintrag wird aus `contracts.json` entfernt.

#### 4. Socratic-Überschneidung aufgelöst

Die `references/arc42.md` des `socratic-code-theory-recovery`-Skills enthält einen **Phase-1-Dekompositions-Guide** (Q-IDs, wann man aufhört zu dekomponieren) — das ist spezifisch für den Socratic-Workflow, nicht für arc42-Authoring. Keine Überschneidung — beide Skills koexistieren ohne Duplikation:

| Skill | arc42-Inhalt | Zweck |
|---|---|---|
| `arc42-authoring` | Traceability-Regeln, Kapitelstruktur, Scaffolding | Dokumentation *produzieren* |
| `socratic-code-theory-recovery` | Q3-Dekompositions-Hints, Leaf-vs-Branch-Kriterien | Dokumentation aus Code *recovern* |

---

### Trade-off anerkannt

Die Traceability-Regeln wandern von always-on zu on-demand. Für Architekturarbeit wird der Skill ohnehin aufgerufen — kein Verlust. Für jemanden, der den Contract nur als Erinnerung liest, war das Detail bereits zu umfangreich für always-on-Kontext — dies ist eine Korrektur, keine Regression (wie #529 feststellt).

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Umfassende Richtlinien zur Erstellung und Pflege von arc42-Architektur‑Dokumentationen ergänzt (inkl. Template-Scaffolding und When to use/When NOT to use)
* Einheitliches Six‑Part‑Format für Quality‑Szenarien sowie Statusmodell eingeführt
* Struktur für Risiken/Technical Debt mit stabilen IDs, Priorisierung und ADR↔Risk‑Verknüpfungslogik festgelegt
* Traceability‑Regeln sowie Vorgaben für Crosscutting Concepts, Kapitel‑8/9‑Verweise und Diagrammkonventionen ergänzt
* Vertragsbaustein‑Templates inhaltlich verkürzt/angepasst

## Chores
* Anchor-/Template‑Felder in öffentlichen Vertragsdaten auf mehrzeilige, eingerückte Darstellung umgestellt
<!-- end of auto-generated comment: release notes by coderabbit.ai -->