### PR TITLE
fix: contract deep links on direct load, persistent highlight, permalink icons (#611)

### DIFF
--- a/scripts/render-contracts.js
+++ b/scripts/render-contracts.js
@@ -74,7 +74,7 @@ function renderAnchorChips(contract, lang) {
 function renderContract(contract) {
   return `
     <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-5 mb-4">
-      <h3 class="text-lg font-semibold mb-1"><a href="${BASE}/contract/${escapeHtml(contract.id)}" class="hover:underline">${escapeHtml(contract.title)}</a></h3>
+      <h3 class="text-lg font-semibold mb-1"><a href="${BASE}/contract/${escapeHtml(contract.id)}" class="hover:underline">${escapeHtml(contract.title)}</a> <a href="${BASE}/contract/${escapeHtml(contract.id)}" class="inline-flex items-center align-middle text-[var(--color-text-secondary)] hover:text-blue-600 transition-colors" aria-label="Link to this contract"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/></svg></a></h3>
       <p class="text-sm text-[var(--color-text-secondary)] mb-3">${escapeHtml(contract.description)}</p>
       <div class="rounded-md bg-[var(--color-bg-secondary)] p-3 mb-3 text-sm leading-relaxed">
         <ul class="list-disc list-inside space-y-1">

--- a/website/src/components/contracts-page.js
+++ b/website/src/components/contracts-page.js
@@ -214,6 +214,17 @@ export function renderContractCard(contract, isSelected) {
           <div class="flex-1 min-w-0">
             <div class="flex items-start justify-between gap-2 mb-1">
               <h3 class="text-lg font-semibold text-[var(--color-text)]"><a href="${import.meta.env.BASE_URL}contract/${esc(contract.id)}" class="hover:underline" title="${esc(i18n.t('contracts.permalink'))}">${esc(title)}</a></h3>
+              <div class="flex shrink-0 gap-1.5">
+              <a
+                href="${import.meta.env.BASE_URL}contract/${esc(contract.id)}"
+                class="contract-permalink inline-flex items-center justify-center rounded-md border border-[var(--color-border)] p-1.5 text-[var(--color-text-secondary)] hover:text-blue-600 hover:border-blue-300 dark:hover:text-blue-400 dark:hover:border-blue-700 transition-colors"
+                title="${esc(i18n.t('contracts.permalink'))}"
+                aria-label="${esc(i18n.t('contracts.permalink'))}"
+              >
+                <svg class="w-4 h-4 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/>
+                </svg>
+              </a>
               <button
                 type="button"
                 class="contract-copy-btn shrink-0 inline-flex items-center justify-center rounded-md border border-[var(--color-border)] p-1.5 text-[var(--color-text-secondary)] hover:text-blue-600 hover:border-blue-300 dark:hover:text-blue-400 dark:hover:border-blue-700 transition-colors"
@@ -225,6 +236,7 @@ export function renderContractCard(contract, isSelected) {
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
                 </svg>
               </button>
+              </div>
             </div>
             <p class="text-sm text-[var(--color-text-secondary)] mb-3">${esc(description)}</p>
             <div class="rounded-md bg-[var(--color-bg-secondary)] p-3 mb-3 text-sm leading-relaxed max-h-64 overflow-y-auto">

--- a/website/src/components/contracts-page.test.js
+++ b/website/src/components/contracts-page.test.js
@@ -18,6 +18,13 @@ describe('renderContractCard', () => {
     anchors: ['cockburn-use-cases'],
   }
 
+  it('renders a permalink icon linking to the contract detail page', () => {
+    const html = renderContractCard(contract, false)
+    expect(html).toContain('contract-permalink')
+    expect(html).toMatch(/class="contract-permalink[^"]*"[^>]*/)
+    expect(html.match(/contract\/specification/g).length).toBeGreaterThanOrEqual(2)
+  })
+
   it('links the card title to the contract detail page', () => {
     const html = renderContractCard(contract, false)
     expect(html).toContain(`href="${import.meta.env.BASE_URL}contract/specification"`)

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -10,6 +10,18 @@ let currentRoute = null
 let routeBeforeModal = null
 let scrollBeforeModal = 0
 
+// The card highlighted by a /contract/:id route — cleared on the next route
+// change so the marker tracks the URL instead of fading on a timer (#611).
+const CONTRACT_HIGHLIGHT_CLASSES = ['ring-2', 'ring-blue-400']
+let highlightedContractCard = null
+
+function clearContractHighlight() {
+  if (highlightedContractCard) {
+    highlightedContractCard.classList.remove(...CONTRACT_HIGHLIGHT_CLASSES)
+    highlightedContractCard = null
+  }
+}
+
 // Base path for GitHub Pages subdirectory deployment
 const BASE_PATH = import.meta.env.BASE_URL.replace(/\/$/, '')
 
@@ -254,6 +266,7 @@ function handleRoute() {
     const safeContractId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(contractId) ? contractId : null
     if (!safeContractId) return
 
+    clearContractHighlight()
     closeOpenAnchorModal()
     const contractsHandler = routes.get('/contracts')
     if (typeof contractsHandler === 'function') {
@@ -262,24 +275,32 @@ function handleRoute() {
     }
     trackPageview()
 
-    // The contracts page renders asynchronously; locate the card on the
-    // next tick, title the page after its heading (real title, not a
-    // de-kebab-cased slug), and bring it into view.
-    setTimeout(() => {
+    // The contracts page renders asynchronously — on a direct page load it
+    // still has to fetch contracts.json first, so the card appears later
+    // than the next tick. Poll briefly (up to ~3s) instead of checking
+    // once; title the page after the card heading (real title, not a
+    // de-kebab-cased slug), bring the card into view, and highlight it
+    // persistently until the next route change.
+    const locateContractCard = (attempt = 0) => {
       const card = document.querySelector(`[data-contract-id="${safeContractId}"]`)
-      const heading = card ? card.querySelector('h3') : null
+      if (!card) {
+        if (attempt < 30) setTimeout(() => locateContractCard(attempt + 1), 100)
+        return
+      }
+      const heading = card.querySelector('h3')
       const readableName =
         (heading && heading.textContent.trim()) ||
         safeContractId.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
       document.title = `${readableName} — Semantic Anchors`
-      if (card) {
-        card.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        card.classList.add('ring-2', 'ring-blue-400')
-        setTimeout(() => card.classList.remove('ring-2', 'ring-blue-400'), 2500)
-      }
-    }, 0)
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      card.classList.add(...CONTRACT_HIGHLIGHT_CLASSES)
+      highlightedContractCard = card
+    }
+    locateContractCard()
     return
   }
+
+  clearContractHighlight()
 
   // Leaving an anchor route: close any open anchor modal so Back/forward and
   // in-app navigation don't leave it stranded as an overlay over the page.

--- a/website/src/utils/router.test.js
+++ b/website/src/utils/router.test.js
@@ -153,6 +153,41 @@ describe('router contract route (/contract/:id)', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
+  it('finds the card even when the contracts page renders late', async () => {
+    // Direct page loads fetch contracts.json first — the card appears well
+    // after the route handler returns. The router polls instead of checking
+    // once (#611 follow-up).
+    const handler = vi.fn(() => {
+      setTimeout(() => {
+        document.body.innerHTML = `
+        <div data-contract-id="specification"><h3>Specification</h3></div>`
+      }, 150)
+    })
+    addRoute('/contracts', handler)
+    history.replaceState(null, '', '/contract/specification')
+
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    await new Promise((r) => setTimeout(r, 400))
+
+    expect(document.title).toBe('Specification — Semantic Anchors')
+  })
+
+  it('highlights the card persistently and clears it on the next route', async () => {
+    addContractsRoute()
+    addRoute('/elsewhere', vi.fn())
+    history.replaceState(null, '', '/contract/specification')
+
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    await new Promise((r) => setTimeout(r, 0))
+
+    const card = document.querySelector('[data-contract-id="specification"]')
+    expect(card.classList.contains('ring-2')).toBe(true)
+
+    history.replaceState(null, '', '/elsewhere')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    expect(card.classList.contains('ring-2')).toBe(false)
+  })
+
   it('switches to German for /de/contract/:id', async () => {
     const handler = addContractsRoute()
     history.replaceState(null, '', '/de/contract/specification')


### PR DESCRIPTION
## Summary

Addresses the three findings from testing the deployed contract links (#612/#613). Note: this commit was originally pushed to the #613 branch *after* that PR had already been merged — the changes never landed; this PR carries them properly (cherry-picked onto current main, full test suite re-run).

### 1. Direct URL loads did nothing (the bug)

`/contract/<id>` worked when navigating inside the SPA but not on a direct page load: the contracts page fetches `contracts.json` before rendering, so the card appears well after the route handler returns — the single next-tick check missed it. The router now polls for the card (100 ms steps, up to ~3 s). SPA navigation was unaffected because the data was already in memory, which is exactly why the bug only showed on direct URLs.

### 2. Persistent highlight

The 2.5 s highlight flash is now a persistent ring that stays on the card until the next route change (cleared centrally, including contract→contract switches).

### 3. Explicit permalink icons

Every card carries a chain icon linking to its detail page — SPA cards next to the copy button, static no-JS cards next to the title; title links remain. Localized tooltip/aria-label (EN + DE).

## Verification

- Playwright against the built preview on the exact failing case: direct load of `/contract/explaining-teaching/` titles the tab, scrolls to the card, highlights it persistently; 19/19 cards carry the permalink icon
- 111/111 unit tests pass on this branch (3 new: late-render polling, persistent highlight + clearing, icon presence)
- Lint + Prettier clean

Refs #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)