### PR TITLE
fix: legacy hash links in doc content are dead on pre-rendered pages

### DIFF
--- a/scripts/render-contracts.js
+++ b/scripts/render-contracts.js
@@ -44,7 +44,7 @@ function renderContract(contract) {
   const anchors = contract.anchors
     .map(
       (id) =>
-        `<a href="#/anchor/${escapeHtml(id)}" class="inline-block rounded-full bg-blue-100 dark:bg-blue-900/30 px-2 py-0.5 text-xs text-blue-700 dark:text-blue-300">${escapeHtml(id)}</a>`
+        `<a href="/Semantic-Anchors/anchor/${escapeHtml(id)}" class="inline-block rounded-full bg-blue-100 dark:bg-blue-900/30 px-2 py-0.5 text-xs text-blue-700 dark:text-blue-300">${escapeHtml(id)}</a>`
     )
     .join(' ')
 

--- a/scripts/render-docs.js
+++ b/scripts/render-docs.js
@@ -77,12 +77,23 @@ function extractToc(html) {
  * sidecar `<basename>.toc.html` file so doc-page.js can render it in its
  * own sidebar slot.
  */
+/**
+ * Rewrite legacy hash-router links (href="#/anchor/x", href="#/about", …)
+ * that authors used in the .adoc sources to real clean URLs, so the
+ * pre-rendered pages are navigable without JavaScript and crawlable (#599).
+ * In-page TOC/section links (href="#section-id", no slash) stay untouched.
+ * With JS the router intercepts the clean URLs for SPA navigation.
+ */
+function rewriteLegacyHashLinks(html) {
+  return html.replace(/href="#\//g, 'href="/Semantic-Anchors/')
+}
+
 function renderFile(srcPath, destPath, quiet = false) {
   if (!fs.existsSync(srcPath)) return
   try {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
     const html = String(asciidoctor.convertFile(srcPath, { ...OPTS, to_file: false }))
-    const { toc, body } = extractToc(html)
+    const { toc, body } = extractToc(rewriteLegacyHashLinks(html))
     fs.writeFileSync(destPath, body, 'utf-8')
     if (!quiet) console.log(`Rendered: ${path.relative(ROOT, destPath)}`)
     const tocPath = destPath.replace(/\.html$/, '.toc.html')


### PR DESCRIPTION
Closes #599

## What

Doc content shipped ~150 legacy hash-router links (`link:#/anchor/<id>`, `link:#/about`, …) that render as dead fragment URLs on the pre-rendered pages — `/spec-driven-development/` alone had 40 of them (e.g. `…/spec-driven-development/#/anchor/tdd-london-school`). Crawlers and no-JS visitors couldn't follow any content link to the anchor pages that #598 just made indexable.

## Fix (single point, sources untouched)

- `render-docs.js#renderFile()`: rewrite `href="#/…"` → `href="/Semantic-Anchors/…"` after AsciiDoc conversion. Covers all doc fragments, the full reference, and the per-anchor fragments. In-page TOC/section links (`#section-id`, no slash) are untouched.
- `render-contracts.js`: emit clean anchor URLs directly (it generated its own `#/anchor/<id>` links).

The `.adoc` sources stay unchanged — the client-rendered anchor modal still converts them in the browser, where the router's legacy hash shim continues to handle them.

## Verification

- Post-build sweep: `grep -rl 'href="#/' dist --include=index.html` → **zero matches** (before: doc pages + contracts).
- No-JS (Playwright): followed `/spec-driven-development/` → `anchor/tdd-london-school` link chain, lands on the real page ("TDD, London School — Semantic Anchors").
- With JS: same click is router-intercepted — clean URL, anchor modal opens, no page errors.
- 102 unit tests, 35 E2E tests, ESLint + Prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Links in der Dokumentation werden nun mit absoluten Pfaden anstelle von Hash-Navigation generiert
  * Legacy Hash-Links in Dokumentdateien werden automatisch in moderne URL-Formate konvertiert

<!-- end of auto-generated comment: release notes by coderabbit.ai -->