### PR TITLE
docs: add OpenCode to agent-installation guide

### DIFF
--- a/docs/agent-installation.adoc
+++ b/docs/agent-installation.adoc
@@ -78,3 +78,26 @@ Windsurf supports `AGENTS.md` alongside Windsurf Rules.
 
 * Use `AGENTS.md` for portable project context shared with other agents.
 * Use Windsurf Rules only when you need editor-specific or scoped behavior.
+
+=== link:https://opencode.ai[OpenCode]
+OpenCode supports `AGENTS.md` for project-level instructions and a plugin system for runtime enforcement.
+
+* *Static Context*: Use `AGENTS.md` as the shared baseline — OpenCode reads it automatically.
+* *Runtime Enforcement*: Install the link:https://github.com/JensGrote/opencode-semantic-anchors[opencode-semantic-anchors] plugin to enforce anchors as runtime contracts via plugin hooks (BLOCK/WARN modes, step confirmation, source verification):
++
+[source,bash]
+----
+npm install opencode-semantic-anchors
+----
++
+Then add to `opencode.jsonc`:
++
+[source,jsonc]
+----
+{
+  "plugin": "opencode-semantic-anchors",
+  "config": "opencode-semantic-anchors.yaml"
+}
+----
++
+This enforces anchors at runtime without consuming LLM context tokens. See the link:https://github.com/JensGrote/opencode-semantic-anchors[plugin documentation] for configuration details.


### PR DESCRIPTION
## docs: add OpenCode to agent-installation guide

*(German version below)*

Adds an `=== OpenCode` section to `docs/agent-installation.adoc`, covering both static context (`AGENTS.md`) and runtime enforcement via the `opencode-semantic-anchors` plugin.

### Context

The agent-installation guide currently covers Codex, Claude Code, Gemini CLI, Cursor, GitHub Copilot, and Windsurf — but not [OpenCode](https://opencode.ai), which is gaining traction as an open-source terminal-based coding agent.

OpenCode supports `AGENTS.md` natively for static context. However, unlike Kiro's `/steering` files or Claude Code's hooks, OpenCode has no built-in steering mechanism to enforce behavioral rules at runtime. The [opencode-semantic-anchors](https://github.com/JensGrote/opencode-semantic-anchors) plugin closes this gap by enforcing Semantic Anchors as Structural Coupling Contracts via plugin hooks.

### What this PR adds

A new `=== OpenCode` section explaining:
1. **Static context** — `AGENTS.md` works out of the box, same as Codex
2. **Runtime enforcement** — the `opencode-semantic-anchors` plugin enforces contracts via `tool.execute.before` hooks (BLOCK/WARN modes, step confirmation, source verification) without consuming LLM context tokens

### Related

- Plugin submitted to the community plugin list: [awesome-opencode/awesome-opencode#411](https://github.com/awesome-opencode/awesome-opencode/pull/411)
- Plugin repo: https://github.com/JensGrote/opencode-semantic-anchors
- npm: [`opencode-semantic-anchors`](https://www.npmjs.com/package/opencode-semantic-anchors)
- arc42 documentation: https://jensgrote.github.io/opencode-semantic-anchors/

### Disclosure

I am the author of the `opencode-semantic-anchors` plugin. The plugin explicitly references and builds upon the Semantic Anchors methodology from this repository.

---

<details>
<summary><strong>Deutsche Version</strong></summary>

## docs: OpenCode zur agent-installation-Anleitung hinzufügen

Fügt einen `=== OpenCode`-Abschnitt zur `docs/agent-installation.adoc` hinzu, der sowohl statischen Kontext (`AGENTS.md`) als auch Runtime-Enforcement über das `opencode-semantic-anchors`-Plugin abdeckt.

### Kontext

Die Agent-Installationsanleitung deckt aktuell Codex, Claude Code, Gemini CLI, Cursor, GitHub Copilot und Windsurf ab — aber nicht [OpenCode](https://opencode.ai), das als Open-Source-Terminal-Coding-Agent zunehmend an Bedeutung gewinnt.

OpenCode unterstützt `AGENTS.md` nativ für statischen Kontext. Anders als Kiros `/steering`-Dateien oder Claude Codes Hooks bietet OpenCode jedoch keinen eingebauten Steering-Mechanismus, um Verhaltensregeln zur Laufzeit durchzusetzen. Das [opencode-semantic-anchors](https://github.com/JensGrote/opencode-semantic-anchors)-Plugin schließt diese Lücke, indem es Semantic Anchors als Structural Coupling Contracts über Plugin-Hooks erzwingt.

### Was dieser PR hinzufügt

Einen neuen `=== OpenCode`-Abschnitt mit:
1. **Statischer Kontext** — `AGENTS.md` funktioniert out of the box, wie bei Codex
2. **Runtime-Enforcement** — das `opencode-semantic-anchors`-Plugin erzwingt Contracts über `tool.execute.before`-Hooks (BLOCK/WARN-Modi, Schritt-Bestätigung, Quellenprüfung) ohne LLM-Kontext-Tokens zu verbrauchen

### Verwandte Aktivitäten

- Plugin zur Community-Plugin-Liste eingereicht: [awesome-opencode/awesome-opencode#411](https://github.com/awesome-opencode/awesome-opencode/pull/411)
- Plugin-Repository: https://github.com/JensGrote/opencode-semantic-anchors
- npm: [`opencode-semantic-anchors`](https://www.npmjs.com/package/opencode-semantic-anchors)
- arc42-Dokumentation: https://jensgrote.github.io/opencode-semantic-anchors/

### Offenlegung

Ich bin der Autor des `opencode-semantic-anchors`-Plugins. Das Plugin referenziert und baut explizit auf der Semantic-Anchors-Methodik aus diesem Repository auf.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Neuer Abschnitt für OpenCode-Agent-Integration hinzugefügt
  * Dokumentation um Informationen zu Projektanweisungen und Plugin-Installation erweitert
  * Konfigurations- und Installationsbeispiele für die Runtime-Durchsetzung bereitgestellt

<!-- end of auto-generated comment: release notes by coderabbit.ai -->