### PR TITLE
fix: make the website navigable and readable without JavaScript (EN + DE)

### DIFF
--- a/docs/all-anchors.adoc
+++ b/docs/all-anchors.adoc
@@ -11,206 +11,330 @@ include::about.adoc[leveloffset=+1]
 
 include::anchors/4mat.adoc[leveloffset=+2]
 
+[[aida-model]]
+include::anchors/aida-model.adoc[leveloffset=+2]
+
+[[blooms-taxonomy]]
+include::anchors/blooms-taxonomy.adoc[leveloffset=+2]
+
+[[bluf]]
 include::anchors/bluf.adoc[leveloffset=+2]
 
+[[gutes-deutsch-wolf-schneider]]
 include::anchors/gutes-deutsch-wolf-schneider.adoc[leveloffset=+2]
 
+[[inverted-pyramid-style]]
+include::anchors/inverted-pyramid-style.adoc[leveloffset=+2]
+
+[[mece]]
 include::anchors/mece.adoc[leveloffset=+2]
 
+[[myers-briggs-type-indicator]]
 include::anchors/myers-briggs-type-indicator.adoc[leveloffset=+2]
 
+[[plain-english-strunk-white]]
 include::anchors/plain-english-strunk-white.adoc[leveloffset=+2]
 
+[[problem-space-nvc]]
 include::anchors/problem-space-nvc.adoc[leveloffset=+2]
 
+[[pyramid-principle]]
 include::anchors/pyramid-principle.adoc[leveloffset=+2]
 
 <<<
 
 == Creative Writing
 
+[[fichtean-curve]]
 include::anchors/fichtean-curve.adoc[leveloffset=+2]
 
+[[freytags-pyramid]]
 include::anchors/freytags-pyramid.adoc[leveloffset=+2]
 
+[[heros-journey]]
 include::anchors/heros-journey.adoc[leveloffset=+2]
 
+[[kishotenketsu]]
 include::anchors/kishotenketsu.adoc[leveloffset=+2]
 
+[[save-the-cat]]
 include::anchors/save-the-cat.adoc[leveloffset=+2]
 
+[[story-circle-dan-harmon]]
 include::anchors/story-circle-dan-harmon.adoc[leveloffset=+2]
 
+[[three-act-structure]]
 include::anchors/three-act-structure.adoc[leveloffset=+2]
 
 <<<
 
 == Design Principles & Patterns
 
+[[code-smells]]
 include::anchors/code-smells.adoc[leveloffset=+2]
 
+[[cohesion-criteria]]
 include::anchors/cohesion-criteria.adoc[leveloffset=+2]
 
+[[crc-cards]]
 include::anchors/crc-cards.adoc[leveloffset=+2]
 
+[[dry]]
+include::anchors/dry.adoc[leveloffset=+2]
+
+[[fowler-patterns]]
 include::anchors/fowler-patterns.adoc[leveloffset=+2]
 
+[[gof-abstract-factory-pattern]]
 include::anchors/gof-abstract-factory-pattern.adoc[leveloffset=+2]
 
+[[gof-adapter-pattern]]
 include::anchors/gof-adapter-pattern.adoc[leveloffset=+2]
 
+[[gof-bridge-pattern]]
 include::anchors/gof-bridge-pattern.adoc[leveloffset=+2]
 
+[[gof-builder-pattern]]
 include::anchors/gof-builder-pattern.adoc[leveloffset=+2]
 
+[[gof-chain-of-responsibility-pattern]]
 include::anchors/gof-chain-of-responsibility-pattern.adoc[leveloffset=+2]
 
+[[gof-command-pattern]]
 include::anchors/gof-command-pattern.adoc[leveloffset=+2]
 
+[[gof-composite-pattern]]
 include::anchors/gof-composite-pattern.adoc[leveloffset=+2]
 
+[[gof-decorator-pattern]]
 include::anchors/gof-decorator-pattern.adoc[leveloffset=+2]
 
+[[gof-design-patterns]]
 include::anchors/gof-design-patterns.adoc[leveloffset=+2]
 
+[[gof-facade-pattern]]
 include::anchors/gof-facade-pattern.adoc[leveloffset=+2]
 
+[[gof-factory-method-pattern]]
 include::anchors/gof-factory-method-pattern.adoc[leveloffset=+2]
 
+[[gof-flyweight-pattern]]
 include::anchors/gof-flyweight-pattern.adoc[leveloffset=+2]
 
+[[gof-interpreter-pattern]]
 include::anchors/gof-interpreter-pattern.adoc[leveloffset=+2]
 
+[[gof-iterator-pattern]]
 include::anchors/gof-iterator-pattern.adoc[leveloffset=+2]
 
+[[gof-mediator-pattern]]
 include::anchors/gof-mediator-pattern.adoc[leveloffset=+2]
 
+[[gof-memento-pattern]]
 include::anchors/gof-memento-pattern.adoc[leveloffset=+2]
 
+[[gof-observer-pattern]]
 include::anchors/gof-observer-pattern.adoc[leveloffset=+2]
 
+[[gof-prototype-pattern]]
 include::anchors/gof-prototype-pattern.adoc[leveloffset=+2]
 
+[[gof-proxy-pattern]]
 include::anchors/gof-proxy-pattern.adoc[leveloffset=+2]
 
+[[gof-singleton-pattern]]
 include::anchors/gof-singleton-pattern.adoc[leveloffset=+2]
 
+[[gof-state-pattern]]
 include::anchors/gof-state-pattern.adoc[leveloffset=+2]
 
+[[gof-strategy-pattern]]
 include::anchors/gof-strategy-pattern.adoc[leveloffset=+2]
 
+[[gof-template-method-pattern]]
 include::anchors/gof-template-method-pattern.adoc[leveloffset=+2]
 
+[[gof-visitor-pattern]]
 include::anchors/gof-visitor-pattern.adoc[leveloffset=+2]
 
+[[grasp]]
 include::anchors/grasp.adoc[leveloffset=+2]
 
-include::anchors/kiss-principle.adoc[leveloffset=+2]
-
-include::anchors/single-level-of-abstraction-principle.adoc[leveloffset=+2]
-
+[[iosp]]
 include::anchors/iosp.adoc[leveloffset=+2]
 
+[[kiss-principle]]
+include::anchors/kiss-principle.adoc[leveloffset=+2]
+
+[[law-of-demeter]]
+include::anchors/law-of-demeter.adoc[leveloffset=+2]
+
+[[postels-law]]
+include::anchors/postels-law.adoc[leveloffset=+2]
+
+[[single-level-of-abstraction-principle]]
+include::anchors/single-level-of-abstraction-principle.adoc[leveloffset=+2]
+
+[[solid-dip]]
 include::anchors/solid-dip.adoc[leveloffset=+2]
 
+[[solid-isp]]
 include::anchors/solid-isp.adoc[leveloffset=+2]
 
+[[solid-lsp]]
 include::anchors/solid-lsp.adoc[leveloffset=+2]
 
+[[solid-ocp]]
 include::anchors/solid-ocp.adoc[leveloffset=+2]
 
+[[solid-principles]]
 include::anchors/solid-principles.adoc[leveloffset=+2]
 
+[[solid-srp]]
 include::anchors/solid-srp.adoc[leveloffset=+2]
 
+[[ssot-principle]]
 include::anchors/ssot-principle.adoc[leveloffset=+2]
 
+[[yagni]]
 include::anchors/yagni.adoc[leveloffset=+2]
 
 <<<
 
 == Development Workflow
 
+[[bem-methodology]]
 include::anchors/bem-methodology.adoc[leveloffset=+2]
 
+[[conventional-commits]]
 include::anchors/conventional-commits.adoc[leveloffset=+2]
 
+[[definition-of-done]]
 include::anchors/definition-of-done.adoc[leveloffset=+2]
 
