### PR TITLE
fix(docs): address review on the Anchors and Training Data article

### DIFF
--- a/docs/training-data-vs-practice.adoc
+++ b/docs/training-data-vs-practice.adoc
@@ -8,14 +8,14 @@ _What a pull request about "use cases" taught us about semantic anchors — with
 
 [NOTE]
 ====
-*The short version.* A semantic anchor works by triggering a concept the model already learned. Its power is therefore proportional to how _densely_ that concept appears in the training data. We tested this directly: naming "Cockburn use cases" reshapes a generic answer into a full fully-dressed use case (the anchor delivers), while naming "Use-Case 3.0" delivers nothing distinct — the model silently falls back to the nearest concept it does know. That is why an anchor's popup describes the _triggered_ definition, not the state of the art, and why weak-prior terms belong in a *contract* (which supplies its own meaning), not an anchor.
+*The short version.* A semantic anchor works by triggering a concept the model already learned. Its power is therefore proportional to how _densely_ that concept appears in the training data. We tested this directly: naming "Cockburn use cases" reshapes a generic answer into a complete fully-dressed use case (the anchor delivers), while naming "Use-Case 3.0" delivers nothing distinct — the model silently falls back to the nearest concept it does know. That is why an anchor's popup describes the _triggered_ definition, not the state of the art, and why weak-prior terms belong in a *contract* (which supplies its own meaning), not an anchor.
 ====
 
 == A Discussion About One Anchor Started It
 
 Simon Martinelli opened a https://github.com/LLM-Coding/Semantic-Anchors/pull/582[pull request] proposing to rename the _Cockburn Use Cases_ anchor to plain _Use Cases_, fix the attribution, and modernise it with Use-Case 2.0 and 3.0.
 
-His facts are correct. Ivar Jacobson invented use cases (OOPSLA 1987, _Object-Oriented Software Engineering_, 1992); Cockburn did not — his _Writing Effective Use Cases_ (2001) codified how to write them well. The technique later grew into Use-Case 2.0 (Jacobson, Spence & Bittner, 2011) and Use-Case 3.0 (Jacobson, Spence & de Mendonca, 2024). As a daily practitioner, Simon added that most teams no longer separate Cockburn from Jacobson, and that the full fully-dressed ceremony is rarely used.
+His facts are correct. Ivar Jacobson invented use cases (OOPSLA 1987, _Object-Oriented Software Engineering_, 1992); Cockburn did not — his _Writing Effective Use Cases_ (2001) codified how to write them well. The technique later grew into Use-Case 2.0 (Jacobson, Spence & Bittner, 2011) and Use-Case 3.0 (Jacobson, Spence & de Mendonca, 2024). As a daily practitioner, Simon added that most teams no longer separate Cockburn from Jacobson, and that the fully-dressed ceremony is rarely used.
 
 When the discussion continued, Simon made a fair challenge: he pasted output from several chatbots to show they clearly _know_ use cases. They do — and that turned out to be beside the point. The question is not whether a model knows the term, but _which_ definition the term triggers and _how far_ that knowledge reaches. The rest of this article answers that question with an experiment, and the answer is what decided the pull request.
 

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -584,6 +584,8 @@ function handleLanguageChange() {
     loadDocContent('docs/brownfield-fair-comparison.adoc')
   } else if (currentRoute === '/harness-inventory') {
     loadDocContent('docs/harness-inventory.adoc')
+  } else if (currentRoute === '/training-data-vs-practice') {
+    loadDocContent('docs/training-data-vs-practice.adoc')
   } else if (currentRoute === '/contracts') {
     renderContractsPageHandler()
   } else if (currentRoute === '/') {

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -22,7 +22,8 @@ const ROUTE_TITLES = {
   '/brownfield-fair-comparison': 'Brownfield Fair Comparison — Semantic Anchors',
   '/socratic-recovery-skill': 'Socratic Code-Theory Recovery Skill — Semantic Anchors',
   '/harness-inventory': 'The Harness Inventory — Semantic Anchors',
-  '/training-data-vs-practice': 'Anchors and Training Data — Semantic Anchors',
+  '/training-data-vs-practice':
+    'An Anchor Delivers Only as Far as the Prior Reaches — Semantic Anchors',
   '/evaluations': 'Evaluations — Semantic Anchors',
   '/contributing': 'Contributing — Semantic Anchors',
   '/changelog': 'Changelog — Semantic Anchors',


### PR DESCRIPTION
Follow-up to #586, addressing the CodeRabbit + Copilot review.

- **`main.js` (real bug, CodeRabbit):** `handleLanguageChange()` had no case for `/training-data-vs-practice`, so toggling EN/DE on the article did not re-render it, unlike every other doc route. Added the branch (mirrors `harness-inventory`).
- **`router.js` (Copilot):** aligned the browser/tab title with the article's actual title (*An Anchor Delivers Only as Far as the Prior Reaches*) instead of the nav label.
- **article (Copilot):** dropped the "full fully-dressed" wording redundancy (2 spots).

Skipped the "&" → "and" nav-label nit — "&" is idiomatic and short in a nav menu.

The cross-model validation (GPT-5 / Gemini) from @JensGrote's review is intentionally **not** in this PR — he is opening a separate PR for that with his raw data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Sprachliche und stilistische Verbesserungen der Dokumentation zu semantischen Ankern.
  * Sprachunterstützung für die Ankerdokumentation optimiert.
  * Seitentitel aktualisiert für bessere Klarheit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->