### PR TITLE
feat: Criticism sections for remaining 12 contested anchors (batch 3 of #603)

### DIFF
--- a/docs/anchors/4mat.adoc
+++ b/docs/anchors/4mat.adoc
@@ -47,4 +47,11 @@ Key Proponents:: Bernice McCarthy ("The 4MAT System: Teaching to Learning Styles
 * <<pyramid-principle,Pyramid Principle>> - Top-down structure for written communication; complements 4MAT which is experience-first
 * <<feynman-technique,Feynman Technique>> - Self-directed learning; 4MAT is teacher-directed instructional design
 * <<diataxis-framework,Diátaxis Framework>> - Documentation types (tutorial/how-to/reference/explanation) map loosely to 4MAT quadrants
+
+[discrete]
+== *Criticism*:
+
+* 4MAT rests on learning-styles theory, and the matching claim lacks empirical support: Pashler, McDaniel, Rohrer & Bjork, https://doi.org/10.1111/j.1539-6053.2009.01038.x["Learning Styles: Concepts and Evidence"] (Psychological Science in the Public Interest, 2008) found virtually no valid evidence that teaching matched to a diagnosed learning style improves outcomes
+* Paul Kirschner, https://doi.org/10.1016/j.compedu.2016.12.006["Stop propagating the learning styles myth"] (Computers & Education, 2017) — nearly all studies claiming supporting evidence fail basic criteria of scientific validity
+* The common defense: 4MAT's Why/What/How/What-If cycle works as a lesson-*sequencing* device that every learner moves through — a reading that survives even when the underlying learning-styles claim is dropped
 ====

--- a/docs/anchors/4mat.de.adoc
+++ b/docs/anchors/4mat.de.adoc
@@ -47,4 +47,11 @@ Schlüsselvertreter:: Bernice McCarthy ("The 4MAT System: Teaching to Learning S
 * <<pyramid-principle,Pyramid Principle>> - Top-down-Struktur für schriftliche Kommunikation; ergänzt 4MAT, das erfahrungsorientiert beginnt
 * <<feynman-technique,Feynman Technique>> - Selbstgesteuertes Lernen; 4MAT ist lehrergesteuertes Instruktionsdesign
 * <<diataxis-framework,Diátaxis Framework>> - Dokumentationstypen (Tutorial/How-to/Reference/Explanation) entsprechen grob den 4MAT-Quadranten
+
+[discrete]
+== *Kritik*:
+
+* 4MAT fußt auf der Lernstil-Theorie, und deren Matching-These ist empirisch nicht gedeckt: Pashler, McDaniel, Rohrer & Bjork, https://doi.org/10.1111/j.1539-6053.2009.01038.x["Learning Styles: Concepts and Evidence"] (Psychological Science in the Public Interest, 2008) fanden praktisch keine validen Belege, dass auf diagnostizierte Lernstile zugeschnittener Unterricht die Ergebnisse verbessert
+* Paul Kirschner, https://doi.org/10.1016/j.compedu.2016.12.006["Stop propagating the learning styles myth"] (Computers & Education, 2017) — fast alle Studien mit angeblichen Belegen scheitern an grundlegenden Kriterien wissenschaftlicher Validität
+* Die übliche Verteidigung: Der Why/What/How/What-If-Zyklus von 4MAT funktioniert als *Sequenzierungs*-Werkzeug, das jeder Lernende durchläuft — eine Lesart, die auch ohne die Lernstil-These trägt
 ====

--- a/docs/anchors/aida-model.adoc
+++ b/docs/anchors/aida-model.adoc
@@ -49,4 +49,11 @@ Key Proponents:: Commonly attributed to E. St. Elmo Lewis (1898), an American ad
 * <<inverted-pyramid-style,Inverted Pyramid Style>> - News structure front-loads the full story; AIDA deliberately withholds the ask until Desire is built
 * <<pyramid-principle,Pyramid Principle>> - Logical top-down argument for clarity; AIDA is an emotional persuasion sequence for conversion
 * <<bluf,BLUF (Bottom Line Up Front)>> - Leads with the conclusion; the opposite move to AIDA, which earns the conclusion across four stages
+
+[discrete]
+== *Criticism*:
+
+* Robert Heath & Paul Feldwick, https://researchportal.bath.ac.uk/en/publications/fifty-years-using-the-wrong-model-of-advertising["Fifty years using the wrong model of advertising"] (International Journal of Market Research, 2008) — the rational, sequential persuasion model behind AIDA misrepresents how advertising actually works: largely through emotional, low-attention processing rather than attentive information processing
+* Demetrios Vakratsas & Tim Ambler, https://doi.org/10.1177/002224299906300103["How Advertising Works: What Do We Really Know?"] (Journal of Marketing, 1999) — reviewing over 250 studies, they found little empirical support for any fixed hierarchy of effects and recommended abandoning the hierarchy concept as a planning assumption
+* The model's age is part of the critique: AIDA originates around 1898, pre-dating formal marketing science, yet still dominates campaign planning — precisely the persistence Heath and Feldwick criticize
 ====

--- a/docs/anchors/aida-model.de.adoc
+++ b/docs/anchors/aida-model.de.adoc
@@ -49,4 +49,11 @@ Key Proponents:: Üblicherweise E. St. Elmo Lewis (1898) zugeschrieben, einem am
 * <<inverted-pyramid-style,Inverted Pyramid Style>> - Die News-Struktur stellt die ganze Story nach vorn; AIDA hält den Aufruf bewusst zurück, bis Desire aufgebaut ist
 * <<pyramid-principle,Pyramid Principle>> - Logisches Top-down-Argument für Klarheit; AIDA ist eine emotionale Überzeugungssequenz für Conversion
 * <<bluf,BLUF (Bottom Line Up Front)>> - Beginnt mit dem Fazit; der Gegenzug zu AIDA, das das Fazit über vier Stufen erarbeitet
+
+[discrete]
+== *Kritik*:
+
+* Robert Heath & Paul Feldwick, https://researchportal.bath.ac.uk/en/publications/fifty-years-using-the-wrong-model-of-advertising["Fifty years using the wrong model of advertising"] (International Journal of Market Research, 2008) — das rationale, sequenzielle Überzeugungsmodell hinter AIDA verzerrt, wie Werbung tatsächlich wirkt: großteils über emotionale Verarbeitung bei niedriger Aufmerksamkeit statt über aufmerksame Informationsverarbeitung
+* Demetrios Vakratsas & Tim Ambler, https://doi.org/10.1177/002224299906300103["How Advertising Works: What Do We Really Know?"] (Journal of Marketing, 1999) — in der Auswertung von über 250 Studien fanden sie kaum empirische Belege für irgendeine feste Wirkungshierarchie und empfahlen, das Hierarchie-Konzept als Planungsannahme aufzugeben
+* Das Alter des Modells ist Teil der Kritik: AIDA stammt von etwa 1898, vor der formalen Marketingwissenschaft — und dominiert dennoch die Kampagnenplanung; genau diese Beharrungskraft kritisieren Heath und Feldwick
 ====

--- a/docs/anchors/clean-architecture.adoc
+++ b/docs/anchors/clean-architecture.adoc
@@ -38,4 +38,11 @@ Key Proponent:: Robert C. Martin ("Uncle Bob")
 * Systems requiring long-term maintainability
 * When team size and turnover are high
 * Projects where business rules must be protected from technology changes
+
+[discrete]
+== *Criticism*:
+
+* Jimmy Bogard, https://www.jimmybogard.com/vertical-slice-architecture/["Vertical Slice Architecture"] (2018) — calls the "traditional layered/onion/clean architecture" monolithic in its approach and appropriate for only a minority of requests, criticizing mock-heavy tests and abstractions "around concepts that really shouldn't be abstracted"; his alternative is <<vertical-slice-architecture,Vertical Slice Architecture>>
+* Derek Comartin, https://codeopinion.com/clean-architecture-and-indirection-no-thanks/["'Clean Architecture' and indirection. No thanks."] (CodeOpinion) — dismisses canonical Clean Architecture examples as "useless indirection": the layering adds cost without paying for itself in typical systems
+* The critiques converge: the dependency rule imposes a fixed indirection tax on every feature, while most changes cut across all layers anyway — the coupling Vertical Slice Architecture organizes around instead
 ====

--- a/docs/anchors/clean-architecture.de.adoc
+++ b/docs/anchors/clean-architecture.de.adoc
@@ -37,4 +37,11 @@ Schlüsselvertreter:: Robert C. Martin ("Uncle Bob")
 * Systeme, die langfristige Wartbarkeit erfordern
 * Wenn Teamgröße und Fluktuation hoch sind
 * Projekte, bei denen Geschäftsregeln vor Technologieänderungen geschützt werden müssen
+
+[discrete]
+== *Kritik*:
+
+* Jimmy Bogard, https://www.jimmybogard.com/vertical-slice-architecture/["Vertical Slice Architecture"] (2018) — nennt die "traditionelle Layered/Onion/Clean Architecture" monolithisch im Ansatz und nur für eine Minderheit der Requests angemessen; er kritisiert mock-lastige Tests und Abstraktionen "um Konzepte, die nicht abstrahiert gehören"; seine Alternative ist <<vertical-slice-architecture,Vertical Slice Architecture>>
+* Derek Comartin, https://codeopinion.com/clean-architecture-and-indirection-no-thanks/["'Clean Architecture' and indirection. No thanks."] (CodeOpinion) — tut kanonische Clean-Architecture-Beispiele als "nutzlose Indirektion" ab: Die Schichtung kostet, ohne sich in typischen Systemen zu bezahlen
+* Die Kritiken laufen zusammen: Die Dependency Rule erhebt auf jedes Feature eine fixe Indirektions-Steuer, während die meisten Änderungen ohnehin durch alle Schichten schneiden — genau die Kopplung, um die Vertical Slice Architecture stattdessen organisiert
 ====

--- a/docs/anchors/cqrs.adoc
+++ b/docs/anchors/cqrs.adoc
@@ -47,4 +47,11 @@ Key Proponents:: Greg Young (coined CQRS), Bertrand Meyer (CQS origin, "Object-O
 * <<domain-driven-design,Domain-Driven Design>> - Often combined with CQRS for complex domains
 * <<hexagonal-architecture,Hexagonal Architecture>> - Ports and adapters complement CQRS separation
 * <<fowler-patterns,Fowler Patterns>> - CQRS builds on enterprise application patterns
+
+[discrete]
+== *Criticism*:
+
+* Martin Fowler, https://martinfowler.com/bliki/CQRS.html[bliki: CQRS] — warns that "for most systems CQRS adds risky complexity", a "significant mental leap" that pays off only in specific bounded contexts, not as a default pattern
+* Udi Dahan, one of CQRS's main proponents, opens https://udidahan.com/2011/04/22/when-to-avoid-cqrs/["When to avoid CQRS"] (2011) with "Most people using CQRS (and Event Sourcing too) shouldn't have done so" — and adds that CQRS "should not be your top-level architectural pattern"
+* Greg Young himself pushed back on scope creep in https://web.archive.org/web/20121129063556/http://codebetter.com/gregyoung/2012/09/09/cqrs-is-not-an-architecture-2/["CQRS is not an Architecture"] (2012, archived): CQRS is a pattern applied inside a single component, not an architectural style for a whole system
 ====

--- a/docs/anchors/cqrs.de.adoc
+++ b/docs/anchors/cqrs.de.adoc
@@ -46,4 +46,11 @@ Schlüsselvertreter:: Greg Young (prägte CQRS), Bertrand Meyer (CQS-Ursprung, "
 * <<domain-driven-design,Domain-Driven Design>> - Wird oft mit CQRS für komplexe Domänen kombiniert
 * <<hexagonal-architecture,Hexagonal Architecture>> - Ports und Adapter ergänzen die CQRS-Trennung
 * <<fowler-patterns,Fowler Patterns>> - CQRS baut auf Enterprise-Application-Patterns auf
+
+[discrete]
+== *Kritik*:
+
+* Martin Fowler, https://martinfowler.com/bliki/CQRS.html[bliki: CQRS] — warnt, dass "CQRS für die meisten Systeme riskante Komplexität hinzufügt", ein "erheblicher mentaler Sprung", der sich nur in bestimmten Bounded Contexts auszahlt, nicht als Default-Pattern
+* Udi Dahan, einer der Hauptvertreter von CQRS, eröffnet https://udidahan.com/2011/04/22/when-to-avoid-cqrs/["When to avoid CQRS"] (2011) mit "Most people using CQRS (and Event Sourcing too) shouldn't have done so" — und ergänzt, CQRS "sollte nicht dein Top-Level-Architekturpattern sein"
+* Greg Young selbst trat dem Scope Creep entgegen in https://web.archive.org/web/20121129063556/http://codebetter.com/gregyoung/2012/09/09/cqrs-is-not-an-architecture-2/["CQRS is not an Architecture"] (2012, archiviert): CQRS ist ein Pattern innerhalb einer einzelnen Komponente, kein Architekturstil für ein ganzes System
 ====

--- a/docs/anchors/dry.adoc
+++ b/docs/anchors/dry.adoc
@@ -48,4 +48,11 @@ Key Proponents:: Andy Hunt & Dave Thomas, *The Pragmatic Programmer* (1999)
 * <<single-level-of-abstraction-principle,Single Level of Abstraction Principle>> — keeps extracted abstractions coherent
 * <<kiss-principle,KISS Principle>> — the simplicity counterweight to over-abstraction
 * <<yagni,YAGNI>> — don't build the abstraction until you actually need it
+
+[discrete]
+== *Criticism*:
+
+* Sandi Metz, https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction["The Wrong Abstraction"] (2016) — overzealous DRY produces abstractions that later requirements don't fit: "duplication is far cheaper than the wrong abstraction"; her advice is to re-introduce the duplication until the right abstraction reveals itself
+* The authors themselves concede the principle is widely misread: in the 20th Anniversary Edition (2019), Thomas & Hunt write they "did a poor job of explaining" DRY — it targets duplication of *knowledge and intent*; code deduplication is "a tiny and fairly trivial part" (https://media.pragprog.com/titles/tpp20/dry.pdf[official chapter extract])
+* The corollary both critiques share: two pieces of code that look alike but encode different business knowledge are not a DRY violation — merging them creates coupling, not clarity
 ====

--- a/docs/anchors/dry.de.adoc
+++ b/docs/anchors/dry.de.adoc
@@ -48,4 +48,11 @@ Key Proponents:: Andy Hunt & Dave Thomas, *The Pragmatic Programmer* (1999)
 * <<single-level-of-abstraction-principle,Single Level of Abstraction Principle>> — hält extrahierte Abstraktionen kohärent
 * <<kiss-principle,KISS Principle>> — das Einfachheits-Gegengewicht zur Über-Abstraktion
 * <<yagni,YAGNI>> — die Abstraktion erst bauen, wenn sie wirklich gebraucht wird
+
+[discrete]
+== *Kritik*:
+
+* Sandi Metz, https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction["The Wrong Abstraction"] (2016) — übereifriges DRY erzeugt Abstraktionen, in die spätere Anforderungen nicht passen: "duplication is far cheaper than the wrong abstraction"; ihr Rat: die Duplizierung wieder einführen, bis sich die richtige Abstraktion zeigt
+* Die Autoren selbst räumen ein, dass das Prinzip breit missverstanden wird: In der 20th Anniversary Edition (2019) schreiben Thomas & Hunt, sie hätten DRY ursprünglich "schlecht erklärt" — es zielt auf Duplizierung von *Wissen und Absicht*; Code-Deduplizierung ist "ein winziger und ziemlich trivialer Teil" (https://media.pragprog.com/titles/tpp20/dry.pdf[offizieller Kapitelauszug])
+* Die Folgerung beider Kritiken: Zwei Code-Stücke, die gleich aussehen, aber unterschiedliches Fachwissen kodieren, sind keine DRY-Verletzung — sie zu verschmelzen erzeugt Kopplung, nicht Klarheit
 ====

--- a/docs/anchors/freytags-pyramid.adoc
+++ b/docs/anchors/freytags-pyramid.adoc
@@ -45,4 +45,11 @@ Key Proponents:: Gustav Freytag ("Die Technik des Dramas", 1863); John Yorke ("I
 * <<heros-journey,Hero's Journey (Monomyth)>>
 * <<fichtean-curve,Fichtean Curve>>
 * <<save-the-cat,Save the Cat! (15-Beat Sheet)>>
+
+[discrete]
+== *Criticism*:
+
+* Novelist and writing professor Jane Alison (_Meander, Spiral, Explode_, 2019; https://www.craftliterary.com/2019/04/23/alison-meander-spiral-explode/[excerpt at CRAFT]) objects that the pyramid was never a general theory of stories — "Novels didn't exist for Aristotle and weren't Freytag's subject" — calls the swell-climax-collapse arc "masculo-sexual", and proposes waves, meanders, and spirals as equally valid narrative designs
+* Freytag derived the model from five-act stage tragedy, not narrative in general; Chris Winkle (https://mythcreants.com/blog/freytags-pyramid-is-outdated-heres-what-to-do-instead/[Mythcreants, 2024]) argues it "isn't really applicable to modern stories"
+* Defenders such as TD Storm (https://stormwritingschool.com/freytags-pyramid/[Storm Writing School]) counter that, read as Freytag intended — an analysis of classical drama — it is a descriptive lens; the criticism properly targets its later misuse as a universal template
 ====

--- a/docs/anchors/freytags-pyramid.de.adoc
+++ b/docs/anchors/freytags-pyramid.de.adoc
@@ -33,4 +33,11 @@ Schlüsselvertreter:: Gustav Freytag ("Die Technik des Dramas", 1863); John York
 * Diagnose, ob der Höhepunkt einer Geschichte am richtigen Punkt positioniert ist
 * Schreiben von Tragödien oder dramatischer Belletristik, bei der der Fehler des Protagonisten den Zusammenbruch antreibt
 * Verstehen, warum Akt 2 / aufsteigende Handlung sich träge anfühlt — er muss eskalierender Komplikationen, keine Füllmaterialien enthalten
+
+[discrete]
+== *Kritik*:
+
+* Die Romanautorin und Schreibprofessorin Jane Alison (_Meander, Spiral, Explode_, 2019; https://www.craftliterary.com/2019/04/23/alison-meander-spiral-explode/[Auszug bei CRAFT]) wendet ein, die Pyramide sei nie eine allgemeine Erzähltheorie gewesen — "Novels didn't exist for Aristotle and weren't Freytag's subject" — nennt den Anstieg-Höhepunkt-Kollaps-Bogen "masculo-sexual" und schlägt Wellen, Mäander und Spiralen als ebenso gültige Erzählmuster vor
+* Freytag leitete das Modell aus der fünfaktigen Bühnentragödie ab, nicht aus Erzählung im Allgemeinen; Chris Winkle (https://mythcreants.com/blog/freytags-pyramid-is-outdated-heres-what-to-do-instead/[Mythcreants, 2024]) hält es für "auf moderne Geschichten kaum anwendbar"
+* Verteidiger wie TD Storm (https://stormwritingschool.com/freytags-pyramid/[Storm Writing School]) halten dagegen: Gelesen wie von Freytag gemeint — als Analyse des klassischen Dramas — ist es eine beschreibende Linse; die Kritik trifft zu Recht den späteren Missbrauch als Universalschablone
 ====

--- a/docs/anchors/gof-design-patterns.adoc
+++ b/docs/anchors/gof-design-patterns.adoc
@@ -47,4 +47,11 @@ Key Proponents:: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides ("Desi
 * <<solid-principles,SOLID Principles>> - Design principles that GoF patterns help implement
 * <<fowler-patterns,Fowler Patterns>> - Enterprise application architecture patterns (complementary scope)
 * <<clean-architecture,Clean Architecture>> - Architectural style leveraging GoF principles
+
+[discrete]
+== *Criticism*:
+
+* Peter Norvig, https://norvig.com/design-patterns/["Design Patterns in Dynamic Languages"] (1996/1998) — 16 of the 23 patterns have a "qualitatively simpler implementation" in Lisp or Dylan than in C++, or vanish into the language entirely: many patterns compensate for missing language features rather than capture universal design wisdom
+* Paul Graham, https://www.paulgraham.com/icad.html["Revenge of the Nerds"] (2002) — recurring patterns may be evidence of "the human compiler at work": "When I see patterns in my programs, I consider it a sign of trouble", a sign the language's abstractions are not powerful enough
+* The authors themselves treat the catalog as a 1994 snapshot, not a closed canon: in the https://www.informit.com/articles/article.aspx?p=1404056[2009 InformIT interview] they discuss how they would reorganize and trim it today (see also the Criticism on <<gof-singleton-pattern,Singleton>>)
 ====

--- a/docs/anchors/gof-design-patterns.de.adoc
+++ b/docs/anchors/gof-design-patterns.de.adoc
@@ -46,4 +46,11 @@ Schlüsselvertreter:: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides (
 * <<solid-principles,SOLID Principles>> - Entwurfsprinzipien, deren Umsetzung GoF-Patterns unterstützen
 * <<fowler-patterns,Fowler Patterns>> - Architekturmuster für Unternehmensanwendungen (komplementärer Umfang)
 * <<clean-architecture,Clean Architecture>> - Architekturstil, der GoF-Prinzipien nutzt
+
+[discrete]
+== *Kritik*:
+
+* Peter Norvig, https://norvig.com/design-patterns/["Design Patterns in Dynamic Languages"] (1996/1998) — 16 der 23 Patterns haben in Lisp oder Dylan eine "qualitativ einfachere Implementierung" als in C++ oder verschwinden ganz in der Sprache: Viele Patterns kompensieren fehlende Sprachfeatures, statt universelle Designweisheit festzuhalten
+* Paul Graham, https://www.paulgraham.com/icad.html["Revenge of the Nerds"] (2002) — wiederkehrende Patterns können Belege für den "menschlichen Compiler bei der Arbeit" sein: "When I see patterns in my programs, I consider it a sign of trouble" — ein Zeichen, dass die Abstraktionen der Sprache nicht mächtig genug sind
+* Die Autoren selbst behandeln den Katalog als Momentaufnahme von 1994, nicht als geschlossenen Kanon: Im https://www.informit.com/articles/article.aspx?p=1404056[InformIT-Interview von 2009] diskutieren sie, wie sie ihn heute umbauen und kürzen würden (siehe auch die Kritik bei <<gof-singleton-pattern,Singleton>>)
 ====

--- a/docs/anchors/heros-journey.adoc
+++ b/docs/anchors/heros-journey.adoc
@@ -52,4 +52,11 @@ Key Proponents:: Joseph Campbell ("The Hero with a Thousand Faces", 1949), Chris
 * <<three-act-structure,Three-Act Structure>>
 * <<story-circle-dan-harmon,Story Circle (Dan Harmon)>>
 * <<freytags-pyramid,Freytag's Pyramid>>
+
+[discrete]
+== *Criticism*:
+
+* Folklorists broadly reject the monomyth's claim to universality: Alan Dundes ("Folkloristics in the Twenty-First Century", Journal of American Folklore 118/470, 2005) called Campbell a "non-expert" whose pattern survives only by source-selection bias, and Barre Toelken noted Campbell "could construct a monomyth of the hero only by citing those stories that fit his preconceived mold" (overview with citations: https://www.patheos.com/blogs/foxyfolklorist/why-folklorists-hate-joseph-campbells-work/[Jeana Jorgensen, "Why Folklorists Hate Joseph Campbell's Work"])
+* David Brin (https://www.salon.com/1999/06/15/brin_main/[Salon, 1999]) attacks the template's value system: the Campbellian demigod formula carries elitist, anti-democratic ideals
+* Since Christopher Vogler's Disney memo turned Campbell into a screenwriting guide, forcing stories into the template has been blamed for predictable, interchangeable plots — defenders reply that Campbell described recurring mythic patterns, not a recipe
 ====

--- a/docs/anchors/heros-journey.de.adoc
+++ b/docs/anchors/heros-journey.de.adoc
@@ -41,4 +41,11 @@ Schlüsselvertreter:: Joseph Campbell ("Der Heros in tausend Gestalten", 1949), 
 * Anleitung von LLMs zum Schreiben archetypischer Geschichten oder zur Analyse bestehender Mythen und Filme
 * Vertiefung der Charakterentwicklung durch Abbildung jeder Phase auf die innere Transformation
 * Marketingerzählungen, die den Kunden als Held positionieren
+
+[discrete]
+== *Kritik*:
+
+* Folkloristen weisen den Universalitätsanspruch des Monomythos breit zurück: Alan Dundes ("Folkloristics in the Twenty-First Century", Journal of American Folklore 118/470, 2005) nannte Campbell einen "Nicht-Experten", dessen Muster nur durch selektive Quellenwahl überlebt; Barre Toelken merkte an, Campbell habe den Monomythos "nur konstruieren können, indem er die Geschichten zitierte, die in seine vorgefasste Form passten" (Überblick mit Belegen: https://www.patheos.com/blogs/foxyfolklorist/why-folklorists-hate-joseph-campbells-work/[Jeana Jorgensen, "Why Folklorists Hate Joseph Campbell's Work"])
+* David Brin (https://www.salon.com/1999/06/15/brin_main/[Salon, 1999]) greift das Wertesystem der Schablone an: Die Campbell'sche Halbgott-Formel transportiere elitäre, antidemokratische Ideale
+* Seit Christopher Voglers Disney-Memo Campbell zur Drehbuch-Anleitung machte, gilt das Pressen von Geschichten in die Schablone als Quelle vorhersehbarer, austauschbarer Plots — Verteidiger entgegnen, Campbell habe wiederkehrende mythische Muster beschrieben, kein Rezept
 ====

--- a/docs/anchors/jobs-to-be-done.adoc
+++ b/docs/anchors/jobs-to-be-done.adoc
@@ -40,4 +40,11 @@ Key Proponents:: Clayton Christensen, Alan Klement, Bob Moesta
 * Identifying true competition
 * Writing more meaningful user stories
 * Market segmentation based on jobs, not demographics
+
+[discrete]
+== *Criticism*:
+
+* Two schools claim the same term: Alan Klement documents in https://jtbd.info/know-the-two-very-different-interpretations-of-jobs-to-be-done-5a18b748bd89["Know the Two — Very — Different Interpretations of Jobs to be Done"] that Christensen/Moesta's *Jobs-as-Progress* and Ulwick's *Jobs-as-Activities* (Outcome-Driven Innovation) are incompatible interpretations that confuse practitioners
+* Even the origin is contested: Ulwick's Strategyn states that https://strategyn.com/jobs-to-be-done/history-of-jtbd/["JTBD was created by Tony Ulwick in 1990"] and merely popularized by Christensen (https://hbr.org/2016/09/know-your-customers-jobs-to-be-done["Know Your Customers' 'Jobs to Be Done'"], HBR 2016)
+* The bare acronym therefore activates two conflicting priors — say "JTBD (Christensen, jobs as progress)" or "JTBD (Ulwick, Outcome-Driven Innovation)"; this anchor's full name carries the Christensen qualifier for exactly that reason
 ====

--- a/docs/anchors/jobs-to-be-done.de.adoc
+++ b/docs/anchors/jobs-to-be-done.de.adoc
@@ -39,4 +39,11 @@ Schlüsselvertreter:: Clayton Christensen, Alan Klement, Bob Moesta
 * Identifikation echter Konkurrenz
 * Schreiben bedeutungsvollerer User Stories
 * Marktsegmentierung basierend auf Jobs, nicht Demografie
+
+[discrete]
+== *Kritik*:
+
+* Zwei Schulen beanspruchen denselben Begriff: Alan Klement dokumentiert in https://jtbd.info/know-the-two-very-different-interpretations-of-jobs-to-be-done-5a18b748bd89["Know the Two — Very — Different Interpretations of Jobs to be Done"], dass Christensen/Moestas *Jobs-as-Progress* und Ulwicks *Jobs-as-Activities* (Outcome-Driven Innovation) inkompatible Interpretationen sind, die Praktiker verwirren
+* Sogar der Ursprung ist umstritten: Ulwicks Strategyn erklärt, https://strategyn.com/jobs-to-be-done/history-of-jtbd/["JTBD wurde 1990 von Tony Ulwick erfunden"] und von Christensen lediglich popularisiert (https://hbr.org/2016/09/know-your-customers-jobs-to-be-done["Know Your Customers' 'Jobs to Be Done'"], HBR 2016)
+* Das nackte Akronym aktiviert also zwei widersprüchliche Priors — sage „JTBD (Christensen, Jobs als Fortschritt)" oder „JTBD (Ulwick, Outcome-Driven Innovation)"; der vollständige Name dieses Ankers trägt den Christensen-Qualifier aus genau diesem Grund
 ====

--- a/docs/anchors/kotter-8-step-change-model.adoc
+++ b/docs/anchors/kotter-8-step-change-model.adoc
@@ -55,4 +55,11 @@ Historical Context:: One of the most cited change management frameworks in busin
 * <<wardley-mapping,Wardley Mapping>> — visualise where change is needed in the value chain before defining the vision
 
 Counter-example:: Pure top-down mandate ("from Monday we will be agile") — Kotter's whole point is that without urgency, coalition, vision and short-term wins, the mandate produces compliance theatre, not change.
+
+[discrete]
+== *Criticism*:
+
+* No empirical validation of the whole model: Appelbaum, Habashy, Malo & Shafiq, https://doi.org/10.1108/02621711211253231["Back to the future: revisiting Kotter's 1996 change model"] (Journal of Management Development 31(8), 2012) reviewed 15 years of literature — support for most individual steps, but no formal study validating the model as a whole; its popularity "appears to derive more from its direct and usable format than from any scientific consensus on the results"
+* The evidence base of n-step change models in general is thin: Rune Todnem By, https://doi.org/10.1080/14697010500359250["Organisational change management: A critical review"] (Journal of Change Management 5(4), 2005) finds planned, step-based approaches — of which Kotter's is the best-known — "often contradictory, mostly lacking empirical evidence and supported by unchallenged hypotheses"
+* Kotter's own revision concedes the linearity: his organization https://www.kotterinc.com/methodology/8-steps/[describes the original as "the linear 8 Step"] that he evolved into the 8 Accelerators of _Accelerate_ (2014; based on https://hbr.org/2012/11/accelerate["Accelerate!"], HBR 2012) with a "dual operating system" — an agile network running alongside the hierarchy
 ====

--- a/docs/anchors/kotter-8-step-change-model.de.adoc
+++ b/docs/anchors/kotter-8-step-change-model.de.adoc
@@ -55,4 +55,11 @@ Historischer Kontext:: Einer der meistzitierten Change-Management-Frameworks der
 * <<wardley-mapping,Wardley Mapping>> — visualisiert, wo in der Wertschöpfungskette Veränderung nötig ist, bevor die Vision definiert wird
 
 Gegenbeispiel:: Reines Top-down-Mandat ("ab Montag sind wir agil") — genau Kotters Punkt: ohne Dringlichkeit, Koalition, Vision und kurzfristige Erfolge entsteht Compliance-Theater, kein Wandel.
+
+[discrete]
+== *Kritik*:
+
+* Keine empirische Validierung des Gesamtmodells: Appelbaum, Habashy, Malo & Shafiq, https://doi.org/10.1108/02621711211253231["Back to the future: revisiting Kotter's 1996 change model"] (Journal of Management Development 31(8), 2012) werteten 15 Jahre Literatur aus — Belege für die meisten Einzelschritte, aber keine formale Studie, die das Modell als Ganzes validiert; seine Popularität "scheint mehr aus seinem direkten, nutzbaren Format zu stammen als aus wissenschaftlichem Konsens über die Ergebnisse"
+* Die Evidenzbasis von n-Schritt-Change-Modellen ist generell dünn: Rune Todnem By, https://doi.org/10.1080/14697010500359250["Organisational change management: A critical review"] (Journal of Change Management 5(4), 2005) findet geplante, schrittbasierte Ansätze — Kotters ist der bekannteste — "oft widersprüchlich, größtenteils ohne empirische Evidenz und gestützt auf ungeprüfte Hypothesen"
+* Kotters eigene Revision räumt die Linearität ein: Seine Organisation https://www.kotterinc.com/methodology/8-steps/[beschreibt das Original als "the linear 8 Step"], das er zu den 8 Accelerators von _Accelerate_ (2014; basierend auf https://hbr.org/2012/11/accelerate["Accelerate!"], HBR 2012) weiterentwickelte — mit einem "dual operating system", einem agilen Netzwerk neben der Hierarchie
 ====

--- a/docs/anchors/mvp.adoc
+++ b/docs/anchors/mvp.adoc
@@ -50,4 +50,11 @@ Key Proponents:: Eric Ries ("The Lean Startup", 2011); Frank Robinson coined the
 * <<impact-mapping,Impact Mapping>> - Technique for aligning MVP scope with business outcomes
 * <<user-story-mapping,User Story Mapping>> - Visual tool for identifying the minimum set of stories for an MVP
 * <<walking-skeleton,Walking Skeleton>> - Architectural counterpart; validates structure rather than market demand
+
+[discrete]
+== *Criticism*:
+
+* The term is diluted in practice: Nielsen Norman Group (https://www.nngroup.com/articles/mvp-definition/[Sara Paul, "Minimum Viable Product (MVP): Definition"]) notes that "'MVP' often means different things to different people" — from paper prototype to released product — and advises defining what you are testing and what you expect to learn before using the word
+* Henrik Kniberg's widely cited corrective https://blog.crisp.se/2016/01/25/henrikkniberg/making-sense-of-mvp["Making sense of MVP — and why I prefer Earliest Testable/Usable/Lovable"] (Crisp, 2016 — the skateboard→car drawing) argues "Minimum" and "Product" mislead teams into shipping useless fragments; each increment should be a smaller complete solution to the user's need, not a piece of the final one
+* Disambiguation advice: state which sense you mean — Ries's learning vehicle ("maximum validated learning for least effort") or Kniberg's Earliest Testable/Usable/Lovable staging — rather than relying on the bare acronym
 ====

--- a/docs/anchors/mvp.de.adoc
+++ b/docs/anchors/mvp.de.adoc
@@ -50,4 +50,11 @@ Schlüsselvertreter:: Eric Ries ("The Lean Startup", 2011); Frank Robinson präg
 * <<impact-mapping,Impact Mapping>> - Technik zur Ausrichtung des MVP-Umfangs auf Geschäftsziele
 * <<user-story-mapping,User Story Mapping>> - Visuelles Werkzeug zur Identifikation des minimalen Story-Sets für ein MVP
 * <<walking-skeleton,Walking Skeleton>> - Architektonisches Gegenstück; validiert Struktur statt Marktnachfrage
+
+[discrete]
+== *Kritik*:
+
+* Der Begriff ist in der Praxis verwässert: Die Nielsen Norman Group (https://www.nngroup.com/articles/mvp-definition/[Sara Paul, "Minimum Viable Product (MVP): Definition"]) stellt fest, dass „'MVP' für verschiedene Leute oft Verschiedenes bedeutet" — vom Papier-Prototyp bis zum Release — und rät, vor Verwendung des Worts zu definieren, was getestet und was gelernt werden soll
+* Henrik Knibergs vielzitierte Korrektur https://blog.crisp.se/2016/01/25/henrikkniberg/making-sense-of-mvp["Making sense of MVP — and why I prefer Earliest Testable/Usable/Lovable"] (Crisp, 2016 — die Skateboard→Auto-Zeichnung) argumentiert, „Minimum" und „Product" verleiten Teams dazu, nutzlose Fragmente zu liefern; jedes Inkrement sollte eine kleinere vollständige Lösung des Nutzerbedürfnisses sein, kein Teil der finalen
+* Disambiguierung: Sage, welchen Sinn du meinst — Ries' Lernvehikel („maximales validiertes Lernen mit geringstem Aufwand") oder Knibergs Earliest-Testable/Usable/Lovable-Stufen — statt dich auf das nackte Akronym zu verlassen
 ====

--- a/docs/anchors/save-the-cat.adoc
+++ b/docs/anchors/save-the-cat.adoc
@@ -60,4 +60,10 @@ Key Proponents:: Blake Snyder ("Save the Cat!", 2005)
 * <<three-act-structure,Three-Act Structure>>
 * <<freytags-pyramid,Freytag's Pyramid>>
 * <<fichtean-curve,Fichtean Curve>>
+
+[discrete]
+== *Criticism*:
+
+* Peter Suderman, https://slate.com/culture/2013/07/hollywood-and-blake-snyders-screenwriting-book-save-the-cat.html["Save the Movie!"] (Slate, 2013) — the beat sheet "has taken over Hollywood screenwriting" and "made every movie feel the same": where Syd Field and Robert McKee treated structure as "an organizing principle", Snyder pinned named beats to page numbers, turning description into prescription
+* The piece sparked an industry debate; responses like Christopher Boone's at https://nofilmschool.com/2013/07/screenwriter-reliance-story-structure-ruined-movies[No Film School] (2013) accept that screenplays need structure but ask whether writers lean on the beat sheet instead of the story — the recurring defense being that Snyder catalogued beats that already recur in successful films
 ====

--- a/docs/anchors/save-the-cat.de.adoc
+++ b/docs/anchors/save-the-cat.de.adoc
@@ -48,4 +48,10 @@ Schlüsselvertreter:: Blake Snyder ("Save the Cat!", 2005)
 * Beat-für-Beat-Prüfung einer Geschichte auf strukturelle Lücken oder Tempoprobleme
 * Anleitung von LLMs zur Erstellung von Storygliederungen nach Hollywood-Konventionen
 * Lehren von Geschichtsstruktur mit präzisen Seiten-/Prozentangaben
+
+[discrete]
+== *Kritik*:
+
+* Peter Suderman, https://slate.com/culture/2013/07/hollywood-and-blake-snyders-screenwriting-book-save-the-cat.html["Save the Movie!"] (Slate, 2013) — das Beat Sheet habe "das Hollywood-Drehbuchschreiben übernommen" und dafür gesorgt, dass "sich jeder Film gleich anfühlt": Wo Syd Field und Robert McKee Struktur als "Ordnungsprinzip" behandelten, nagelte Snyder benannte Beats auf Seitenzahlen fest — aus Beschreibung wurde Vorschrift
+* Der Artikel löste eine Branchendebatte aus; Antworten wie Christopher Boones bei https://nofilmschool.com/2013/07/screenwriter-reliance-story-structure-ruined-movies[No Film School] (2013) akzeptieren, dass Drehbücher Struktur brauchen, fragen aber, ob Autoren sich auf das Beat Sheet statt auf die Geschichte stützen — die wiederkehrende Verteidigung: Snyder katalogisierte Beats, die in erfolgreichen Filmen ohnehin wiederkehren
 ====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,11 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-11
 
+*Criticism sections, batch 3 (#603):*
+
+* The remaining twelve contested anchors from the catalog triage now carry a *Criticism* section (EN + DE), every claim with a named critic and a fetch-verified linked source: 4MAT (learning-styles evidence — Pashler et al. 2008, Kirschner 2017), AIDA (hierarchy-of-effects critique — Heath & Feldwick 2008, Vakratsas & Ambler 1999), Clean Architecture (indirection tax — Bogard, Comartin; alternative: Vertical Slice Architecture), CQRS (author-acknowledged overuse — Fowler, Dahan, Young), DRY (the authors' own "we did a poor job of explaining" concession plus Sandi Metz), Freytag's Pyramid (Jane Alison), GoF Design Patterns (Norvig's 16-of-23, Paul Graham's human compiler), Hero's Journey (folklorists Dundes and Toelken), Jobs To Be Done (the Christensen-vs-Ulwick two-schools problem), Kotter's 8 Steps (no empirical validation of the whole model — Appelbaum et al. 2012; Kotter's own Accelerate revision), MVP (term dilution — NN/g; Kniberg's skateboard corrective), and Save the Cat (Suderman's "Save the Movie!").
+* With batch 3, all 23 Criticism candidates and the 6 highest-drift Current Status candidates from the #603 triage are done — 28 anchors carry sourced sections.
+
 *Current Status sections, batch 2 (#603):*
 
 * The six anchors whose referent has editions or successors now carry a *Current Status* section (EN + DE) naming what is current, which edition an LLM's training-data prior most plausibly serves, and how to disambiguate in prompts — every claim fetch-verified by research agents: OWASP Top 10 (2025 edition is current; bare category IDs are ambiguous — A03 means Injection in 2021 but Software Supply Chain Failures in 2025), ISO/IEC 25010 (2023 revision: nine characteristics, Safety added; prior serves the withdrawn 2011 model), MADR (4.0.0; prior reproduces the 2.x-era template), Effective Go (deliberately frozen by the Go team since 2009, predates generics and modules), Bloom's Taxonomy (1956 nouns vs 2001 verbs — priors blend both), and Cockburn Use Cases (Use-Case 2.0 is an anchor of its own; the official Use Case 3.0 ebook exists since 2024 but its prior is thin — supply the definition in the prompt).


### PR DESCRIPTION
## Summary

Third batch of the catalog triage in #603 — completes **all 23 Criticism candidates** (batch 1 did 10, MBTI predates the convention). Twelve anchors get a Criticism section (EN + DE), every claim with a named critic and a fetch-verified linked source. Six parallel research agents, link verification before commit.

## Anchors covered

| Anchor | Key sources |
|---|---|
| `4mat` | Pashler et al. 2008 (PSPI, learning-styles evidence review); Kirschner 2017 ("Stop propagating the learning styles myth") |
| `aida-model` | Heath & Feldwick 2008 ("Fifty years using the wrong model of advertising"); Vakratsas & Ambler 1999 (250-study review, J. Marketing) |
| `clean-architecture` | Bogard ("Vertical Slice Architecture", 2018); Comartin ("useless indirection") — alternative cross-linked to the VSA anchor |
| `cqrs` | Fowler (bliki: "risky complexity"); Dahan ("Most people… shouldn't have"); Young ("CQRS is not an Architecture", archived) |
| `dry` | Sandi Metz ("The Wrong Abstraction"); the authors' own 20th-Anniversary concession (publisher's chapter extract) |
| `freytags-pyramid` | Jane Alison (Meander, Spiral, Explode); Mythcreants; defender position (Storm) included |
| `gof-design-patterns` | Norvig (16 of 23 "qualitatively simpler" — attribution corrected: "invisible or simpler" is Graham's paraphrase); Graham ("Revenge of the Nerds") |
| `heros-journey` | Folklorists Dundes (JAF 2005) and Toelken via Jorgensen's overview; Brin (Salon 1999) |
| `jobs-to-be-done` | Klement (two-schools split); Strategyn's priority claim; HBR 2016 — explains why our anchor carries the "(Christensen interpretation)" qualifier |
| `kotter-8-step-change-model` | Appelbaum et al. 2012 (no validation of the whole model, DOI); By 2005; Kotter Inc's own "linear 8 Step" → Accelerate concession |
| `mvp` | NN/g (term dilution); Kniberg's skateboard corrective (Crisp 2016) |
| `save-the-cat` | Suderman, "Save the Movie!" (Slate 2013); Boone's response (No Film School) |

## Source hygiene notes

- Dan North was *excluded* from Clean Architecture for lack of a citable written source (talks only) — the convention held even when it cost a famous name.
- DOI links to Sage/Emerald/T&F return bot-403s but resolve for humans; each was confirmed via Crossref/OpenAlex metadata plus a second fetched source.
- Dead originals link their Internet Archive captures (Young's codebetter post).

## Verification

- `node scripts/render-docs.js`: all 317 fragments render without errors
- All 24 sections confirmed present in rendered EN + DE HTML

Refs #603. Remaining from the triage after this: the 14 lower-priority Current Status candidates (table B rest), 6 thin-prior notes (table C), and the About-page lexicon sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Erweiterung von 16 Konzept-Ankern um Kritik-Abschnitte mit wissenschaftlichen Quellenverweisen und kritischen Perspektiven (sowohl englische als auch deutsche Versionen).
  * Neue Kritik-Inhalte adressieren Limitationen, alternative Sichtweisen und empirische Befunde zu etablierten Modellen und Mustern.
  * Changelog aktualisiert mit Übersicht der hinzugefügten Criticism-Sektionen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->