+[[effective-go]]
 include::anchors/effective-go.adoc[leveloffset=+2]
 
+[[github-flow]]
 include::anchors/github-flow.adoc[leveloffset=+2]
 
+[[mental-model-according-to-naur]]
 include::anchors/mental-model-according-to-naur.adoc[leveloffset=+2]
 
+[[mikado-method]]
 include::anchors/mikado-method.adoc[leveloffset=+2]
 
+[[regulated-environment]]
 include::anchors/regulated-environment.adoc[leveloffset=+2]
 
+[[semantic-versioning]]
 include::anchors/semantic-versioning.adoc[leveloffset=+2]
 
+[[site-reliability-engineering]]
+include::anchors/site-reliability-engineering.adoc[leveloffset=+2]
+
+[[sota]]
 include::anchors/sota.adoc[leveloffset=+2]
 
+[[spike-solution]]
 include::anchors/spike-solution.adoc[leveloffset=+2]
 
+[[thin-vertical-slice]]
 include::anchors/thin-vertical-slice.adoc[leveloffset=+2]
 
+[[timtowtdi]]
 include::anchors/timtowtdi.adoc[leveloffset=+2]
 
 <<<
 
 == Dialogue Interaction
 
+[[socratic-method]]
 include::anchors/socratic-method.adoc[leveloffset=+2]
 
+[[systemic-consulting]]
+include::anchors/systemic-consulting.adoc[leveloffset=+2]
+
+[[xy-problem]]
 include::anchors/xy-problem.adoc[leveloffset=+2]
 
 <<<
 
 == Documentation
 
+[[diataxis-framework]]
 include::anchors/diataxis-framework.adoc[leveloffset=+2]
 
+[[docs-as-code]]
 include::anchors/docs-as-code.adoc[leveloffset=+2]
 
 <<<
 
 == Knowledge Management
 
+[[gtd]]
 include::anchors/gtd.adoc[leveloffset=+2]
 
+[[hemingway-bridge]]
 include::anchors/hemingway-bridge.adoc[leveloffset=+2]
 
+[[para-method]]
 include::anchors/para-method.adoc[leveloffset=+2]
 
+[[todotxt-flavoured-markdown]]
 include::anchors/todotxt-flavoured-markdown.adoc[leveloffset=+2]
 
 <<<
 
 == Meta
 
+[[luhmann-system-theory]]
+include::anchors/luhmann-system-theory.adoc[leveloffset=+2]
+
+[[simon-constructivism]]
+include::anchors/simon-constructivism.adoc[leveloffset=+2]
+
+[[what-qualifies-as-a-semantic-anchor]]
 include::anchors/what-qualifies-as-a-semantic-anchor.adoc[leveloffset=+2]
 
 <<<
 
 == Problem Solving
 
+[[chain-of-thought]]
 include::anchors/chain-of-thought.adoc[leveloffset=+2]
 
+[[decisional-balance-sheet]]
 include::anchors/decisional-balance-sheet.adoc[leveloffset=+2]
 
+[[devils-advocate]]
 include::anchors/devils-advocate.adoc[leveloffset=+2]
 
+[[double-diamond]]
 include::anchors/double-diamond.adoc[leveloffset=+2]
 
+[[feynman-technique]]
 include::anchors/feynman-technique.adoc[leveloffset=+2]
 
+[[first-principles-thinking]]
+include::anchors/first-principles-thinking.adoc[leveloffset=+2]
+
+[[five-whys]]
 include::anchors/five-whys.adoc[leveloffset=+2]
 
+include::anchors/luhmann-system-theory.adoc[leveloffset=+2]
+
+[[morphological-box]]
 include::anchors/morphological-box.adoc[leveloffset=+2]
 
+[[occams-razor]]
 include::anchors/occams-razor.adoc[leveloffset=+2]
 
+include::anchors/simon-constructivism.adoc[leveloffset=+2]
+
+include::anchors/systemic-consulting.adoc[leveloffset=+2]
+
+[[what-would-chuck-norris-do]]
 include::anchors/what-would-chuck-norris-do.adoc[leveloffset=+2]
 
 include::anchors/xy-problem.adoc[leveloffset=+2]
@@ -219,156 +343,224 @@ include::anchors/xy-problem.adoc[leveloffset=+2]
 
 == Requirements Engineering
 
+[[cockburn-use-cases]]
 include::anchors/cockburn-use-cases.adoc[leveloffset=+2]
 
 include::anchors/double-diamond.adoc[leveloffset=+2]
 
+[[ears-requirements]]
 include::anchors/ears-requirements.adoc[leveloffset=+2]
 
+[[event-storming]]
+include::anchors/event-storming.adoc[leveloffset=+2]
+
+[[invest]]
 include::anchors/invest.adoc[leveloffset=+2]
 
+[[kano-model]]
 include::anchors/kano-model.adoc[leveloffset=+2]
 
+[[moscow]]
 include::anchors/moscow.adoc[leveloffset=+2]
 
+[[prd]]
 include::anchors/prd.adoc[leveloffset=+2]
 
 include::anchors/problem-space-nvc.adoc[leveloffset=+2]
 
+[[quality-attribute-scenario]]
+include::anchors/quality-attribute-scenario.adoc[leveloffset=+2]
+
+[[user-story-mapping]]
 include::anchors/user-story-mapping.adoc[leveloffset=+2]
 
 <<<
 
 == Software Architecture
 
+[[adr-according-to-nygard]]
 include::anchors/adr-according-to-nygard.adoc[leveloffset=+2]
 
+[[arc42]]
 include::anchors/arc42.adoc[leveloffset=+2]
 
+[[atam]]
 include::anchors/atam.adoc[leveloffset=+2]
 
+[[c4-diagrams]]
 include::anchors/c4-diagrams.adoc[leveloffset=+2]
 
+[[cap-theorem]]
+include::anchors/cap-theorem.adoc[leveloffset=+2]
+
+[[clean-architecture]]
 include::anchors/clean-architecture.adoc[leveloffset=+2]
 
+[[conways-law]]
+include::anchors/conways-law.adoc[leveloffset=+2]
+
+[[cqrs]]
 include::anchors/cqrs.adoc[leveloffset=+2]
 
+[[domain-driven-design]]
 include::anchors/domain-driven-design.adoc[leveloffset=+2]
 
+[[event-driven-architecture]]
 include::anchors/event-driven-architecture.adoc[leveloffset=+2]
 
+include::anchors/event-storming.adoc[leveloffset=+2]
+
+[[fallacies-of-distributed-computing]]
+include::anchors/fallacies-of-distributed-computing.adoc[leveloffset=+2]
+
+[[gom]]
 include::anchors/gom.adoc[leveloffset=+2]
 
+[[hexagonal-architecture]]
 include::anchors/hexagonal-architecture.adoc[leveloffset=+2]
 
+[[iso-25010]]
 include::anchors/iso-25010.adoc[leveloffset=+2]
 
+[[lasr]]
 include::anchors/lasr.adoc[leveloffset=+2]
 
+[[lehmans-classification]]
 include::anchors/lehmans-classification.adoc[leveloffset=+2]
 
+[[madr]]
 include::anchors/madr.adoc[leveloffset=+2]
 
+include::anchors/quality-attribute-scenario.adoc[leveloffset=+2]
+
+[[tracer-bullet]]
 include::anchors/tracer-bullet.adoc[leveloffset=+2]
 
+[[vertical-slice-architecture]]
 include::anchors/vertical-slice-architecture.adoc[leveloffset=+2]
 
+[[walking-skeleton]]
 include::anchors/walking-skeleton.adoc[leveloffset=+2]
 
 <<<
 
 == Statistical Methods & Process Monitoring
 
+[[control-chart-shewhart]]
 include::anchors/control-chart-shewhart.adoc[leveloffset=+2]
 
+[[nelson-rules]]
 include::anchors/nelson-rules.adoc[leveloffset=+2]
 
