### PR TITLE
docs(article): add Fable 5 to the prior-mapping matrix

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -8,6 +8,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 * *Strategic Architecture Analysis* — a strategic-analysis recipe that combines four lenses with the questions they answer: Wardley Mapping (how each component evolves), the Cynefin Framework (match the response to the domain), a Morphological Box (explore the option space deliberately instead of anchoring on the first design), ATAM (weigh tradeoffs against the quality goals), and the Five Whys (drill to the root cause); for build-vs-buy decisions, architecture-fitness reviews, and strategic technology-radar reviews
 
+*Updated article:*
+
+* *An Anchor Delivers Only as Far as the Prior Reaches* — added Fable 5 (Anthropic's newest model, probed on its release day) as a fourth column in the prior-mapping matrix. It holds the richest Use-Case 2.0 prior of the four models yet still hedges on Use-Case 3.0, strengthening the finding that a dense 2.0 prior does not buy a 3.0 one.
+
 == 2026-06-08
 
 *Refined contracts:*

--- a/docs/training-data-vs-practice.adoc
+++ b/docs/training-data-vs-practice.adoc
@@ -79,25 +79,25 @@ Opus substituted Use-Case 2.0 and _told you_. Haiku did the same kind of substit
 
 == How Far the Prior Actually Reaches
 
-The anchor experiment shows leverage tracks density. A second set of probes maps where the density is. We asked five plain questions, each on Haiku 4.5, Sonnet 4.6 and Opus 4.8, with no internet and no custom instructions.
+The anchor experiment shows leverage tracks density. A second set of probes maps where the density is. We asked five plain questions, each on Haiku 4.5, Sonnet 4.6, Opus 4.8 and Fable 5 — Anthropic's newest model, added on its release day — with no internet and no custom instructions.
 
-[cols="2,2,2,2", options="header"]
+[cols="3,2,2,2,2", options="header"]
 |===
-| Probe | Haiku 4.5 | Sonnet 4.6 | Opus 4.8
+| Probe | Haiku 4.5 | Sonnet 4.6 | Opus 4.8 | Fable 5
 
-| Who invented use cases? | Jacobson (high) | Jacobson (high) | Jacobson (high)
-| Associations with "use cases" | Jacobson + Cockburn + UML | Cockburn (+ Larman) | Cockburn > Jacobson/UML
-| "Write a use case" (default) | Cockburn-shaped, no slices | Cockburn fully-dressed, no slices | Cockburn fully-dressed, no slices
-| What is Use-Case 2.0? | low / thin | medium / moderate | high / rich
-| What is Use-Case 3.0? | low / thin, doubts it exists | low / thin, reaching, doubts | low / thin, doubts it exists
+| Who invented use cases? | Jacobson (high) | Jacobson (high) | Jacobson (high) | Jacobson (high)
+| Associations with "use cases" | Jacobson + Cockburn + UML | Cockburn (+ Larman) | Cockburn > Jacobson/UML | Jacobson + Cockburn + UML
+| "Write a use case" (default) | Cockburn-shaped, no slices | Cockburn fully-dressed, no slices | Cockburn fully-dressed, no slices | Cockburn fully-dressed, no slices
+| What is Use-Case 2.0? | low / thin | medium / moderate | high / rich | high / rich (names slices + 6 principles)
+| What is Use-Case 3.0? | low / thin, doubts it exists | low / thin, reaching, doubts | low / thin, doubts it exists | low / thin, hedges, guesses AI-era
 |===
 
-Four findings, each robust across the three models:
+Four findings, each robust across the four models:
 
 . *The inventor is known.* Every model credits Jacobson, with high confidence. The popular misattribution to Cockburn lives in casual human shorthand, not in the model.
 . *The default use case is Cockburn-shaped.* Ask any of them to write a use case and you get fully-dressed structure — never slices, never 2.0/3.0. The dense prior _is_ the Cockburn era.
-. *Use-Case 2.0 degrades with model size.* Opus describes it richly, Sonnet moderately, Haiku barely. The thinner prior survives only in the larger model — though, as framing D showed, even Haiku can _act_ on "slices" when told to. Describing a method and applying its core move are different things.
-. *Use-Case 3.0 is a gap for everyone.* Even the newest frontier models, with the latest cutoffs, are thin and uncertain. Haiku put it plainly: it was _"not even confident enough to know if there's a 2.0 to confuse it with."_ If the strongest, most recent models cannot reach 3.0, older or smaller ones certainly cannot.
+. *Use-Case 2.0 tracks model scale and recency.* Opus describes it richly, Sonnet moderately, Haiku barely — and Fable 5, the newest model, richest of all: it recalls the slices _and_ the six principles by name. The thinner prior survives best in the larger, more recent model — though, as framing D showed, even Haiku can _act_ on "slices" when told to. Describing a method and applying its core move are different things.
+. *Use-Case 3.0 is a gap for everyone.* Even the newest frontier models, with the latest cutoffs, are thin and uncertain. Haiku put it plainly: it was _"not even confident enough to know if there's a 2.0 to confuse it with."_ Fable 5 sharpens the point: released the day we ran the probe, it holds the richest Use-Case 2.0 prior of the four — yet on 3.0 it still hedges and reaches for an unverified "AI-era" evolution. A dense 2.0 prior does not buy a 3.0 one; the two sit at different densities in the data, not at different model strengths. If the strongest, most recent models cannot reach 3.0, older or smaller ones certainly cannot.
 
 The fourth point is the strongest form of the argument. We could not test older model generations — Claude 3.x is no longer reachable through this account — but we did not need to. The gap shows up on the latest models; older ones only widen it.
 
@@ -169,7 +169,7 @@ claude -p "<prompt>" --model <haiku|sonnet|opus> \
     --strict-mcp-config --setting-sources ""
 ----
 
-`--setting-sources ""` drops user/project/local config (including the global `CLAUDE.md` and auto-memory); starting from a neutral directory drops the project `CLAUDE.md`. Verified clean: the model reports "no CLAUDE.md, no memory." All results above are from this clean setup, on Claude Haiku 4.5, Sonnet 4.6 and Opus 4.8.
+`--setting-sources ""` drops user/project/local config (including the global `CLAUDE.md` and auto-memory); starting from a neutral directory drops the project `CLAUDE.md`. Verified clean: the model reports "no CLAUDE.md, no memory." All results above are from this clean setup: the anchor experiment (A–E) on Claude Haiku 4.5 and Opus 4.8, the prior-mapping probes on Claude Haiku 4.5, Sonnet 4.6, Opus 4.8 and Fable 5.
 ====
 
 Thanks to Simon Martinelli, whose pull request — and his insistence on testing the claim against real chatbots — turned a naming discussion into a measurement.


### PR DESCRIPTION
## What

Adds **Fable 5** (Anthropic's newest model, `claude-fable-5`) as a fourth column in the prior-mapping matrix of the *An Anchor Delivers Only as Far as the Prior Reaches* article.

Probed clean-room on its release day with the same five mapping prompts already used for Haiku 4.5 / Sonnet 4.6 / Opus 4.8 (`claude -p --strict-mcp-config --setting-sources ""` from a neutral dir).

| Probe | Fable 5 |
|---|---|
| Who invented use cases? | Jacobson (high) |
| Associations | Jacobson + Cockburn + UML |
| Write a use case (default) | Cockburn fully-dressed, no slices |
| Use-Case 2.0 | **high / rich** — recalls slices + the six principles |
| Use-Case 3.0 | low / thin, hedges, guesses "AI-era" |

## Why it matters

Fable 5 holds the **richest Use-Case 2.0 prior of all four models** — yet still hedges on 3.0. That sharpens finding 4: a dense 2.0 prior does not buy a 3.0 one; the two sit at different densities in the training data, not at different model strengths. The newest, strongest model does not close the gap.

## Changes

- `docs/training-data-vs-practice.adoc` — Fable 5 column in the matrix; findings 3 and 4 updated; method note made precise (A–E experiment on Haiku + Opus, prior-mapping probes on all four)
- `docs/changelog.adoc` — `2026-06-09` "Updated article" entry

The A–E anchor experiment was **not** re-run on Fable 5; only the prior-mapping probes were, and the text says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Changelog mit neuem Eintrag für aktualisierte Artikelfassung ergänzt
  * Experiment-Dokumentation um zusätzliches Modell erweitert und Ergebnistabelle sowie Findings aktualisiert
  * Anleitung zum Setup-Prozess präzisiert mit zusätzlichen Details zur Konfiguration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->