### PR TITLE
fix: issue templates referenced non-existent labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/contract-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/contract-proposal.yml
@@ -1,7 +1,7 @@
 name: 📜 Contract Proposal
 description: Propose a new semantic contract for the catalog
 title: "[Contract Proposal]: "
-labels: ["new-contract", "needs-validation"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/process-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/process-proposal.yml
@@ -1,7 +1,7 @@
 name: ⚙️ Process Proposal
 description: Propose a change to project processes or governance
 title: "[Process Proposal]: "
-labels: ["process", "discussion"]
+labels: ["question"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/propose-anchor.yml
+++ b/.github/ISSUE_TEMPLATE/propose-anchor.yml
@@ -1,7 +1,7 @@
 name: Propose New Semantic Anchor
 description: Suggest a new semantic anchor for the catalog
 title: "[Anchor Proposal]: "
-labels: ["new-anchor", "needs-validation"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Three issue templates referenced labels the repository does not define, so issues created from them silently arrived unlabeled (discovered while filing #608 — `gh` fails loudly, the web flow drops them silently):

| Template | Was | Now |
|---|---|---|
| `propose-anchor.yml` | `new-anchor`, `needs-validation` | `enhancement` |
| `contract-proposal.yml` | `new-contract`, `needs-validation` | `enhancement` |
| `process-proposal.yml` | `process`, `discussion` | `question` |

Alternative considered: creating the five missing labels instead — that would allow finer proposal filtering. Went with the minimal fix to existing labels; happy to switch if dedicated proposal labels are preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Releases-Hinweise

* **Chores**
  * Issue-Template-Beschriftungen aktualisiert: Die Klassifizierungsetiketten für Vertrags-, Prozess- und Anchor-Vorschläge wurden überarbeitet und vereinheitlicht, um einen verbesserten Workflow bei der Problemverwaltung zu ermöglichen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->