+[[spc]]
 include::anchors/spc.adoc[leveloffset=+2]
 
 <<<
 
 == Strategic Planning
 
+[[cynefin-framework]]
 include::anchors/cynefin-framework.adoc[leveloffset=+2]
 
 include::anchors/decisional-balance-sheet.adoc[leveloffset=+2]
 
+[[goodharts-law]]
+include::anchors/goodharts-law.adoc[leveloffset=+2]
+
+[[hoshin-kanri]]
 include::anchors/hoshin-kanri.adoc[leveloffset=+2]
 
+[[impact-mapping]]
 include::anchors/impact-mapping.adoc[leveloffset=+2]
 
+[[jobs-to-be-done]]
 include::anchors/jobs-to-be-done.adoc[leveloffset=+2]
 
 include::anchors/kano-model.adoc[leveloffset=+2]
 
+[[kotter-8-step-change-model]]
 include::anchors/kotter-8-step-change-model.adoc[leveloffset=+2]
 
+[[meaningful-human-control]]
+include::anchors/meaningful-human-control.adoc[leveloffset=+2]
+
+[[mvp]]
 include::anchors/mvp.adoc[leveloffset=+2]
 
+[[pert]]
 include::anchors/pert.adoc[leveloffset=+2]
 
+[[pugh-matrix]]
 include::anchors/pugh-matrix.adoc[leveloffset=+2]
 
+[[swot]]
 include::anchors/swot.adoc[leveloffset=+2]
 
+[[wardley-mapping]]
 include::anchors/wardley-mapping.adoc[leveloffset=+2]
 
 <<<
 
 == Testing & Quality Practices
 
+[[bdd-given-when-then]]
 include::anchors/bdd-given-when-then.adoc[leveloffset=+2]
 
+[[fagan-inspection]]
 include::anchors/fagan-inspection.adoc[leveloffset=+2]
 
+[[gherkin]]
 include::anchors/gherkin.adoc[leveloffset=+2]
 
+[[iec-61508-sil-levels]]
 include::anchors/iec-61508-sil-levels.adoc[leveloffset=+2]
 
+[[linddun]]
 include::anchors/linddun.adoc[leveloffset=+2]
 
+[[llm-evaluations]]
 include::anchors/llm-evaluations.adoc[leveloffset=+2]
 
+[[mutation-testing]]
 include::anchors/mutation-testing.adoc[leveloffset=+2]
 
+[[owasp-top-10]]
 include::anchors/owasp-top-10.adoc[leveloffset=+2]
 
+[[property-based-testing]]
 include::anchors/property-based-testing.adoc[leveloffset=+2]
 
+[[red-green-tdd]]
 include::anchors/red-green-tdd.adoc[leveloffset=+2]
 
+[[stride]]
 include::anchors/stride.adoc[leveloffset=+2]
 
+[[tdd-chicago-school]]
 include::anchors/tdd-chicago-school.adoc[leveloffset=+2]
 
+[[tdd-london-school]]
 include::anchors/tdd-london-school.adoc[leveloffset=+2]
 
+[[test-double-dummy]]
 include::anchors/test-double-dummy.adoc[leveloffset=+2]
 
+[[test-double-fake]]
 include::anchors/test-double-fake.adoc[leveloffset=+2]
 
+[[test-double-meszaros]]
 include::anchors/test-double-meszaros.adoc[leveloffset=+2]
 
+[[test-double-mock]]
 include::anchors/test-double-mock.adoc[leveloffset=+2]
 
+[[test-double-spy]]
 include::anchors/test-double-spy.adoc[leveloffset=+2]
 
+[[test-double-stub]]
 include::anchors/test-double-stub.adoc[leveloffset=+2]
 
+[[testing-pyramid]]
 include::anchors/testing-pyramid.adoc[leveloffset=+2]
-
-<<<
-
-== Workflow
-
-include::anchors/workflow-architecture-documentation.adoc[leveloffset=+2]
-
-include::anchors/workflow-code-review.adoc[leveloffset=+2]
-
-include::anchors/workflow-requirements-to-spec.adoc[leveloffset=+2]
-
-include::anchors/workflow-strategic-analysis.adoc[leveloffset=+2]
-
-include::anchors/workflow-tdd-clean-architecture.adoc[leveloffset=+2]
 
 <<<

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,13 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-10
 
