### PR TITLE
fix: per-context SCTR output files + fixed Q3.2 constraints sub-level (#531, #532)

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -2,6 +2,13 @@
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 
+== 2026-06-12
+
+*Socratic Code-Theory Recovery skill v0.3 (#531, #532):*
+
+* *Per-context output files (#531)* — Phase 1 now writes `QUESTION_TREE-<context>.adoc` and `OPEN_QUESTIONS-<context>.adoc` instead of fixed filenames, so the documented "one bounded context at a time" workflow no longer silently overwrites earlier runs; Phase 2 reads the context-specific tree, and ADRs get a context prefix (`adrs/<context>-adr-NNN-*.adoc`) so two contexts cannot clobber each other's decision records.
+* *Fixed Q3.2 constraints sub-level (#532)* — the Architecture Constraints node now always emits Q3.2.1 technical, Q3.2.2 organizational/process, and Q3.2.3 conventional constraints, mirroring arc42 Chapter 2's constraint kinds; for this branch the prompt explicitly admits non-code evidence (CLAUDE.md/AGENTS.md, CONTRIBUTING, CI workflows, linter configs), closing the gap where process and convention constraints surfaced untraceably in Phase 2 output.
+
 == 2026-06-11
 
 *Current Status sections, batch 4 — triage complete (#603):*

--- a/docs/socratic-recovery-skill.adoc
+++ b/docs/socratic-recovery-skill.adoc
@@ -9,16 +9,16 @@ Recovers documentation from a brownfield codebase without hallucinating the part
 
 === Phase 1 — Build the Question Tree
 
-The skill prompts the LLM to build a Question Tree from five root questions about a bounded context (Problem/Users, Specification, Architecture, Quality Goals, Risks). Their second level is fixed — every run emits the same enumerated nodes (Q1.1–Q5.5: six PRD elements, six specification categories, the twelve arc42 chapters, the eight ISO/IEC 25010 characteristics plus a priority question, five risk categories), so Q-IDs are stable and trees from different runs can be diffed node-by-node. Adaptive, code-driven decomposition happens only below that fixed level — a node keeps splitting until each leaf maps to one specific `file:line`, so tree depth tracks code density and a large bounded context yields a deeper tree. Each leaf is classified:
+The skill prompts the LLM to build a Question Tree from five root questions about a bounded context (Problem/Users, Specification, Architecture, Quality Goals, Risks). Their second level is fixed — every run emits the same enumerated nodes (Q1.1–Q5.5: six PRD elements, six specification categories, the twelve arc42 chapters, the eight ISO/IEC 25010 characteristics plus a priority question, five risk categories — and a fixed third level under Q3.2 for technical, organizational, and conventional constraints, with CLAUDE.md, CONTRIBUTING, CI and linter config as valid evidence sources), so Q-IDs are stable and trees from different runs can be diffed node-by-node. Adaptive, code-driven decomposition happens only below that fixed level — a node keeps splitting until each leaf maps to one specific `file:line`, so tree depth tracks code density and a large bounded context yields a deeper tree. Each leaf is classified:
 
 * `[ANSWERED]` -- the LLM found it in the code, with `<file>:<line>` evidence
 * `[OPEN]` -- the answer is not derivable from code; tagged with a Category and the role that must answer (Product Owner, Architect, Developer, Domain Expert, Operations)
 
-Outputs two AsciiDoc files: `QUESTION_TREE.adoc` (full reasoning trace) and `OPEN_QUESTIONS.adoc` (handoff, grouped by role).
+Outputs two AsciiDoc files, suffixed with the bounded-context name so sequential runs never overwrite each other: `QUESTION_TREE-<context>.adoc` (full reasoning trace) and `OPEN_QUESTIONS-<context>.adoc` (handoff, grouped by role).
 
 === Between phases — Team answers the OPEN leaves
 
-`OPEN_QUESTIONS.adoc` is routed to humans by role. They write answers directly into the file. Deferred questions get an explicit `(deferred)` marker, not invention.
+`OPEN_QUESTIONS-<context>.adoc` is routed to humans by role. They write answers directly into the file. Deferred questions get an explicit `(deferred)` marker, not invention.
 
 === Phase 2 — Synthesize documentation
 
@@ -202,7 +202,7 @@ Any AI assistant that accepts a system prompt or custom instructions can use thi
 | ADR fields as Q3.9 sub-tree; what makes a decision architecturally significant; Pugh-matrix guidance
 
 | `references/output-schema.md`
-| Strict format for `QUESTION_TREE.adoc` and `OPEN_QUESTIONS.adoc`; Q-ID scheme; `[ANSWERED]`/`[OPEN]` block formats; Phase 2 traceability rules
+| Strict format for `QUESTION_TREE-<context>.adoc` and `OPEN_QUESTIONS-<context>.adoc`; Q-ID scheme; `[ANSWERED]`/`[OPEN]` block formats; Phase 2 traceability rules
 
 | `references/examples.md`
 | Worked `[ANSWERED]` and `[OPEN]` leaves for each major branch (Q1-Q5)

--- a/docs/socratic-recovery-skill.de.adoc
+++ b/docs/socratic-recovery-skill.de.adoc
@@ -14,11 +14,11 @@ Der Skill weist das LLM an, aus fünf Wurzelfragen zum Bounded Context (Problem/
 * `[ANSWERED]` -- das LLM hat es im Code gefunden, mit `<file>:<line>`-Evidenz
 * `[OPEN]` -- die Antwort steckt nicht im Code; mit Category und der Rolle markiert, die antworten muss (Product Owner, Architect, Developer, Domain Expert, Operations)
 
-Output sind zwei AsciiDoc-Dateien: `QUESTION_TREE.adoc` (vollständige Begründungs-Spur) und `OPEN_QUESTIONS.adoc` (Handoff, nach Rolle gruppiert).
+Output sind zwei AsciiDoc-Dateien, mit dem Bounded-Context-Namen als Suffix, damit sequenzielle Läufe einander nie überschreiben: `QUESTION_TREE-<context>.adoc` (vollständige Begründungs-Spur) und `OPEN_QUESTIONS-<context>.adoc` (Handoff, nach Rolle gruppiert).
 
 === Zwischen den Phasen — Team beantwortet die OPEN-Leafs
 
-`OPEN_QUESTIONS.adoc` wird rollenweise an Menschen geleitet. Sie schreiben Antworten direkt in die Datei. Verschobene Fragen bekommen einen expliziten `(deferred)`-Marker, keine Erfindung.
+`OPEN_QUESTIONS-<context>.adoc` wird rollenweise an Menschen geleitet. Sie schreiben Antworten direkt in die Datei. Verschobene Fragen bekommen einen expliziten `(deferred)`-Marker, keine Erfindung.
 
 === Phase 2 — Dokumentation synthetisieren
 
@@ -202,7 +202,7 @@ Jeder Assistent, der einen System-Prompt oder Custom Instructions akzeptiert, ka
 | ADR-Felder als Q3.9-Sub-Tree; was eine Entscheidung architektonisch signifikant macht; Pugh-Matrix-Leitfaden
 
 | `references/output-schema.md`
-| Striktes Format für `QUESTION_TREE.adoc` und `OPEN_QUESTIONS.adoc`; Q-ID-Schema; `[ANSWERED]`/`[OPEN]`-Blockformate; Phase-2-Traceability-Regeln
+| Striktes Format für `QUESTION_TREE-<context>.adoc` und `OPEN_QUESTIONS-<context>.adoc`; Q-ID-Schema; `[ANSWERED]`/`[OPEN]`-Blockformate; Phase-2-Traceability-Regeln
 
 | `references/examples.md`
 | Worked `[ANSWERED]` und `[OPEN]` Leaves für jeden Hauptast (Q1-Q5)

--- a/plugins/semantic-anchors/plugin.json
+++ b/plugins/semantic-anchors/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-anchors",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Semantic anchor skills for translating terminology and installing persistent anchor context into coding agents.",
   "author": {
     "name": "LLM Coding",

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
@@ -24,7 +24,7 @@ When this skill is invoked:
 
 3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path and `[context-name]` with the kebab-cased human-readable name. Do not change the leaf classification, Q-ID scheme, or the output-file naming scheme.
 
-4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS-<context-name>.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+4. **Stop after Phase 1.** Tell the user that Phase 1 is complete, where the two output files are, and that the next step is routing `OPEN_QUESTIONS-<context-name>.adoc` to the team. Phase 2 is gated on the file, not on being asked: before starting Phase 2 — even when the user explicitly requests it — check that every `[OPEN]` leaf in `OPEN_QUESTIONS-<context-name>.adoc` has either a team answer or an explicit `(deferred)` marker. If any leaf has neither, do not run Phase 2; list the unanswered leaves instead.
 
 ## When to use this skill
 

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/SKILL.md
@@ -3,7 +3,7 @@ name: socratic-code-theory-recovery
 description: Recover the "theory" (Naur 1985) of an existing codebase through recursive question refinement before writing documentation. Use on brownfield projects where the spec is missing — produces a Question Tree separating what is answerable from code (with evidence) from what must be asked of the team (routed by role). Phase 1 builds the tree; team answers the OPEN leaves; Phase 2 synthesizes PRD, Cockburn use cases, arc42 architecture, and Nygard ADRs from the answered tree.
 metadata:
   author: LLM-Coding
-  version: "0.2"
+  version: "0.3"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---
@@ -18,13 +18,13 @@ When this skill is invoked:
 
 1. **Check whether the user named a bounded context.** Look at the same message that invoked the skill and at the immediately preceding messages. A valid bounded-context pointer is a path (relative or absolute) to a directory, plus a short human-readable name for what the context is (e.g. `src/auth`, "Authentication"). If both are present, proceed to Phase 1.
 
-2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE.adoc`, `OPEN_QUESTIONS.adoc`) and running it on the wrong directory wastes work. Ask exactly:
+2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE-<context-name>.adoc`, `OPEN_QUESTIONS-<context-name>.adoc`) and running it on the wrong directory wastes work. Ask exactly:
 
    > Which bounded context should I apply Socratic Code-Theory Recovery to? Give me a directory path (the bounded context's code root) and a short human-readable name. If you want the whole current repo treated as one bounded context, say so explicitly.
 
-3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path. Do not change the leaf classification, Q-ID scheme, or output files.
+3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path and `[context-name]` with the kebab-cased human-readable name. Do not change the leaf classification, Q-ID scheme, or the output-file naming scheme.
 
-4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS-<context-name>.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
 
 ## When to use this skill
 
@@ -57,7 +57,7 @@ The fix: model the gaps explicitly. Every question about the system is either `[
                   └────────────────┬───────────────┘
                                    ▼
                   ┌────────────────────────────────┐
-   Between        │  OPEN_QUESTIONS.adoc           │
+   Between        │  OPEN_QUESTIONS-<context>.adoc │
                   │  ──► team (routed by role)     │
                   │  ──► answers fill in OPENs     │
                   └────────────────┬───────────────┘
@@ -71,18 +71,18 @@ The fix: model the gaps explicitly. Every question about the system is either `[
 
 ### Phase 1: Build the Question Tree
 
-Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md). Adapt the bounded-context path and the Q1-Q5 wording; do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output files.
+Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md). Adapt the bounded-context path and the Q1-Q5 wording; do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output-file naming scheme.
 
-Outputs:
+Outputs (named after the context so sequential runs on different bounded contexts never overwrite each other):
 
-- `QUESTION_TREE.adoc` — the full hierarchical reasoning trace
-- `OPEN_QUESTIONS.adoc` — only the `[OPEN]` leaves, grouped by Ask role
+- `QUESTION_TREE-<context-name>.adoc` — the full hierarchical reasoning trace
+- `OPEN_QUESTIONS-<context-name>.adoc` — only the `[OPEN]` leaves, grouped by Ask role
 
 The five root questions decompose into a **fixed second level** — the same enumerated node set on every run, so Q-IDs are stable and trees from different runs can be diffed node-by-node. Adaptive, code-driven decomposition applies only *below* the fixed level. The fixed nodes:
 
 - **Q1.1–Q1.6** — product identity, primary users, channels, why-built, success metrics, segment priority.
 - **Q2.1–Q2.6** — actors, use-case catalog, per-interface system specs, data/entity model, acceptance criteria, cross-cutting business rules. See [references/cockburn-use-cases.md](references/cockburn-use-cases.md).
-- **Q3.1–Q3.12** — the twelve arc42 chapters, in arc42 order. See [references/arc42.md](references/arc42.md). Design rationale lives in the Q3.9 chapter — see [references/nygard-adrs.md](references/nygard-adrs.md).
+- **Q3.1–Q3.12** — the twelve arc42 chapters, in arc42 order. See [references/arc42.md](references/arc42.md). Design rationale lives in the Q3.9 chapter — see [references/nygard-adrs.md](references/nygard-adrs.md). **Q3.2 (Architecture Constraints) additionally carries a fixed third level** — Q3.2.1 technical, Q3.2.2 organizational/process, Q3.2.3 conventional constraints — because these rarely live in dense code; for this branch, `CLAUDE.md`/`AGENTS.md`, CONTRIBUTING files, CI workflows, and linter configs are valid evidence sources.
 - **Q4.1–Q4.8** — the eight ISO/IEC 25010 characteristics; **Q4.9** — which characteristic has priority. See [references/iso-25010.md](references/iso-25010.md).
 - **Q5.1–Q5.5** — technical debt, security risks, operational risks, dependency/supply-chain risks, scaling/performance risks.
 
@@ -96,9 +96,9 @@ Worked examples — one `[ANSWERED]` and one `[OPEN]` leaf for each major branch
 
 ### Between Phases: Team answers the OPEN leaves
 
-Route `OPEN_QUESTIONS.adoc` to the people whose role appears in each section: Product Owner, Architect, Developer, Domain Expert, Operations. In one controlled experiment with a 13,000-line Go codebase, 11 targeted OPEN questions were enough to close the gap to the original documentation.
+Route `OPEN_QUESTIONS-<context-name>.adoc` to the people whose role appears in each section: Product Owner, Architect, Developer, Domain Expert, Operations. In one controlled experiment with a 13,000-line Go codebase, 11 targeted OPEN questions were enough to close the gap to the original documentation.
 
-Team answers are written **directly into `OPEN_QUESTIONS.adoc`** under each question, marked clearly. Do not call Phase 2 until every OPEN leaf has either an answer or an explicit `(deferred)` marker.
+Team answers are written **directly into `OPEN_QUESTIONS-<context-name>.adoc`** under each question, marked clearly. Do not call Phase 2 until every OPEN leaf has either an answer or an explicit `(deferred)` marker.
 
 ### Phase 2: Synthesize documentation
 

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/prompts/phase-1-question-tree.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/prompts/phase-1-question-tree.md
@@ -1,6 +1,6 @@
 # Phase 1 Prompt: Build the Question Tree
 
-Copy the block below into a session that has read access to the bounded context. Replace `[bounded context path]` with the actual path. Adapt the Q1-Q5 wording if your domain has different starting concerns, but do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output files.
+Copy the block below into a session that has read access to the bounded context. Replace `[bounded context path]` with the actual path and `[context-name]` with the short human-readable context name in kebab-case (e.g. `auth`, `vibe-core`) — the same name Phase 2 uses for its output files. Adapt the Q1-Q5 wording if your domain has different starting concerns, but do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output-file naming scheme.
 
 ```
 You are performing Socratic Code-Theory Recovery on a brownfield bounded
@@ -31,6 +31,22 @@ Process:
      Q4.9       which characteristic has priority
      Q5.1-Q5.5  technical debt, security risks, operational risks,
                 dependency/supply-chain risks, scaling/performance risks
+
+   One node carries a FIXED third level too: Q3.2 (Architecture
+   Constraints) always emits exactly these three sub-nodes, mirroring the
+   constraint kinds arc42 Chapter 2 distinguishes:
+     Q3.2.1 technical constraints — language, runtime, mandated
+            frameworks/libraries
+     Q3.2.2 organizational/process constraints — git workflow, branching,
+            release process, review rules
+     Q3.2.3 conventional constraints — naming, file layout, code-style
+            rules, commit conventions
+   For the Q3.2 branch specifically, look beyond source code: CLAUDE.md /
+   AGENTS.md, CONTRIBUTING files, CI workflow definitions, and
+   linter/formatter configs are valid evidence sources — cite them
+   file:line like any other evidence. Constraints of these kinds rarely
+   live in dense code, so a code-density-driven decomposition would walk
+   right past them.
 
 3. Below the fixed second level, decompose ADAPTIVELY and code-driven.
    A node is a leaf ONLY when its question can be answered with specific
@@ -79,16 +95,17 @@ Process:
    an [ANSWERED] quality scenario with file:line. Never invent a target
    number. Only the quality-goal ranking (Q4.9) is [OPEN].
 
-5. Output two files in AsciiDoc:
+5. Output two files in AsciiDoc, named after the bounded context so that
+   sequential runs on different contexts never overwrite each other:
 
-   QUESTION_TREE.adoc
+   QUESTION_TREE-[context-name].adoc
      - Full hierarchical tree with all nodes and Q-IDs
      - Each leaf marked [ANSWERED] (with evidence) or [OPEN] (with Category
        and Ask role)
      - Includes all reasoning, not only the leaves
 
-   OPEN_QUESTIONS.adoc
-     - Only the [OPEN] leaves, copied verbatim from QUESTION_TREE.adoc
+   OPEN_QUESTIONS-[context-name].adoc
+     - Only the [OPEN] leaves, copied verbatim from the Question Tree file
      - Always one section per Ask role (Product Owner, Architect,
        Developer, Domain Expert, Operations) — emit every section even
        when it is empty ("No open questions for this role")
@@ -101,12 +118,12 @@ team has filled in the [OPEN] leaves.
 
 ## What to do after the prompt completes
 
-1. **Sanity-check `QUESTION_TREE.adoc` for evidence.** Pick three `[ANSWERED]` leaves at random and verify the cited file:line actually contains the claim. If any cite is wrong, the LLM is hallucinating evidence — re-run with a smaller bounded context.
+1. **Sanity-check `QUESTION_TREE-[context-name].adoc` for evidence.** Pick three `[ANSWERED]` leaves at random and verify the cited file:line actually contains the claim. If any cite is wrong, the LLM is hallucinating evidence — re-run with a smaller bounded context.
 
 2. **Sanity-check the tree for depth.** Scan for `[ANSWERED]` leaves whose evidence is a directory or a whole file, or whose answer is one paragraph standing in for an entire arc42 chapter (a common failure on `Q3.5` building-block view and `Q2.3` per-interface system specs). Those leaves were not decomposed far enough — decomposition stopped before the answer became specific. Re-run Phase 1, or decompose those branches further. Note: the OPEN-question count measures only the OPEN side; a healthy count (10-15) does not mean the ANSWERED side is deep enough — check leaf granularity separately.
 
-3. **Route `OPEN_QUESTIONS.adoc` to the team.** One section per Ask role. Typically 10-15 questions for a small bounded context; if you see 50+, the bounded context is too large.
+3. **Route `OPEN_QUESTIONS-[context-name].adoc` to the team.** One section per Ask role. Typically 10-15 questions for a small bounded context; if you see 50+, the bounded context is too large.
 
-4. **Team writes answers directly into `OPEN_QUESTIONS.adoc`** under each question. Mark deferrals explicitly as `(deferred)` so Phase 2 can decide whether to leave them as gaps in the documentation.
+4. **Team writes answers directly into `OPEN_QUESTIONS-[context-name].adoc`** under each question. Mark deferrals explicitly as `(deferred)` so Phase 2 can decide whether to leave them as gaps in the documentation.
 
 5. Only after every leaf has an answer or an explicit deferral, run Phase 2.

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/prompts/phase-2-synthesize.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/prompts/phase-2-synthesize.md
@@ -1,14 +1,15 @@
 # Phase 2 Prompt: Synthesize Documentation
 
-Run this prompt only after every `[OPEN]` leaf in `OPEN_QUESTIONS.adoc` has either a team answer or an explicit `(deferred)` marker.
+Run this prompt only after every `[OPEN]` leaf in `OPEN_QUESTIONS-[context-name].adoc` has either a team answer or an explicit `(deferred)` marker. Replace `[context-name]` with the same kebab-case context name Phase 1 used.
 
 ```
 You are performing Phase 2 of Socratic Code-Theory Recovery.
 
 Inputs:
-- QUESTION_TREE.adoc — the answered Question Tree from Phase 1.
-- OPEN_QUESTIONS.adoc — same OPEN leaves, now with team answers (or
-  (deferred) markers) written under each question.
+- QUESTION_TREE-[context-name].adoc — the answered Question Tree from
+  Phase 1.
+- OPEN_QUESTIONS-[context-name].adoc — same OPEN leaves, now with team
+  answers (or (deferred) markers) written under each question.
 
 Goal: synthesize documentation from the answered tree. Every claim must
 trace back to a tree leaf — this is a build-time check, not a Q-ID stamped
@@ -22,7 +23,7 @@ Produce four artifacts:
 1. docs/specs/prd-[context-name].adoc — Product Requirements Document
    - Problem statement, target users, goals, success criteria, scope
      boundaries, constraints, open questions
-   - Source: Q1 branch of QUESTION_TREE.adoc
+   - Source: Q1 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: PRD (Cagan / Pichler)
 
 2. docs/specs/use-cases-[context-name].adoc — Specification
@@ -35,7 +36,7 @@ Produce four artifacts:
    - Supplementary Specifications: Entity Model, State Machines, Interface
      Contracts, Validation Rules.
    - Gherkin acceptance criteria where applicable.
-   - Source: Q2 branch of QUESTION_TREE.adoc
+   - Source: Q2 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: Cockburn Use Cases
 
 3. docs/arc42/arc42-[context-name].adoc — Architecture
@@ -48,14 +49,16 @@ Produce four artifacts:
      the test concept. Only the goal ranking stays [OPEN]; "No
      information" is legitimate here only if Q4 produced no answered
      scenario at all.
-   - Source: Q3 branch of QUESTION_TREE.adoc
+   - Source: Q3 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: arc42 (Starke / Hruschka)
 
-4. docs/specs/adrs/*.adoc — one ADR per significant design decision
+4. docs/specs/adrs/[context-name]-adr-NNN-*.adoc — one ADR per
+   significant design decision. The context-name prefix keeps ADRs from
+   different bounded contexts from colliding in the shared adrs/ folder.
    - Nygard format: Title, Status, Context, Decision, Consequences.
    - Include a Pugh Matrix listing the alternatives considered with a
      3-point scale (-1, 0, +1) against the quality goals from Q4.
-   - Source: Q3.9 branch of QUESTION_TREE.adoc
+   - Source: Q3.9 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: ADR according to Nygard
 
 Rules for traceability:
@@ -77,8 +80,9 @@ Rules for traceability:
   "Sessions expire after 24 hours (team answer)."
 - Deferred questions stay as explicit gaps: "Quality-goal priorities are
   deferred and must be resolved before the next release."
-- Do not introduce facts that do not appear in QUESTION_TREE.adoc or
-  OPEN_QUESTIONS.adoc. If a Section feels under-specified, leave it
+- Do not introduce facts that do not appear in
+  QUESTION_TREE-[context-name].adoc or OPEN_QUESTIONS-[context-name].adoc.
+  If a Section feels under-specified, leave it
   under-specified — that is signal, not a defect.
 ```
 

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/references/arc42.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/references/arc42.md
@@ -7,7 +7,7 @@ arc42 is a 12-chapter template for documenting software architecture (Gernot Sta
 | Q-ID | Section | Sub-question(s) |
 |------|---------|-----------------|
 | Q3.1 | Introduction and Goals | What does the system do at the highest level? Which 3-5 quality goals drive design? Who are the most important stakeholders? |
-| Q3.2 | Architecture Constraints | Which technical, organizational, conventional constraints restrict design choices? |
+| Q3.2 | Architecture Constraints | Which technical (Q3.2.1), organizational/process (Q3.2.2), conventional (Q3.2.3) constraints restrict design choices? Fixed third level — look beyond code: CLAUDE.md/AGENTS.md, CONTRIBUTING, CI config, linter rules are valid evidence. |
 | Q3.3 | Context and Scope | What are the system's external interfaces — neighbours, channels, protocols? Business context vs technical context? |
 | Q3.4 | Solution Strategy | Which fundamental decisions and patterns shape the architecture? Technology choices, top-level decomposition, quality-goal approaches, organizational decisions? |
 | Q3.5 | Building Block View | How is the system decomposed into containers, components, classes? Static structure at multiple levels of zoom. |

--- a/plugins/semantic-anchors/skills/socratic-code-theory-recovery/references/output-schema.md
+++ b/plugins/semantic-anchors/skills/socratic-code-theory-recovery/references/output-schema.md
@@ -1,8 +1,8 @@
-# Output Schema — QUESTION_TREE.adoc and OPEN_QUESTIONS.adoc
+# Output Schema — QUESTION_TREE-<context-name>.adoc and OPEN_QUESTIONS-<context-name>.adoc
 
-Two AsciiDoc files. The schema is rigid enough to be machine-checkable but written in plain prose so a team member can read it.
+Two AsciiDoc files, each suffixed with the kebab-cased bounded-context name so sequential runs on different contexts never overwrite each other. The schema is rigid enough to be machine-checkable but written in plain prose so a team member can read it.
 
-## QUESTION_TREE.adoc
+## QUESTION_TREE-<context-name>.adoc
 
 Hierarchical tree, top-down. Each node has a Q-ID, the question, and (for leaves) either an `[ANSWERED]` or `[OPEN]` marker.
 
@@ -95,7 +95,7 @@ Ask role: <one or more of: Product Owner | Architect | Developer | Domain Expert
 - **Ask role** is the role-class of person who can answer, not a named individual. Multiple roles are fine — list them in order of best to ask.
 - The body of the leaf must explain *why* the code can't answer it. If the body says "the code doesn't say", widen it: "the code persists status=PENDING but never transitions it" is a real reason; "we don't know" is not.
 
-## OPEN_QUESTIONS.adoc
+## OPEN_QUESTIONS-<context-name>.adoc
 
 A flat, role-grouped projection of every `[OPEN]` leaf. This is the handoff document — the team sees only their section.
 
@@ -137,7 +137,7 @@ _(write here)_
 
 - One section per Ask role.
 - A leaf with multiple Ask roles is duplicated under each role's section — make it explicit to whichever role reads first.
-- The `*Your answer:*` block is mandatory. Team members write directly into the file. Phase 2 reads this file together with `QUESTION_TREE.adoc`.
+- The `*Your answer:*` block is mandatory. Team members write directly into the file. Phase 2 reads this file together with `QUESTION_TREE-<context-name>.adoc`.
 - A deferred question gets `(deferred — <reason>)` instead of an answer. Phase 2 treats deferred questions as explicit gaps, not as filled-in answers.
 
 ## Phase 2 traceability

--- a/skill/socratic-code-theory-recovery/SKILL.md
+++ b/skill/socratic-code-theory-recovery/SKILL.md
@@ -24,7 +24,7 @@ When this skill is invoked:
 
 3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path and `[context-name]` with the kebab-cased human-readable name. Do not change the leaf classification, Q-ID scheme, or the output-file naming scheme.
 
-4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS-<context-name>.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+4. **Stop after Phase 1.** Tell the user that Phase 1 is complete, where the two output files are, and that the next step is routing `OPEN_QUESTIONS-<context-name>.adoc` to the team. Phase 2 is gated on the file, not on being asked: before starting Phase 2 — even when the user explicitly requests it — check that every `[OPEN]` leaf in `OPEN_QUESTIONS-<context-name>.adoc` has either a team answer or an explicit `(deferred)` marker. If any leaf has neither, do not run Phase 2; list the unanswered leaves instead.
 
 ## When to use this skill
 

--- a/skill/socratic-code-theory-recovery/SKILL.md
+++ b/skill/socratic-code-theory-recovery/SKILL.md
@@ -3,7 +3,7 @@ name: socratic-code-theory-recovery
 description: Recover the "theory" (Naur 1985) of an existing codebase through recursive question refinement before writing documentation. Use on brownfield projects where the spec is missing — produces a Question Tree separating what is answerable from code (with evidence) from what must be asked of the team (routed by role). Phase 1 builds the tree; team answers the OPEN leaves; Phase 2 synthesizes PRD, Cockburn use cases, arc42 architecture, and Nygard ADRs from the answered tree.
 metadata:
   author: LLM-Coding
-  version: "0.2"
+  version: "0.3"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---
@@ -18,13 +18,13 @@ When this skill is invoked:
 
 1. **Check whether the user named a bounded context.** Look at the same message that invoked the skill and at the immediately preceding messages. A valid bounded-context pointer is a path (relative or absolute) to a directory, plus a short human-readable name for what the context is (e.g. `src/auth`, "Authentication"). If both are present, proceed to Phase 1.
 
-2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE.adoc`, `OPEN_QUESTIONS.adoc`) and running it on the wrong directory wastes work. Ask exactly:
+2. **If no bounded context is named, ask for it before doing anything else.** Do not start Phase 1 against the current working directory by default — Phase 1 produces files (`QUESTION_TREE-<context-name>.adoc`, `OPEN_QUESTIONS-<context-name>.adoc`) and running it on the wrong directory wastes work. Ask exactly:
 
    > Which bounded context should I apply Socratic Code-Theory Recovery to? Give me a directory path (the bounded context's code root) and a short human-readable name. If you want the whole current repo treated as one bounded context, say so explicitly.
 
-3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path. Do not change the leaf classification, Q-ID scheme, or output files.
+3. **Once you have the pointer, run Phase 1.** Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md) — substitute `[bounded context path]` with the user's path and `[context-name]` with the kebab-cased human-readable name. Do not change the leaf classification, Q-ID scheme, or the output-file naming scheme.
 
-4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
+4. **Stop after Phase 1.** Phase 2 must wait for the team to answer the `[OPEN]` leaves in `OPEN_QUESTIONS-<context-name>.adoc`. Tell the user that Phase 1 is complete, where the two output files are, and what the next manual step is — do not proceed to Phase 2 in the same session unless the user explicitly asks.
 
 ## When to use this skill
 
@@ -57,7 +57,7 @@ The fix: model the gaps explicitly. Every question about the system is either `[
                   └────────────────┬───────────────┘
                                    ▼
                   ┌────────────────────────────────┐
-   Between        │  OPEN_QUESTIONS.adoc           │
+   Between        │  OPEN_QUESTIONS-<context>.adoc │
                   │  ──► team (routed by role)     │
                   │  ──► answers fill in OPENs     │
                   └────────────────┬───────────────┘
@@ -71,18 +71,18 @@ The fix: model the gaps explicitly. Every question about the system is either `[
 
 ### Phase 1: Build the Question Tree
 
-Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md). Adapt the bounded-context path and the Q1-Q5 wording; do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output files.
+Use [prompts/phase-1-question-tree.md](prompts/phase-1-question-tree.md). Adapt the bounded-context path and the Q1-Q5 wording; do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output-file naming scheme.
 
-Outputs:
+Outputs (named after the context so sequential runs on different bounded contexts never overwrite each other):
 
-- `QUESTION_TREE.adoc` — the full hierarchical reasoning trace
-- `OPEN_QUESTIONS.adoc` — only the `[OPEN]` leaves, grouped by Ask role
+- `QUESTION_TREE-<context-name>.adoc` — the full hierarchical reasoning trace
+- `OPEN_QUESTIONS-<context-name>.adoc` — only the `[OPEN]` leaves, grouped by Ask role
 
 The five root questions decompose into a **fixed second level** — the same enumerated node set on every run, so Q-IDs are stable and trees from different runs can be diffed node-by-node. Adaptive, code-driven decomposition applies only *below* the fixed level. The fixed nodes:
 
 - **Q1.1–Q1.6** — product identity, primary users, channels, why-built, success metrics, segment priority.
 - **Q2.1–Q2.6** — actors, use-case catalog, per-interface system specs, data/entity model, acceptance criteria, cross-cutting business rules. See [references/cockburn-use-cases.md](references/cockburn-use-cases.md).
-- **Q3.1–Q3.12** — the twelve arc42 chapters, in arc42 order. See [references/arc42.md](references/arc42.md). Design rationale lives in the Q3.9 chapter — see [references/nygard-adrs.md](references/nygard-adrs.md).
+- **Q3.1–Q3.12** — the twelve arc42 chapters, in arc42 order. See [references/arc42.md](references/arc42.md). Design rationale lives in the Q3.9 chapter — see [references/nygard-adrs.md](references/nygard-adrs.md). **Q3.2 (Architecture Constraints) additionally carries a fixed third level** — Q3.2.1 technical, Q3.2.2 organizational/process, Q3.2.3 conventional constraints — because these rarely live in dense code; for this branch, `CLAUDE.md`/`AGENTS.md`, CONTRIBUTING files, CI workflows, and linter configs are valid evidence sources.
 - **Q4.1–Q4.8** — the eight ISO/IEC 25010 characteristics; **Q4.9** — which characteristic has priority. See [references/iso-25010.md](references/iso-25010.md).
 - **Q5.1–Q5.5** — technical debt, security risks, operational risks, dependency/supply-chain risks, scaling/performance risks.
 
@@ -96,9 +96,9 @@ Worked examples — one `[ANSWERED]` and one `[OPEN]` leaf for each major branch
 
 ### Between Phases: Team answers the OPEN leaves
 
-Route `OPEN_QUESTIONS.adoc` to the people whose role appears in each section: Product Owner, Architect, Developer, Domain Expert, Operations. In one controlled experiment with a 13,000-line Go codebase, 11 targeted OPEN questions were enough to close the gap to the original documentation.
+Route `OPEN_QUESTIONS-<context-name>.adoc` to the people whose role appears in each section: Product Owner, Architect, Developer, Domain Expert, Operations. In one controlled experiment with a 13,000-line Go codebase, 11 targeted OPEN questions were enough to close the gap to the original documentation.
 
-Team answers are written **directly into `OPEN_QUESTIONS.adoc`** under each question, marked clearly. Do not call Phase 2 until every OPEN leaf has either an answer or an explicit `(deferred)` marker.
+Team answers are written **directly into `OPEN_QUESTIONS-<context-name>.adoc`** under each question, marked clearly. Do not call Phase 2 until every OPEN leaf has either an answer or an explicit `(deferred)` marker.
 
 ### Phase 2: Synthesize documentation
 

--- a/skill/socratic-code-theory-recovery/prompts/phase-1-question-tree.md
+++ b/skill/socratic-code-theory-recovery/prompts/phase-1-question-tree.md
@@ -1,6 +1,6 @@
 # Phase 1 Prompt: Build the Question Tree
 
-Copy the block below into a session that has read access to the bounded context. Replace `[bounded context path]` with the actual path. Adapt the Q1-Q5 wording if your domain has different starting concerns, but do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output files.
+Copy the block below into a session that has read access to the bounded context. Replace `[bounded context path]` with the actual path and `[context-name]` with the short human-readable context name in kebab-case (e.g. `auth`, `vibe-core`) — the same name Phase 2 uses for its output files. Adapt the Q1-Q5 wording if your domain has different starting concerns, but do not change the fixed second level, the leaf classification, the Q-ID scheme, or the output-file naming scheme.
 
 ```
 You are performing Socratic Code-Theory Recovery on a brownfield bounded
@@ -31,6 +31,22 @@ Process:
      Q4.9       which characteristic has priority
      Q5.1-Q5.5  technical debt, security risks, operational risks,
                 dependency/supply-chain risks, scaling/performance risks
+
+   One node carries a FIXED third level too: Q3.2 (Architecture
+   Constraints) always emits exactly these three sub-nodes, mirroring the
+   constraint kinds arc42 Chapter 2 distinguishes:
+     Q3.2.1 technical constraints — language, runtime, mandated
+            frameworks/libraries
+     Q3.2.2 organizational/process constraints — git workflow, branching,
+            release process, review rules
+     Q3.2.3 conventional constraints — naming, file layout, code-style
+            rules, commit conventions
+   For the Q3.2 branch specifically, look beyond source code: CLAUDE.md /
+   AGENTS.md, CONTRIBUTING files, CI workflow definitions, and
+   linter/formatter configs are valid evidence sources — cite them
+   file:line like any other evidence. Constraints of these kinds rarely
+   live in dense code, so a code-density-driven decomposition would walk
+   right past them.
 
 3. Below the fixed second level, decompose ADAPTIVELY and code-driven.
    A node is a leaf ONLY when its question can be answered with specific
@@ -79,16 +95,17 @@ Process:
    an [ANSWERED] quality scenario with file:line. Never invent a target
    number. Only the quality-goal ranking (Q4.9) is [OPEN].
 
-5. Output two files in AsciiDoc:
+5. Output two files in AsciiDoc, named after the bounded context so that
+   sequential runs on different contexts never overwrite each other:
 
-   QUESTION_TREE.adoc
+   QUESTION_TREE-[context-name].adoc
      - Full hierarchical tree with all nodes and Q-IDs
      - Each leaf marked [ANSWERED] (with evidence) or [OPEN] (with Category
        and Ask role)
      - Includes all reasoning, not only the leaves
 
-   OPEN_QUESTIONS.adoc
-     - Only the [OPEN] leaves, copied verbatim from QUESTION_TREE.adoc
+   OPEN_QUESTIONS-[context-name].adoc
+     - Only the [OPEN] leaves, copied verbatim from the Question Tree file
      - Always one section per Ask role (Product Owner, Architect,
        Developer, Domain Expert, Operations) — emit every section even
        when it is empty ("No open questions for this role")
@@ -101,12 +118,12 @@ team has filled in the [OPEN] leaves.
 
 ## What to do after the prompt completes
 
-1. **Sanity-check `QUESTION_TREE.adoc` for evidence.** Pick three `[ANSWERED]` leaves at random and verify the cited file:line actually contains the claim. If any cite is wrong, the LLM is hallucinating evidence — re-run with a smaller bounded context.
+1. **Sanity-check `QUESTION_TREE-[context-name].adoc` for evidence.** Pick three `[ANSWERED]` leaves at random and verify the cited file:line actually contains the claim. If any cite is wrong, the LLM is hallucinating evidence — re-run with a smaller bounded context.
 
 2. **Sanity-check the tree for depth.** Scan for `[ANSWERED]` leaves whose evidence is a directory or a whole file, or whose answer is one paragraph standing in for an entire arc42 chapter (a common failure on `Q3.5` building-block view and `Q2.3` per-interface system specs). Those leaves were not decomposed far enough — decomposition stopped before the answer became specific. Re-run Phase 1, or decompose those branches further. Note: the OPEN-question count measures only the OPEN side; a healthy count (10-15) does not mean the ANSWERED side is deep enough — check leaf granularity separately.
 
-3. **Route `OPEN_QUESTIONS.adoc` to the team.** One section per Ask role. Typically 10-15 questions for a small bounded context; if you see 50+, the bounded context is too large.
+3. **Route `OPEN_QUESTIONS-[context-name].adoc` to the team.** One section per Ask role. Typically 10-15 questions for a small bounded context; if you see 50+, the bounded context is too large.
 
-4. **Team writes answers directly into `OPEN_QUESTIONS.adoc`** under each question. Mark deferrals explicitly as `(deferred)` so Phase 2 can decide whether to leave them as gaps in the documentation.
+4. **Team writes answers directly into `OPEN_QUESTIONS-[context-name].adoc`** under each question. Mark deferrals explicitly as `(deferred)` so Phase 2 can decide whether to leave them as gaps in the documentation.
 
 5. Only after every leaf has an answer or an explicit deferral, run Phase 2.

--- a/skill/socratic-code-theory-recovery/prompts/phase-2-synthesize.md
+++ b/skill/socratic-code-theory-recovery/prompts/phase-2-synthesize.md
@@ -1,14 +1,15 @@
 # Phase 2 Prompt: Synthesize Documentation
 
-Run this prompt only after every `[OPEN]` leaf in `OPEN_QUESTIONS.adoc` has either a team answer or an explicit `(deferred)` marker.
+Run this prompt only after every `[OPEN]` leaf in `OPEN_QUESTIONS-[context-name].adoc` has either a team answer or an explicit `(deferred)` marker. Replace `[context-name]` with the same kebab-case context name Phase 1 used.
 
 ```
 You are performing Phase 2 of Socratic Code-Theory Recovery.
 
 Inputs:
-- QUESTION_TREE.adoc — the answered Question Tree from Phase 1.
-- OPEN_QUESTIONS.adoc — same OPEN leaves, now with team answers (or
-  (deferred) markers) written under each question.
+- QUESTION_TREE-[context-name].adoc — the answered Question Tree from
+  Phase 1.
+- OPEN_QUESTIONS-[context-name].adoc — same OPEN leaves, now with team
+  answers (or (deferred) markers) written under each question.
 
 Goal: synthesize documentation from the answered tree. Every claim must
 trace back to a tree leaf — this is a build-time check, not a Q-ID stamped
@@ -22,7 +23,7 @@ Produce four artifacts:
 1. docs/specs/prd-[context-name].adoc — Product Requirements Document
    - Problem statement, target users, goals, success criteria, scope
      boundaries, constraints, open questions
-   - Source: Q1 branch of QUESTION_TREE.adoc
+   - Source: Q1 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: PRD (Cagan / Pichler)
 
 2. docs/specs/use-cases-[context-name].adoc — Specification
@@ -35,7 +36,7 @@ Produce four artifacts:
    - Supplementary Specifications: Entity Model, State Machines, Interface
      Contracts, Validation Rules.
    - Gherkin acceptance criteria where applicable.
-   - Source: Q2 branch of QUESTION_TREE.adoc
+   - Source: Q2 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: Cockburn Use Cases
 
 3. docs/arc42/arc42-[context-name].adoc — Architecture
@@ -48,14 +49,16 @@ Produce four artifacts:
      the test concept. Only the goal ranking stays [OPEN]; "No
      information" is legitimate here only if Q4 produced no answered
      scenario at all.
-   - Source: Q3 branch of QUESTION_TREE.adoc
+   - Source: Q3 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: arc42 (Starke / Hruschka)
 
-4. docs/specs/adrs/*.adoc — one ADR per significant design decision
+4. docs/specs/adrs/[context-name]-adr-NNN-*.adoc — one ADR per
+   significant design decision. The context-name prefix keeps ADRs from
+   different bounded contexts from colliding in the shared adrs/ folder.
    - Nygard format: Title, Status, Context, Decision, Consequences.
    - Include a Pugh Matrix listing the alternatives considered with a
      3-point scale (-1, 0, +1) against the quality goals from Q4.
-   - Source: Q3.9 branch of QUESTION_TREE.adoc
+   - Source: Q3.9 branch of QUESTION_TREE-[context-name].adoc
    - Anchor: ADR according to Nygard
 
 Rules for traceability:
@@ -77,8 +80,9 @@ Rules for traceability:
   "Sessions expire after 24 hours (team answer)."
 - Deferred questions stay as explicit gaps: "Quality-goal priorities are
   deferred and must be resolved before the next release."
-- Do not introduce facts that do not appear in QUESTION_TREE.adoc or
-  OPEN_QUESTIONS.adoc. If a Section feels under-specified, leave it
+- Do not introduce facts that do not appear in
+  QUESTION_TREE-[context-name].adoc or OPEN_QUESTIONS-[context-name].adoc.
+  If a Section feels under-specified, leave it
   under-specified — that is signal, not a defect.
 ```
 

--- a/skill/socratic-code-theory-recovery/references/arc42.md
+++ b/skill/socratic-code-theory-recovery/references/arc42.md
@@ -7,7 +7,7 @@ arc42 is a 12-chapter template for documenting software architecture (Gernot Sta
 | Q-ID | Section | Sub-question(s) |
 |------|---------|-----------------|
 | Q3.1 | Introduction and Goals | What does the system do at the highest level? Which 3-5 quality goals drive design? Who are the most important stakeholders? |
-| Q3.2 | Architecture Constraints | Which technical, organizational, conventional constraints restrict design choices? |
+| Q3.2 | Architecture Constraints | Which technical (Q3.2.1), organizational/process (Q3.2.2), conventional (Q3.2.3) constraints restrict design choices? Fixed third level — look beyond code: CLAUDE.md/AGENTS.md, CONTRIBUTING, CI config, linter rules are valid evidence. |
 | Q3.3 | Context and Scope | What are the system's external interfaces — neighbours, channels, protocols? Business context vs technical context? |
 | Q3.4 | Solution Strategy | Which fundamental decisions and patterns shape the architecture? Technology choices, top-level decomposition, quality-goal approaches, organizational decisions? |
 | Q3.5 | Building Block View | How is the system decomposed into containers, components, classes? Static structure at multiple levels of zoom. |

--- a/skill/socratic-code-theory-recovery/references/output-schema.md
+++ b/skill/socratic-code-theory-recovery/references/output-schema.md
@@ -1,8 +1,8 @@
-# Output Schema — QUESTION_TREE.adoc and OPEN_QUESTIONS.adoc
+# Output Schema — QUESTION_TREE-<context-name>.adoc and OPEN_QUESTIONS-<context-name>.adoc
 
-Two AsciiDoc files. The schema is rigid enough to be machine-checkable but written in plain prose so a team member can read it.
+Two AsciiDoc files, each suffixed with the kebab-cased bounded-context name so sequential runs on different contexts never overwrite each other. The schema is rigid enough to be machine-checkable but written in plain prose so a team member can read it.
 
-## QUESTION_TREE.adoc
+## QUESTION_TREE-<context-name>.adoc
 
 Hierarchical tree, top-down. Each node has a Q-ID, the question, and (for leaves) either an `[ANSWERED]` or `[OPEN]` marker.
 
@@ -95,7 +95,7 @@ Ask role: <one or more of: Product Owner | Architect | Developer | Domain Expert
 - **Ask role** is the role-class of person who can answer, not a named individual. Multiple roles are fine — list them in order of best to ask.
 - The body of the leaf must explain *why* the code can't answer it. If the body says "the code doesn't say", widen it: "the code persists status=PENDING but never transitions it" is a real reason; "we don't know" is not.
 
-## OPEN_QUESTIONS.adoc
+## OPEN_QUESTIONS-<context-name>.adoc
 
 A flat, role-grouped projection of every `[OPEN]` leaf. This is the handoff document — the team sees only their section.
 
@@ -137,7 +137,7 @@ _(write here)_
 
 - One section per Ask role.
 - A leaf with multiple Ask roles is duplicated under each role's section — make it explicit to whichever role reads first.
-- The `*Your answer:*` block is mandatory. Team members write directly into the file. Phase 2 reads this file together with `QUESTION_TREE.adoc`.
+- The `*Your answer:*` block is mandatory. Team members write directly into the file. Phase 2 reads this file together with `QUESTION_TREE-<context-name>.adoc`.
 - A deferred question gets `(deferred — <reason>)` instead of an answer. Phase 2 treats deferred questions as explicit gaps, not as filled-in answers.
 
 ## Phase 2 traceability


### PR DESCRIPTION
## Summary

Fixes the two Socratic Code-Theory Recovery bugs found during the Mistral Vibe brownfield runs.

### #531 — Phase 1 output collision

Phase 1 wrote two fixed filenames, so the documented "one bounded context at a time" workflow silently destroyed earlier runs. Now:

- Phase 1 writes `QUESTION_TREE-[context-name].adoc` / `OPEN_QUESTIONS-[context-name].adoc` (kebab-cased context name, consistent with Phase 2's existing `prd-[context-name].adoc` scheme)
- Phase 2 reads the context-specific tree
- ADRs get a context prefix: `docs/specs/adrs/[context-name]-adr-NNN-*.adoc` — closes the secondary collision in the shared `adrs/` folder
- All filename references updated: SKILL.md (incl. workflow diagram), both prompts, `references/output-schema.md`, and the website doc page (EN + DE). Grep-verified: no un-parameterized `QUESTION_TREE.adoc`/`OPEN_QUESTIONS.adoc` reference remains.

### #532 — Q3.2 constraints under-decomposition

The code-density-driven decomposition walked past constraints that do not live in dense code (git workflow, naming conventions, mandated libraries, runtime choices) — Phase 2 then picked them up from the repo with no tree leaf to cite, producing exactly the untraceable claims the two-phase design exists to prevent. Now Q3.2 carries a **fixed third level**, mirroring arc42 Chapter 2's constraint kinds:

- Q3.2.1 technical constraints (language, runtime, mandated frameworks/libraries)
- Q3.2.2 organizational/process constraints (git workflow, branching, release, review rules)
- Q3.2.3 conventional constraints (naming, file layout, code style, commit conventions)

For this branch specifically, the prompt admits non-code evidence sources — `CLAUDE.md`/`AGENTS.md`, CONTRIBUTING, CI workflows, linter/formatter configs — cited file:line like any other evidence. `references/arc42.md` carries the same note.

### Versioning

Skill `0.2` → `0.3`, plugin `0.3.0` → `0.4.0` (same PR, per convention).

## Note on the contract

The *Socratic Code Theory Recovery* contract text (CLAUDE.md / contracts.json) states "the second level of the tree is FIXED" — the fixed Q3.2.x third level is an extension of that idea. If the contract should mirror it, that is a separate edit to contracts.json (and your CLAUDE.md); happy to follow up.

## Verification

- Grep: zero remaining fixed-name references outside parameterized forms
- `node scripts/render-docs.js`: website doc pages (EN + DE) render clean

Fixes #531, fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Workflow und Output-Dateien zu kontextspezifischen Namen geändert (`QUESTION_TREE-<context-name>.adoc`, `OPEN_QUESTIONS-<context-name>.adoc`) — verhindert Überschreiben zwischen Läufen; Phase‑1 stoppt bis Teamantwort/`(deferred)`-Marker.
  * Q3.2 (Architecture Constraints) auf fixe dritte Ebene erweitert: technische, organisatorische/prozessuale, konventionelle Constraints.
  * Explizite Zulassung von Nicht‑Code‑Evidenz (z. B. CLAUDE.md, AGENTS.md, CONTRIBUTING, CI-/Linter‑Configs).

* **Chores**
  * Skill-Version auf 0.3; Plugin‑Metadaten auf 0.4 aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->