### PR TITLE
feat: real pre-rendered pages for all 161 anchors (EN + 155 DE) — no more 404s

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-10
 
+*Real anchor pages (#597):*
+
+* Every `/anchor/<id>` URL was an HTTP 404, served only through the JavaScript SPA fallback — while the sitemap and the DefinedTerm structured data advertised all 161 of them. Each anchor is now a real pre-rendered page (own title, description, canonical URL, content expanded), plus a German `/de/anchor/<id>` variant for the 155 translated anchors, with `hreflang` pairs. The static home catalog now links to these pages directly.
+
 *The website now works without JavaScript (#595):*
 
 * *Static navigation* — the HTML shell shipped empty header/footer placeholders and not a single `<a href>` link, so without JavaScript the site was a dead end for crawlers, LLM fetchers, and no-JS visitors. The shell now carries a real header (logo + nav) and footer with plain clean-URL links; with JavaScript the SPA hydrates on top exactly as before.

--- a/scripts/generate-jsonld.js
+++ b/scripts/generate-jsonld.js
@@ -165,4 +165,4 @@ function main() {
 
 if (require.main === module) main()
 
-module.exports = { buildDefinedTermSet, buildScriptTag }
+module.exports = { buildDefinedTermSet, buildScriptTag, extractDescription }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -103,7 +103,9 @@ for (const dePath of DE_PAGES) {
   sitemap += urlEntry(loc, today, 'monthly', '0.5')
 }
 
-// Individual anchor pages
+// Individual anchor pages (pre-rendered static pages since #597), plus the
+// /de variant where a German translation exists.
+let deAnchorCount = 0
 anchorsData.forEach((anchor) => {
   sitemap += urlEntry(
     `${BASE_URL}/anchor/${anchor.id}`,
@@ -112,6 +114,10 @@ anchorsData.forEach((anchor) => {
     '0.6',
     `Anchor: ${anchor.title}`
   )
+  if (fs.existsSync(path.join(__dirname, '..', 'docs', 'anchors', `${anchor.id}.de.adoc`))) {
+    sitemap += urlEntry(`${BASE_URL}/de/anchor/${anchor.id}`, today, 'monthly', '0.5')
+    deAnchorCount++
+  }
 })
 
 sitemap += `</urlset>
@@ -121,5 +127,5 @@ fs.writeFileSync(OUTPUT_FILE, sitemap, 'utf-8')
 
 console.log(`✓ Sitemap generated: ${OUTPUT_FILE}`)
 console.log(
-  `✓ Total URLs: ${PAGES.length + DE_PAGES.length + anchorsData.length} (${PAGES.length} pages + ${DE_PAGES.length} German variants + ${anchorsData.length} anchors)`
+  `✓ Total URLs: ${PAGES.length + DE_PAGES.length + anchorsData.length + deAnchorCount} (${PAGES.length} pages + ${DE_PAGES.length} German pages + ${anchorsData.length} anchors + ${deAnchorCount} German anchors)`
 )

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -26,6 +26,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const { extractDescription } = require('./generate-jsonld.js')
 
 const DIST = path.join(__dirname, '..', 'website', 'dist')
 const SHELL = path.join(DIST, 'index.html')
@@ -322,7 +323,7 @@ function prerenderRoute(shell, route) {
  * the fragment is missing so the build fails fast instead of shipping an
  * incomplete set of pre-rendered pages.
  */
-function writeRouteVariant(shell, outPath, fragmentRel, headMeta) {
+function writeRouteVariant(shell, outPath, fragmentRel, headMeta, transformFragment) {
   const fragmentPath = path.join(DIST, fragmentRel)
   if (!fs.existsSync(fragmentPath)) {
     throw new Error(
@@ -330,7 +331,8 @@ function writeRouteVariant(shell, outPath, fragmentRel, headMeta) {
         `Make sure scripts/render-docs.js runs before prerender-routes.js and writes the fragment to website/public/docs/.`
     )
   }
-  const fragment = fs.readFileSync(fragmentPath, 'utf-8')
+  let fragment = fs.readFileSync(fragmentPath, 'utf-8')
+  if (transformFragment) fragment = transformFragment(fragment)
 
   let html = applyHead(shell, headMeta)
 
@@ -401,6 +403,15 @@ function buildCatalogMarkup(lang, translations) {
     'rounded-md px-2 py-1 text-sm text-[var(--color-text-secondary)] ' +
     'hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-colors'
 
+  // Link each anchor to its real pre-rendered page (#597); the German
+  // catalog points at the /de variant where the translation exists.
+  const hasDePage = (id) =>
+    fs.existsSync(path.join(__dirname, '..', 'docs', 'anchors', `${id}.de.adoc`))
+  const anchorHref = (id) =>
+    lang === 'de' && hasDePage(id)
+      ? `/Semantic-Anchors/de/anchor/${id}`
+      : `/Semantic-Anchors/anchor/${id}`
+
   const sections = categories
     .map((category) => {
       const items = (category.anchors || [])
@@ -408,7 +419,7 @@ function buildCatalogMarkup(lang, translations) {
         .filter(Boolean)
         .map(
           (anchor) =>
-            `<li><a href="/Semantic-Anchors/all-anchors#${escapeHtml(anchor.id)}" class="${linkClasses}">${escapeHtml(anchor.title)}</a></li>`
+            `<li><a href="${anchorHref(escapeHtml(anchor.id))}" class="${linkClasses}">${escapeHtml(anchor.title)}</a></li>`
         )
         .join('')
       if (!items) return ''
@@ -427,6 +438,76 @@ function buildCatalogMarkup(lang, translations) {
         <h2 class="text-2xl font-bold mb-3">${escapeHtml(heading)}</h2>${sections}
       </section>
     `
+}
+
+/**
+ * Pre-render every anchor to a real page at /anchor/<id>/ (HTTP 200), plus
+ * a /de/anchor/<id>/ variant where a German translation exists — fixing the
+ * sitemap- and JSON-LD-advertised 404s (#597). With JS the SPA hydrates and
+ * shows the anchor as a modal over the home page, exactly as before.
+ */
+function prerenderAnchorPages(shell) {
+  const anchors = loadWebsiteJson('public/data/anchors.json')
+  let enCount = 0
+  let deCount = 0
+  let skipped = 0
+  for (const anchor of anchors) {
+    const fragment = `docs/anchors/${anchor.id}.html`
+    if (!fs.existsSync(path.join(DIST, fragment))) {
+      console.warn(`  ! skipped /anchor/${anchor.id} — fragment ${fragment} missing`)
+      skipped++
+      continue
+    }
+    const fragmentDe = `docs/anchors/${anchor.id}.de.html`
+    const hasDe = fs.existsSync(path.join(DIST, fragmentDe))
+    const enUrl = `${SITE}/anchor/${anchor.id}`
+    const deUrl = hasDe ? `${SITE}/de/anchor/${anchor.id}` : null
+    const description =
+      extractDescription(`docs/anchors/${anchor.id}.adoc`) ||
+      `${anchor.title} — a semantic anchor: an established term that activates a rich, well-defined concept in any modern LLM.`
+
+    // The anchor body sits in a [%collapsible] block; expand it on the
+    // static page so the content is visible without a click. With JS the
+    // SPA replaces the page with the modal anyway.
+    const expandDetails = (html) => html.replace(/<details>/g, '<details open>')
+
+    writeRouteVariant(
+      shell,
+      `/anchor/${anchor.id}`,
+      fragment,
+      {
+        title: `${anchor.title} — Semantic Anchors`,
+        description,
+        canonicalUrl: enUrl,
+        enUrl,
+        deUrl,
+        lang: 'en',
+      },
+      expandDetails
+    )
+    enCount++
+
+    if (hasDe) {
+      writeRouteVariant(
+        shell,
+        `/de/anchor/${anchor.id}`,
+        fragmentDe,
+        {
+          title: `${anchor.title} — Semantic Anchors`,
+          description: extractDescription(`docs/anchors/${anchor.id}.de.adoc`) || description,
+          canonicalUrl: deUrl,
+          enUrl,
+          deUrl,
+          lang: 'de',
+        },
+        expandDetails
+      )
+      deCount++
+    }
+  }
+  console.log(
+    `  ✓ pre-rendered ${enCount} anchor pages (+ ${deCount} German variants${skipped ? `, ${skipped} skipped` : ''})`
+  )
 }
 
 /**
@@ -496,7 +577,10 @@ function main() {
     console.log(`  ✓ pre-rendered ${route.path}${route.fragmentDe ? ' (+ /de variant)' : ''}`)
   }
   prerenderHome(shell)
-  console.log(`\n✓ Pre-rendered ${ROUTES.length} routes + home to dist/<route>/index.html`)
+  prerenderAnchorPages(shell)
+  console.log(
+    `\n✓ Pre-rendered ${ROUTES.length} routes + home + anchor pages to dist/<route>/index.html`
+  )
 }
 
 main()

--- a/scripts/render-docs.js
+++ b/scripts/render-docs.js
@@ -77,18 +77,18 @@ function extractToc(html) {
  * sidecar `<basename>.toc.html` file so doc-page.js can render it in its
  * own sidebar slot.
  */
-function renderFile(srcPath, destPath) {
+function renderFile(srcPath, destPath, quiet = false) {
   if (!fs.existsSync(srcPath)) return
   try {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
     const html = String(asciidoctor.convertFile(srcPath, { ...OPTS, to_file: false }))
     const { toc, body } = extractToc(html)
     fs.writeFileSync(destPath, body, 'utf-8')
-    console.log(`Rendered: ${path.relative(ROOT, destPath)}`)
+    if (!quiet) console.log(`Rendered: ${path.relative(ROOT, destPath)}`)
     const tocPath = destPath.replace(/\.html$/, '.toc.html')
     if (toc) {
       fs.writeFileSync(tocPath, toc, 'utf-8')
-      console.log(`Rendered: ${path.relative(ROOT, tocPath)}`)
+      if (!quiet) console.log(`Rendered: ${path.relative(ROOT, tocPath)}`)
     } else if (fs.existsSync(tocPath)) {
       fs.unlinkSync(tocPath)
     }
@@ -180,6 +180,23 @@ renderFile(
   path.join(ROOT, 'docs/spec-driven-workflow.de.adoc'),
   path.join(WEB_DOCS, 'spec-driven-workflow.de.html')
 )
+
+// Render every anchor (EN + DE) to its own fragment for the pre-rendered
+// /anchor/<id> and /de/anchor/<id> pages (#597). ~315 small documents;
+// logged as a single summary line to keep the build output readable.
+const ANCHORS_SRC = path.join(ROOT, 'docs/anchors')
+const ANCHORS_OUT = path.join(WEB_DOCS, 'anchors')
+let anchorFragments = 0
+for (const file of fs.readdirSync(ANCHORS_SRC).sort()) {
+  if (!file.endsWith('.adoc')) continue
+  renderFile(
+    path.join(ANCHORS_SRC, file),
+    path.join(ANCHORS_OUT, file.replace(/\.adoc$/, '.html')),
+    true
+  )
+  anchorFragments++
+}
+console.log(`Rendered: ${anchorFragments} anchor fragments to website/public/docs/anchors/`)
 
 // Render contracts page from JSON
 require('./render-contracts.js')

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -27,7 +27,7 @@ import {
 } from './components/onboarding-modal.js'
 import { renderContractsPage, initContractsPage } from './components/contracts-page.js'
 
-const APP_VERSION = '0.5.0'
+const APP_VERSION = '0.6.0'
 
 window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   const url = `${window.location.origin}${import.meta.env.BASE_URL}anchor/${anchorId}`


### PR DESCRIPTION
Closes #597

## What

Every `/anchor/<id>` URL returned **HTTP 404** (SPA-fallback only) while `sitemap.xml` and the DefinedTerm JSON-LD (#579) advertised all 161 of them. Each anchor now gets a real pre-rendered page — and a German variant where a translation exists.

## Changes

1. **Fragments** (`render-docs.js`): every `docs/anchors/*.adoc` (161 EN + 155 DE) renders to `website/public/docs/anchors/<id>(.de).html` at prebuild — one summary log line, adds ~2s to the build.
2. **Pages** (`prerender-routes.js`): `dist/anchor/<id>/index.html` + `dist/de/anchor/<id>/index.html` via the `writeRouteVariant()`/`applyHead()` machinery from #596 — per-anchor `<title>`, meta description (via `extractDescription()` reused from `generate-jsonld.js`, now exported; generic fallback), self-canonical, honest hreflang pairs, `lang="de"` on German pages. The `[%collapsible]` anchor body is expanded (`<details open>`) so the static page shows its content without a click.
3. **Home catalog** links each anchor to its real page (`/anchor/<id>`; German catalog → `/de/anchor/<id>` where available) instead of `/all-anchors#<id>`.
4. **Sitemap**: the existing 161 `/anchor/<id>` entries become valid 200s; 155 `/de/anchor/<id>` entries added (339 URLs total).
5. v0.6.0 + changelog.

**No SPA change needed**: the router from #596 already resolves `/de/anchor/<id>`; with JS the page boots into home + anchor modal exactly as before (verified, no page errors). The DefinedTerm JSON-LD URLs become honest without modification.

## Verification

- Full build: `161 anchor pages (+ 155 German variants)` pre-rendered, build stays ~5s.
- No-JS (Playwright, `javaScriptEnabled: false`): `/anchor/mece/` shows title, expanded Core Concepts, header nav; `/de/anchor/mece/` is `lang="de"` German.
- With JS: modal opens over home on the same URL, no console/page errors.
- 102 unit tests, 35 E2E tests, ESLint + Prettier (website + scripts) green.

## Note for review

`anchors.json` entries without an `.adoc` file are skipped with a warning (currently none). The pre-existing SPA behavior of rewriting the document title to a de-kebab-cased id ("Mece — Semantic Anchors") on hydration is unchanged — could be polished separately by using the real anchor title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anchor-Detailseiten sind jetzt echte, vorkonfigurierte Seiten mit vollständigen SEO-Metadaten (Titel, Beschreibung, kanonische URL)
  * Deutsche Varianten für Anchor-URLs (/de/anchor/<id>) verfügbar
  * Homepage-Katalog verlinkt direkt auf neue Anchor-Detailseiten

* **Documentation**
  * Changelog für Version 0.6.0 aktualisiert

<!-- end of auto-generated comment: release notes by coderabbit.ai -->