+*The website now works without JavaScript (#595):*
+
+* *Static navigation* — the HTML shell shipped empty header/footer placeholders and not a single `<a href>` link, so without JavaScript the site was a dead end for crawlers, LLM fetchers, and no-JS visitors. The shell now carries a real header (logo + nav) and footer with plain clean-URL links; with JavaScript the SPA hydrates on top exactly as before.
+* *Static home catalog* — the full category → anchor catalog (161 anchors) is pre-rendered into the home page, each anchor linking to its stable section in the _Full Reference_ (`/all-anchors#<anchor-id>`).
+* *Static German pages* — the home page and every doc page with a German translation are pre-rendered under `/de/…` with honest `hreflang` pairs (the previous `?lang=de` alternate served identical English HTML). A `/de` URL switches the SPA to German for JS users.
+* The legacy `#/route` hash links in the JS header/footer were replaced with the same clean URLs.
+
 *Discoverability (SEO / AI):*
 
 * *Structured data* — added a standalone `Organization` entity and a `DefinedTermSet` with a `DefinedTerm` for every anchor (name, canonical URL, and a definition where available), generated at build time from `anchors.json`. Lets search engines and retrieval-grounded AI resolve "Semantic Anchors" as a distinct entity and each anchor as a defined term (#579).

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -159,6 +159,7 @@ function adocToMarkdown(adoc) {
 // ─── Generate docs/all-anchors.adoc ─────────────────────────────────────────
 
 function generateAllAnchorsAdoc() {
+  const anchoredIds = new Set()
   const lines = [
     '= Semantic Anchors — Complete Reference',
     ':toc:',
@@ -177,6 +178,17 @@ function generateAllAnchorsAdoc() {
     for (const anchorId of category.anchors) {
       const filepath = path.join(ROOT, 'docs/anchors', `${anchorId}.adoc`)
       if (fs.existsSync(filepath)) {
+        // Explicit block anchor so each anchor section gets its stable
+        // catalog ID (e.g. #mece) instead of a title-derived one — the
+        // static home catalog links to /all-anchors#<anchor-id> (#595).
+        // AsciiDoc anchors must start with a letter; digit-leading IDs
+        // (4mat) already match their title-derived ID, so skip those.
+        // Multi-category anchors are included once per category — only
+        // the first occurrence gets the ID to avoid duplicate-id warnings.
+        if (/^[a-z]/.test(anchorId) && !anchoredIds.has(anchorId)) {
+          anchoredIds.add(anchorId)
+          lines.push(`[[${anchorId}]]`)
+        }
         lines.push(`include::anchors/${anchorId}.adoc[leveloffset=+2]`)
         lines.push('')
       }
@@ -434,6 +446,7 @@ function stripDocAttrs(content) {
 }
 
 function generateAllAnchorsWebAdoc() {
+  const anchoredIds = new Set()
   const WEB_DOCS = path.join(ROOT, 'website/public/docs')
   fs.mkdirSync(WEB_DOCS, { recursive: true })
 
@@ -461,6 +474,12 @@ function generateAllAnchorsWebAdoc() {
       const filepath = path.join(ROOT, 'docs/anchors', `${anchorId}.adoc`)
       if (fs.existsSync(filepath)) {
         const anchorContent = fs.readFileSync(filepath, 'utf-8')
+        // Same stable per-anchor section ID as in the include-based
+        // docs/all-anchors.adoc (see generateAllAnchorsAdoc).
+        if (/^[a-z]/.test(anchorId) && !anchoredIds.has(anchorId)) {
+          anchoredIds.add(anchorId)
+          lines.push(`[[${anchorId}]]`)
+        }
         lines.push(shiftHeadings(stripDocAttrs(anchorContent), 2))
         lines.push('')
       }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -51,6 +51,19 @@ const PAGES = [
   { path: '/rejected-proposals', priority: '0.5', changefreq: 'monthly' },
 ]
 
+// Pre-rendered German variants under /de/. Keep in sync with the routes in
+// scripts/prerender-routes.js that carry a fragmentDe (plus the home page).
+const DE_PAGES = [
+  '/',
+  '/about',
+  '/spec-driven-development',
+  '/brownfield',
+  '/socratic-recovery-skill',
+  '/contributing',
+  '/agentskill',
+  '/rejected-proposals',
+]
+
 const anchorsData = JSON.parse(fs.readFileSync(ANCHORS_DATA, 'utf-8'))
 const today = new Date().toISOString().split('T')[0]
 
@@ -84,6 +97,12 @@ for (const page of PAGES) {
   sitemap += urlEntry(loc, today, page.changefreq, page.priority)
 }
 
+// German variants
+for (const dePath of DE_PAGES) {
+  const loc = dePath === '/' ? `${BASE_URL}/de/` : `${BASE_URL}/de${dePath}`
+  sitemap += urlEntry(loc, today, 'monthly', '0.5')
+}
+
 // Individual anchor pages
 anchorsData.forEach((anchor) => {
   sitemap += urlEntry(
@@ -102,5 +121,5 @@ fs.writeFileSync(OUTPUT_FILE, sitemap, 'utf-8')
 
 console.log(`✓ Sitemap generated: ${OUTPUT_FILE}`)
 console.log(
-  `✓ Total URLs: ${PAGES.length + anchorsData.length} (${PAGES.length} pages + ${anchorsData.length} anchors)`
+  `✓ Total URLs: ${PAGES.length + DE_PAGES.length + anchorsData.length} (${PAGES.length} pages + ${DE_PAGES.length} German variants + ${anchorsData.length} anchors)`
 )

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -39,6 +39,10 @@ const ROUTES = [
     title: 'About — Semantic Anchors',
     description:
       'Learn what semantic anchors are, why they matter for LLM communication, and how the catalog is curated.',
+    fragmentDe: 'docs/about.de.html',
+    titleDe: 'Über — Semantic Anchors',
+    descriptionDe:
+      'Was semantische Anker sind, warum sie für die Kommunikation mit LLMs zählen und wie der Katalog kuratiert wird.',
   },
   {
     path: '/workflow',
@@ -50,6 +54,10 @@ const ROUTES = [
     title: 'Spec-Driven Development with Semantic Anchors',
     description:
       'Spec-driven development workflow — from requirements to specification to implementation, powered by semantic anchors.',
+    fragmentDe: 'docs/spec-driven-workflow.de.html',
+    titleDe: 'Spec-Driven Development mit Semantic Anchors',
+    descriptionDe:
+      'Spec-Driven-Development-Workflow — von den Anforderungen über die Spezifikation zur Implementierung, getragen von semantischen Ankern.',
   },
   {
     path: '/brownfield',
@@ -57,6 +65,10 @@ const ROUTES = [
     title: 'Brownfield Workflow — Semantic Anchors',
     description:
       'Applying semantic anchors to brownfield codebases using a bounded-context approach.',
+    fragmentDe: 'docs/brownfield-workflow.de.html',
+    titleDe: 'Brownfield-Workflow — Semantic Anchors',
+    descriptionDe:
+      'Semantische Anker in Brownfield-Codebasen anwenden — mit einem Bounded-Context-Ansatz.',
   },
   {
     path: '/brownfield-experiment-report',
@@ -85,6 +97,10 @@ const ROUTES = [
     title: 'Socratic Code-Theory Recovery Skill — Semantic Anchors',
     description:
       'Installable Claude Code Skill that packages the brownfield documentation-recovery workflow. Two-phase Question Tree with [ANSWERED]/[OPEN] leaves, Q-ID traceability. Install on Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI, and Amazon Kiro.',
+    fragmentDe: 'docs/socratic-recovery-skill.de.html',
+    titleDe: 'Socratic Code-Theory Recovery Skill — Semantic Anchors',
+    descriptionDe:
+      'Installierbarer Claude Code Skill für den Brownfield-Workflow zur Dokumentations-Wiederherstellung. Zweiphasiger Question Tree mit [ANSWERED]/[OPEN]-Blättern und Q-ID-Nachverfolgbarkeit.',
   },
   {
     path: '/training-data-vs-practice',
@@ -112,6 +128,10 @@ const ROUTES = [
     title: 'Contributing — Semantic Anchors',
     description:
       'How to propose new semantic anchors, quality criteria, and the contribution workflow.',
+    fragmentDe: 'CONTRIBUTING.de.html',
+    titleDe: 'Mitwirken — Semantic Anchors',
+    descriptionDe:
+      'Wie du neue semantische Anker vorschlägst: Qualitätskriterien und der Beitrags-Workflow.',
   },
   {
     path: '/agentskill',
@@ -119,6 +139,10 @@ const ROUTES = [
     title: 'AgentSkill — Semantic Anchors',
     description:
       'The semantic-anchor-translator AgentSkill — install semantic anchors into Claude Code, Codex, Cursor, and other coding agents.',
+    fragmentDe: 'docs/agentskill.de.html',
+    titleDe: 'AgentSkill — Semantic Anchors',
+    descriptionDe:
+      'Der semantic-anchor-translator AgentSkill — semantische Anker in Claude Code, Codex, Cursor und andere Coding-Agents installieren.',
   },
   {
     path: '/rejected-proposals',
@@ -126,6 +150,10 @@ const ROUTES = [
     title: 'Rejected Proposals — Semantic Anchors',
     description:
       'Anchor proposals that did not meet the quality criteria, with reasoning — useful for understanding the curation bar.',
+    fragmentDe: 'docs/rejected-proposals.de.html',
+    titleDe: 'Abgelehnte Vorschläge — Semantic Anchors',
+    descriptionDe:
+      'Anker-Vorschläge, die die Qualitätskriterien nicht erfüllt haben — mit Begründung, nützlich zum Verständnis der Kurationsschwelle.',
   },
   {
     path: '/all-anchors',
@@ -177,6 +205,53 @@ function escapeHtml(str) {
   )
 }
 
+const SITE = 'https://llm-coding.github.io/Semantic-Anchors'
+
+/**
+ * Apply per-page <head> metadata to a copy of the shell: <title>, meta
+ * description, self-referencing canonical URL, honest hreflang alternates
+ * (the shell ships home-pointing ones), and the <html lang> attribute for
+ * German pages.
+ * @param {string} html - Shell HTML.
+ * @param {{title: string, description: string, canonicalUrl: string,
+ *   enUrl: string, deUrl: (string|null), lang: string}} meta
+ * @returns {string} Updated HTML.
+ */
+function applyHead(html, { title, description, canonicalUrl, enUrl, deUrl, lang }) {
+  html = html.replace(/<title>[\s\S]*?<\/title>/, `<title>${escapeHtml(title)}</title>`)
+
+  html = html.replace(
+    /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/,
+    `<meta name="description" content="${escapeHtml(description)}" />`
+  )
+
+  html = html.replace(
+    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/,
+    `<link rel="canonical" href="${canonicalUrl}" />`
+  )
+
+  // Drop the shell's home-pointing language alternates, then re-insert
+  // per-page ones right after the canonical link.
+  html = html.replace(
+    /[ \t]*<link\s+rel="alternate"\s+hreflang="[^"]*"\s+href="[^"]*"\s*\/?>\s*\n/g,
+    ''
+  )
+  const alternates = [
+    `    <link rel="alternate" hreflang="en" href="${enUrl}" />`,
+    deUrl ? `    <link rel="alternate" hreflang="de" href="${deUrl}" />` : null,
+    `    <link rel="alternate" hreflang="x-default" href="${enUrl}" />`,
+  ]
+    .filter(Boolean)
+    .join('\n')
+  html = html.replace(/(<link\s+rel="canonical"[^>]*>)/, `$1\n${alternates}`)
+
+  if (lang === 'de') {
+    html = html.replace('<html lang="en">', '<html lang="de">')
+  }
+
+  return html
+}
+
 /**
  * Wrap the doc fragment in the structure that website/src/components/doc-page.js
  * produces at runtime: a centered article container with a #doc-content div.
@@ -216,32 +291,48 @@ function prerenderRoute(shell, route) {
     return
   }
 
-  const fragmentPath = path.join(DIST, route.fragment)
+  const enUrl = `${SITE}${route.path}`
+  const deUrl = route.fragmentDe ? `${SITE}/de${route.path}` : null
+
+  writeRouteVariant(shell, route.path, route.fragment, {
+    title: route.title,
+    description: route.description,
+    canonicalUrl: enUrl,
+    enUrl,
+    deUrl,
+    lang: 'en',
+  })
+
+  if (route.fragmentDe) {
+    writeRouteVariant(shell, `/de${route.path}`, route.fragmentDe, {
+      title: route.titleDe || route.title,
+      description: route.descriptionDe || route.description,
+      canonicalUrl: deUrl,
+      enUrl,
+      deUrl,
+      lang: 'de',
+    })
+  }
+}
+
+/**
+ * Write one language variant of a pre-rendered route: read the fragment,
+ * apply the per-page <head> metadata, inject the content into the shell's
+ * empty #page-content div, and write dist/<outPath>/index.html. Throws if
+ * the fragment is missing so the build fails fast instead of shipping an
+ * incomplete set of pre-rendered pages.
+ */
+function writeRouteVariant(shell, outPath, fragmentRel, headMeta) {
+  const fragmentPath = path.join(DIST, fragmentRel)
   if (!fs.existsSync(fragmentPath)) {
     throw new Error(
-      `Missing fragment for ${route.path}: ${route.fragment} (expected at ${fragmentPath}). ` +
+      `Missing fragment for ${outPath}: ${fragmentRel} (expected at ${fragmentPath}). ` +
         `Make sure scripts/render-docs.js runs before prerender-routes.js and writes the fragment to website/public/docs/.`
     )
   }
   const fragment = fs.readFileSync(fragmentPath, 'utf-8')
 
-  let html = shell
-
-  // Replace <title>
-  html = html.replace(/<title>[\s\S]*?<\/title>/, `<title>${escapeHtml(route.title)}</title>`)
-
-  // Replace meta description if present
-  html = html.replace(
-    /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/,
-    `<meta name="description" content="${escapeHtml(route.description)}" />`
-  )
-
-  // Update canonical URL so each pre-rendered page points to itself
-  const canonicalUrl = `https://llm-coding.github.io/Semantic-Anchors${route.path}`
-  html = html.replace(
-    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/,
-    `<link rel="canonical" href="${canonicalUrl}" />`
-  )
+  let html = applyHead(shell, headMeta)
 
   // Inject pre-rendered content into the static shell's #page-content div.
   // The shell (set up in website/index.html and preserved through vite build)
@@ -257,7 +348,7 @@ function prerenderRoute(shell, route) {
   }
   html = html.replace(pageContentRegex, `$1${buildDocContentMarkup(fragment)}$2`)
 
-  const outDir = path.join(DIST, route.path)
+  const outDir = path.join(DIST, outPath)
   const outFile = path.join(outDir, 'index.html')
   fs.mkdirSync(outDir, { recursive: true })
   fs.writeFileSync(outFile, html, 'utf-8')
@@ -278,12 +369,76 @@ function prerenderRoute(shell, route) {
  * routes (already written from the cached shell) keep their empty-skeleton
  * assumption.
  */
-function prerenderHome() {
-  const enPath = path.join(__dirname, '..', 'website', 'src', 'translations', 'en.json')
-  const en = JSON.parse(fs.readFileSync(enPath, 'utf-8'))
-  const title = en['hero.title'] || ''
-  const intro = en['hero.intro'] || ''
-  const emphasis = en['hero.introEmphasis'] || ''
+function prerenderHome(shell) {
+  writeHomeVariant(shell, 'en')
+  writeHomeVariant(shell, 'de')
+}
+
+/**
+ * Load a JSON file relative to the website/ app directory.
+ */
+function loadWebsiteJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'website', rel), 'utf-8'))
+}
+
+/**
+ * Build the static catalog markup for the home page: one section per
+ * category with plain links for every anchor, targeting the stable
+ * per-anchor section IDs in the pre-rendered /all-anchors reference.
+ * Uses only utility classes that already occur in src/ or index.html, so
+ * they are guaranteed to be present in the built stylesheet.
+ */
+function buildCatalogMarkup(lang, translations) {
+  const categories = loadWebsiteJson('public/data/categories.json')
+  const anchors = loadWebsiteJson('public/data/anchors.json')
+  const byId = new Map(anchors.map((a) => [a.id, a]))
+  const heading =
+    lang === 'de'
+      ? `Der Katalog: ${anchors.length} Anker`
+      : `The catalog: ${anchors.length} anchors`
+
+  const linkClasses =
+    'rounded-md px-2 py-1 text-sm text-[var(--color-text-secondary)] ' +
+    'hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors'
+
+  const sections = categories
+    .map((category) => {
+      const items = (category.anchors || [])
+        .map((id) => byId.get(id))
+        .filter(Boolean)
+        .map(
+          (anchor) =>
+            `<li><a href="/Semantic-Anchors/all-anchors#${escapeHtml(anchor.id)}" class="${linkClasses}">${escapeHtml(anchor.title)}</a></li>`
+        )
+        .join('')
+      if (!items) return ''
+      const name = translations[`categories.${category.id}`] || category.name
+      return `
+        <section class="mb-3">
+          <h3 class="text-lg font-semibold mb-2">${escapeHtml(name)}</h3>
+          <ul class="flex flex-wrap gap-2">${items}</ul>
+        </section>`
+    })
+    .filter(Boolean)
+    .join('')
+
+  return `
+      <section class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <h2 class="text-2xl font-bold mb-3">${escapeHtml(heading)}</h2>${sections}
+      </section>
+    `
+}
+
+/**
+ * Write one language variant of the home page: hero copy + static catalog,
+ * single-sourced from the translations so it never drifts from the live
+ * hero. EN overwrites dist/index.html, DE goes to dist/de/index.html.
+ */
+function writeHomeVariant(shell, lang) {
+  const tr = loadWebsiteJson(`src/translations/${lang}.json`)
+  const title = tr['hero.title'] || ''
+  const intro = tr['hero.intro'] || ''
+  const emphasis = tr['hero.introEmphasis'] || ''
 
   const block = `
       <section class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -291,9 +446,24 @@ function prerenderHome() {
         <p class="mb-2 max-w-3xl">${escapeHtml(intro)}</p>
         <p class="font-semibold max-w-3xl">${escapeHtml(emphasis)}</p>
       </section>
+      ${buildCatalogMarkup(lang, tr)}
     `
 
-  let html = fs.readFileSync(SHELL, 'utf-8')
+  let html = applyHead(shell, {
+    title:
+      lang === 'de'
+        ? 'Semantic Anchors - Gemeinsames Vokabular für die Kommunikation mit LLMs'
+        : 'Semantic Anchors - Shared Vocabulary for LLM Communication',
+    description:
+      lang === 'de'
+        ? '110+ semantische Anker und semantische Contracts für präzise LLM-Kommunikation. Kuratierte Methoden, Frameworks und komponierbare Projektkonventionen. Über 10 Modelle evaluiert.'
+        : '110+ semantic anchors and semantic contracts for precise LLM communication. Curated methodologies, frameworks, and composable project conventions. Evaluated across 10 models.',
+    canonicalUrl: lang === 'de' ? `${SITE}/de/` : `${SITE}/`,
+    enUrl: `${SITE}/`,
+    deUrl: `${SITE}/de/`,
+    lang,
+  })
+
   const pageContentRegex = /(<div\s+id="page-content"[^>]*>)\s*(<\/div>)/
   if (!pageContentRegex.test(html)) {
     throw new Error(
@@ -301,8 +471,16 @@ function prerenderHome() {
     )
   }
   html = html.replace(pageContentRegex, `$1${block}$2`)
-  fs.writeFileSync(SHELL, html, 'utf-8')
-  console.log('  ✓ pre-rendered / (home answer block)')
+
+  if (lang === 'de') {
+    const outDir = path.join(DIST, 'de')
+    fs.mkdirSync(outDir, { recursive: true })
+    fs.writeFileSync(path.join(outDir, 'index.html'), html, 'utf-8')
+    console.log('  ✓ pre-rendered /de/ (home, German)')
+  } else {
+    fs.writeFileSync(SHELL, html, 'utf-8')
+    console.log('  ✓ pre-rendered / (home answer block + catalog)')
+  }
 }
 
 /**
@@ -315,9 +493,9 @@ function main() {
   const shell = readShell()
   for (const route of ROUTES) {
     prerenderRoute(shell, route)
-    console.log(`  ✓ pre-rendered ${route.path}`)
+    console.log(`  ✓ pre-rendered ${route.path}${route.fragmentDe ? ' (+ /de variant)' : ''}`)
   }
-  prerenderHome()
+  prerenderHome(shell)
   console.log(`\n✓ Pre-rendered ${ROUTES.length} routes + home to dist/<route>/index.html`)
 }
 

--- a/scripts/render-docs.js
+++ b/scripts/render-docs.js
@@ -105,7 +105,12 @@ renderFile(path.join(ROOT, 'docs/about.adoc'), path.join(WEB_DOCS, 'about.html')
 renderFile(path.join(ROOT, 'docs/about.de.adoc'), path.join(WEB_DOCS, 'about.de.html'))
 
 renderFile(path.join(ROOT, 'CONTRIBUTING.adoc'), path.join(WEB_PUBLIC, 'CONTRIBUTING.html'))
-renderFile(path.join(ROOT, 'CONTRIBUTING.de.adoc'), path.join(WEB_PUBLIC, 'CONTRIBUTING.de.html'))
+// The German CONTRIBUTING source lives only in website/public/ (served raw to
+// the SPA); render it from there so the /de/contributing page can be built.
+renderFile(
+  path.join(WEB_PUBLIC, 'CONTRIBUTING.de.adoc'),
+  path.join(WEB_PUBLIC, 'CONTRIBUTING.de.html')
+)
 
 renderFile(path.join(ROOT, 'docs/changelog.adoc'), path.join(WEB_DOCS, 'changelog.html'))
 

--- a/website/index.html
+++ b/website/index.html
@@ -21,7 +21,7 @@
 
     <!-- Language Alternates -->
     <link rel="alternate" hreflang="en" href="https://llm-coding.github.io/Semantic-Anchors/" />
-    <link rel="alternate" hreflang="de" href="https://llm-coding.github.io/Semantic-Anchors/?lang=de" />
+    <link rel="alternate" hreflang="de" href="https://llm-coding.github.io/Semantic-Anchors/de/" />
     <link rel="alternate" hreflang="x-default" href="https://llm-coding.github.io/Semantic-Anchors/" />
 
     <!-- Open Graph / Facebook -->
@@ -112,17 +112,54 @@
   </head>
   <body>
     <!--
-      Skeleton shell: reserves viewport-height layout space so first paint
-      already has the expected header/content/footer footprint. Without this
-      the SPA boot caused CLS ~0.975 (empty #app → populated #app). main.js
-      detects the skeleton via #shell-header / #shell-footer and replaces the
-      header + footer in place, leaving #page-content untouched. See #432.
+      Static shell: real header/footer navigation with plain <a href> links so
+      crawlers and no-JS visitors can reach every pre-rendered page (#595).
+      The reserved min-heights keep the CLS fix from #432 intact. main.js
+      detects the shell via #shell-header / #shell-footer and replaces the
+      header + footer in place at boot (search, filters, menus, language and
+      theme toggles are JS-only extras), leaving #page-content untouched.
+      Keep the link set in sync with src/components/header.js / footer.js.
     -->
     <div id="app">
       <div id="shell-root" class="flex flex-col" style="min-height: 100vh;">
-        <div id="shell-header" class="border-b border-[var(--color-border)]" style="height: 8.75rem;" aria-hidden="true"></div>
+        <div id="shell-header" class="border-b border-[var(--color-border)]" style="min-height: 8.75rem;">
+          <header>
+            <nav class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-3 flex flex-col sm:flex-row items-center gap-4 sm:gap-6">
+              <a href="%BASE_URL%" class="no-underline flex flex-col items-center">
+                <img src="%BASE_URL%logo.png" alt="Semantic Anchors" width="218" height="96" class="h-24 w-[218px] max-w-none shrink-0" />
+                <span class="text-xs text-[var(--color-text-secondary)] leading-tight">One word, and the AI gets the rest.</span>
+              </a>
+              <div class="flex-1 flex flex-wrap items-center justify-center sm:justify-start gap-4 text-lg">
+                <a href="%BASE_URL%" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Anchors</a>
+                <a href="%BASE_URL%contracts" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Contracts</a>
+                <a href="%BASE_URL%spec-driven-development" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Spec-Driven Dev</a>
+                <a href="%BASE_URL%about" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">About</a>
+                <a href="%BASE_URL%agentskill" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">AgentSkill</a>
+                <a href="%BASE_URL%harness-inventory" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Harness Inventory</a>
+                <a href="%BASE_URL%training-data-vs-practice" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Anchors &amp; Training Data</a>
+                <a href="%BASE_URL%contributing" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Contributing</a>
+                <a href="%BASE_URL%changelog" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Changelog</a>
+                <a href="%BASE_URL%de/" hreflang="de" lang="de" class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Deutsch</a>
+              </div>
+            </nav>
+          </header>
+        </div>
         <div id="page-content" class="flex-1" style="min-height: calc(100vh - 14.75rem);"></div>
-        <div id="shell-footer" class="border-t border-[var(--color-border)]" style="height: 6rem;" aria-hidden="true"></div>
+        <div id="shell-footer" class="border-t border-[var(--color-border)]" style="min-height: 6rem;">
+          <footer>
+            <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8 flex flex-wrap items-center justify-center gap-4">
+              <a href="https://github.com/LLM-Coding/Semantic-Anchors" class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">GitHub</a>
+              <span class="text-gray-300 dark:text-gray-600">|</span>
+              <a href="%BASE_URL%llms.txt" class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">llms.txt</a>
+              <span class="text-gray-300 dark:text-gray-600">|</span>
+              <a href="%BASE_URL%all-anchors" class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Full Reference</a>
+              <span class="text-gray-300 dark:text-gray-600">|</span>
+              <a href="%BASE_URL%rejected-proposals" class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Rejected Proposals</a>
+              <span class="text-gray-300 dark:text-gray-600">|</span>
+              <a href="%BASE_URL%evaluations" class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors">Evaluations</a>
+            </div>
+          </footer>
+        </div>
       </div>
     </div>
     <script type="module" src="/src/main.js"></script>

--- a/website/src/components/footer.js
+++ b/website/src/components/footer.js
@@ -21,26 +21,26 @@ export function renderFooter(version) {
             </a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
-              href="llms.txt"
+              href="${import.meta.env.BASE_URL}llms.txt"
               class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
               data-i18n="footer.llmsTxt"
               title="LLM-readable full reference"
             >${i18n.t('footer.llmsTxt')}</a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
-              href="#/all-anchors"
+              href="${import.meta.env.BASE_URL}all-anchors"
               class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
               data-i18n="footer.allAnchors"
             >${i18n.t('footer.allAnchors')}</a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
-              href="#/rejected-proposals"
+              href="${import.meta.env.BASE_URL}rejected-proposals"
               class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
               data-i18n="footer.rejectedProposals"
             >${i18n.t('footer.rejectedProposals')}</a>
             <span class="text-gray-300 dark:text-gray-600">|</span>
             <a
-              href="#/evaluations"
+              href="${import.meta.env.BASE_URL}evaluations"
               class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
               data-i18n="footer.evaluations"
             >${i18n.t('footer.evaluations')}</a>

--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -10,7 +10,7 @@ export function renderHeader() {
         <div class="hidden sm:flex items-stretch gap-6">
           <!-- Logo left, spanning both rows -->
           <div class="flex items-center">
-            <a href="#/" class="no-underline flex flex-col items-center">
+            <a href="${import.meta.env.BASE_URL}" class="no-underline flex flex-col items-center">
               <img src="${import.meta.env.BASE_URL}logo.png" alt="Semantic Anchors" width="218" height="96" class="h-24 w-[218px] max-w-none shrink-0" />
               <span class="text-xs text-[var(--color-text-secondary)] leading-tight" data-i18n="header.slogan">${i18n.t('header.slogan')}</span>
             </a>
@@ -34,21 +34,21 @@ export function renderHeader() {
             <!-- Row 1: Navigation + Language/Theme -->
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-6 text-2xl">
-                <a href="#/" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
-                <a href="#/contracts" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
-                <a href="#/spec-driven-development" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
+                <a href="${import.meta.env.BASE_URL}" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
+                <a href="${import.meta.env.BASE_URL}contracts" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
+                <a href="${import.meta.env.BASE_URL}spec-driven-development" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
                 <div class="relative" id="more-menu-container">
                   <button id="more-menu-toggle" class="nav-link text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors flex items-center gap-1" data-i18n="nav.more">
                     ${i18n.t('nav.more')}
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                   </button>
                   <div id="more-menu-dropdown" class="absolute left-0 top-full mt-1 hidden bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg shadow-lg py-2 min-w-[160px] z-50">
-                    <a href="#/about" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/about" data-i18n="nav.about">${i18n.t('nav.about')}</a>
-                    <a href="#/agentskill" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/agentskill" data-i18n="nav.agentskill">${i18n.t('nav.agentskill')}</a>
-                    <a href="#/harness-inventory" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/harness-inventory" data-i18n="nav.harnessInventory">${i18n.t('nav.harnessInventory')}</a>
-                    <a href="#/training-data-vs-practice" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/training-data-vs-practice" data-i18n="nav.trainingData">${i18n.t('nav.trainingData')}</a>
-                    <a href="#/contributing" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contributing" data-i18n="nav.contributing">${i18n.t('nav.contributing')}</a>
-                    <a href="#/changelog" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/changelog" data-i18n="nav.changelog">${i18n.t('nav.changelog')}</a>
+                    <a href="${import.meta.env.BASE_URL}about" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/about" data-i18n="nav.about">${i18n.t('nav.about')}</a>
+                    <a href="${import.meta.env.BASE_URL}agentskill" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/agentskill" data-i18n="nav.agentskill">${i18n.t('nav.agentskill')}</a>
+                    <a href="${import.meta.env.BASE_URL}harness-inventory" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/harness-inventory" data-i18n="nav.harnessInventory">${i18n.t('nav.harnessInventory')}</a>
+                    <a href="${import.meta.env.BASE_URL}training-data-vs-practice" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/training-data-vs-practice" data-i18n="nav.trainingData">${i18n.t('nav.trainingData')}</a>
+                    <a href="${import.meta.env.BASE_URL}contributing" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contributing" data-i18n="nav.contributing">${i18n.t('nav.contributing')}</a>
+                    <a href="${import.meta.env.BASE_URL}changelog" class="nav-link block px-4 py-2 text-base text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/changelog" data-i18n="nav.changelog">${i18n.t('nav.changelog')}</a>
                   </div>
                 </div>
               </div>
@@ -101,7 +101,7 @@ export function renderHeader() {
         <!-- Mobile: stacked layout -->
         <div class="sm:hidden">
           <div class="flex flex-col items-center">
-            <a href="#/" class="no-underline flex flex-col items-center">
+            <a href="${import.meta.env.BASE_URL}" class="no-underline flex flex-col items-center">
               <img src="${import.meta.env.BASE_URL}logo.png" alt="Semantic Anchors" width="145" height="64" class="h-16 w-[145px] max-w-none shrink-0" />
               <span class="text-xs text-[var(--color-text-secondary)] leading-tight text-center" data-i18n="header.slogan">${i18n.t('header.slogan')}</span>
             </a>
@@ -155,15 +155,15 @@ export function renderHeader() {
         <!-- Mobile menu -->
         <div id="mobile-menu" class="hidden sm:hidden mt-3 pb-2 border-t border-[var(--color-border)] pt-3">
           <div class="flex flex-col gap-2">
-            <a href="#/" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
-            <a href="#/contracts" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
-            <a href="#/spec-driven-development" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
-            <a href="#/about" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/about" data-i18n="nav.about">${i18n.t('nav.about')}</a>
-            <a href="#/agentskill" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/agentskill" data-i18n="nav.agentskill">${i18n.t('nav.agentskill')}</a>
-            <a href="#/harness-inventory" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/harness-inventory" data-i18n="nav.harnessInventory">${i18n.t('nav.harnessInventory')}</a>
-            <a href="#/training-data-vs-practice" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/training-data-vs-practice" data-i18n="nav.trainingData">${i18n.t('nav.trainingData')}</a>
-            <a href="#/contributing" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contributing" data-i18n="nav.contributing">${i18n.t('nav.contributing')}</a>
-            <a href="#/changelog" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/changelog" data-i18n="nav.changelog">${i18n.t('nav.changelog')}</a>
+            <a href="${import.meta.env.BASE_URL}" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/" data-i18n="nav.catalog">${i18n.t('nav.catalog')}</a>
+            <a href="${import.meta.env.BASE_URL}contracts" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contracts" data-i18n="nav.contracts">${i18n.t('nav.contracts')}</a>
+            <a href="${import.meta.env.BASE_URL}spec-driven-development" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/spec-driven-development" data-i18n="nav.workflow">${i18n.t('nav.workflow')}</a>
+            <a href="${import.meta.env.BASE_URL}about" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/about" data-i18n="nav.about">${i18n.t('nav.about')}</a>
+            <a href="${import.meta.env.BASE_URL}agentskill" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/agentskill" data-i18n="nav.agentskill">${i18n.t('nav.agentskill')}</a>
+            <a href="${import.meta.env.BASE_URL}harness-inventory" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/harness-inventory" data-i18n="nav.harnessInventory">${i18n.t('nav.harnessInventory')}</a>
+            <a href="${import.meta.env.BASE_URL}training-data-vs-practice" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/training-data-vs-practice" data-i18n="nav.trainingData">${i18n.t('nav.trainingData')}</a>
+            <a href="${import.meta.env.BASE_URL}contributing" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/contributing" data-i18n="nav.contributing">${i18n.t('nav.contributing')}</a>
+            <a href="${import.meta.env.BASE_URL}changelog" class="nav-link mobile-nav-link px-3 py-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-route="/changelog" data-i18n="nav.changelog">${i18n.t('nav.changelog')}</a>
           </div>
         </div>
       </nav>

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -27,7 +27,7 @@ import {
 } from './components/onboarding-modal.js'
 import { renderContractsPage, initContractsPage } from './components/contracts-page.js'
 
-const APP_VERSION = '0.4.0'
+const APP_VERSION = '0.5.0'
 
 window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   const url = `${window.location.origin}${import.meta.env.BASE_URL}anchor/${anchorId}`
@@ -560,6 +560,13 @@ function bindLanguageToggle() {
 }
 
 function handleLanguageChange() {
+  // Keep the toggle label correct for programmatic language switches too
+  // (e.g. the router switching to German on a /de/<route> URL).
+  const langLabel = i18n.currentLang() === 'en' ? 'DE' : 'EN'
+  document.querySelectorAll('#lang-toggle, #lang-toggle-mobile').forEach((el) => {
+    el.textContent = langLabel
+  })
+
   const currentRoute = getCurrentRouteSync()
 
   if (currentRoute === '/about') {

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -3,6 +3,8 @@
  * Deployed under a base path (e.g., /Semantic-Anchors/)
  */
 
+import { i18n } from '../i18n.js'
+
 const routes = new Map()
 let currentRoute = null
 let routeBeforeModal = null
@@ -50,6 +52,19 @@ function buildPath(route) {
 }
 
 /**
+ * Split an optional language prefix off a route path. The pre-rendered
+ * German pages live under /de/<route> (e.g. /de/about); the SPA resolves
+ * them to the same route handlers with the language switched to German.
+ * @param {string} path - Route path with the base already stripped.
+ * @returns {{path: string, lang: string|null}}
+ */
+function splitLangPrefix(path) {
+  if (path === '/de') return { path: '/', lang: 'de' }
+  if (path.startsWith('/de/')) return { path: path.slice(3), lang: 'de' }
+  return { path, lang: null }
+}
+
+/**
  * Register a route handler
  * @param {string} path - Route path (e.g., '/', '/about', '/contributing')
  * @param {Function} handler - Function to call when route is active
@@ -79,7 +94,7 @@ export function getCurrentRoute() {
   if (window.location.hash.startsWith('#/')) {
     return window.location.hash.slice(1)
   }
-  return stripBase(window.location.pathname)
+  return splitLangPrefix(stripBase(window.location.pathname)).path
 }
 
 /**
@@ -183,6 +198,11 @@ function closeOpenAnchorModal() {
 }
 
 function handleRoute() {
+  // A /de/<route> URL (pre-rendered German page) switches the app language
+  // before the route handler runs, so the SPA hydrates in German.
+  const { lang } = splitLangPrefix(stripBase(window.location.pathname))
+  if (lang) i18n.setLang(lang)
+
   let path = getCurrentRoute()
 
   // Normalize trailing slash: GitHub Pages 301-redirects routes like

--- a/website/src/utils/router.test.js
+++ b/website/src/utils/router.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { addRoute, getCurrentRoute, initRouter, navigate } from './router.js'
+import { i18n } from '../i18n.js'
 
 describe('router', () => {
   beforeEach(() => {
@@ -48,5 +49,44 @@ describe('router', () => {
       expect.objectContaining({ path: '/gc-test' })
     )
     delete window.goatcounter
+  })
+})
+
+describe('router language prefix (/de)', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/')
+    window.location.hash = ''
+    localStorage.clear()
+    i18n.init()
+  })
+
+  it('strips the /de prefix from the current route', () => {
+    history.replaceState(null, '', '/de/about')
+    expect(getCurrentRoute()).toBe('/about')
+  })
+
+  it('maps bare /de to the home route', () => {
+    history.replaceState(null, '', '/de')
+    expect(getCurrentRoute()).toBe('/')
+  })
+
+  it('resolves the underlying route handler and switches to German', () => {
+    const handler = vi.fn()
+    addRoute('/de-prefix-test', handler)
+    history.replaceState(null, '', '/de/de-prefix-test')
+
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    expect(handler).toHaveBeenCalled()
+    expect(i18n.currentLang()).toBe('de')
+  })
+
+  it('leaves the language untouched on unprefixed routes', () => {
+    addRoute('/en-route-test', vi.fn())
+    history.replaceState(null, '', '/en-route-test')
+
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    expect(i18n.currentLang()).toBe('en')
   })
 })


### PR DESCRIPTION
Closes #595

## What

Without JavaScript the site was a complete dead end: the shell shipped empty `aria-hidden` header/footer placeholders, **zero `<a href>` links**, no anchor list, and `/anchor/<id>` URLs are real 404s. This PR makes the static HTML navigable and readable — for crawlers, LLM fetchers, and no-JS visitors — in both languages, while JS users get the exact same SPA as before (hydration on top).

## Changes

1. **Static shell navigation** (`website/index.html`): real header (logo + nav links) and footer (reference links) with plain clean-URL `<a href>`s replace the empty skeleton placeholders. `min-height` keeps the CLS reservation from #432; `main.js#hydrateShell()` still swaps both blocks in place at boot.
2. **Static home catalog** (`prerender-routes.js`): the full category → anchor catalog (161 anchors, EN + DE) is pre-rendered into the home page below the hero, single-sourced from `categories.json`/`anchors.json` and the translations.
3. **Stable per-anchor link targets** (`generate-llms-txt.js` + regenerated `docs/all-anchors.adoc`): every anchor section in the full reference now carries its canonical ID, so `/all-anchors#mece` works (previously only title-derived IDs like `#mece-principle` existed). First occurrence only for multi-category anchors; digit-leading IDs (`4mat`) already match their title-derived ID.
4. **Pre-rendered German pages**: every route with a `.de` fragment (about, contributing, agentskill, rejected-proposals, brownfield, socratic-recovery-skill, spec-driven-development) plus the home page now exists statically under `/de/…` with `lang="de"`, localized title/description, self-canonical URL, and honest `hreflang` pairs — the previous `?lang=de` alternate served identical English HTML. The sitemap lists the 8 German pages.
5. **Router** (`router.js`, TDD): a `/de/<route>` URL resolves to the normal route handler and switches the app language to German, so JS users on a German URL get the SPA in German. `handleLanguageChange` now also refreshes the language-toggle label on programmatic switches.
6. **Legacy hash links** in the JS header/footer (`#/contracts` …) replaced with the same clean URLs the static shell uses (the router already intercepts them for SPA navigation).
7. Version bump to **v0.5.0**, changelog entry.

## Verification

- `npm test`: 102 unit tests pass (4 new router tests for the `/de` prefix).
- `npx playwright test`: all 35 E2E tests pass.
- Playwright with `javaScriptEnabled: false` against the preview build: home shows 11 nav links + 171 catalog links; `/about/`, `/all-anchors/` (incl. `#mece` target), `/de/`, `/de/about/` all render real content; German pages are German.
- With JS: SPA hydrates (search input, card grid, modals), `/de/about` boots in German with the toggle label correct, no page errors.
- Lint + Prettier clean (website + scripts).

No-JS home page after this PR:

| EN | DE |
|----|----|
| real header nav + hero + full catalog | same, localized |

## Out of scope (follow-ups)

- Real static pages per anchor (`/anchor/<id>/index.html`) — the sitemap still advertises those URLs, which remain 404s for non-JS crawlers; worth its own issue.
- The remaining `#/…` links inside client-rendered components (`main-content.js`, `contracts-page.js`) — invisible to crawlers, handled by the router's legacy shim.
- No-JS search/filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Deutsche Sprachvarianten mit dediziertem `/de/`-Pfad für bessere Lokalisierung
  * Statische HTML-Shell mit echtem Header und Footer für verbesserte Crawlbarkeit

* **Dokumentation**
  * Aktualisierte Ankerpunkte und dokumentarische Verweise
  * Changelog mit Verbesserungen zur JavaScript-freien Bereitstellung

* **Refaktor**
  * Optimierte URL-Struktur für Navigation und Footer-Links
  * Verbesserter Sprachwahlmechanismus und Router-Logik

<!-- end of auto-generated comment: release notes by coderabbit.ai -->