### PR TITLE
fix: hide hero during search, make header search work on every route (#615)

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,12 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-12
 
+*Search UX (#615):*
+
+* *Search results were invisible:* typing in the search box filtered the catalog grid, but the hero section above it pushed the results below the fold. An active search now hides the hero (it returns the moment the query is cleared), so results appear directly under the header.
+* *Search works from every page:* the header search box used to be dead outside the home page — no grid to filter, no results page. Typing on any route now jumps to the home page and applies the query there; the typed text survives the switch.
+* The anchor counter ("N / M anchors") is hidden on routes where it has no grid to count — it previously sat at a meaningless "0 / 0" everywhere outside the catalog.
+
 *Direct links to contracts (#611):*
 
 * Every semantic contract now has its own pre-rendered page at `/contract/<id>`, with a German variant at `/de/contract/<id>` — own title, description, canonical URL, social-share metadata, and hreflang pairs, exactly like the anchor pages from #597. Sharing a single contract (e.g. _Specification_) now produces the right preview instead of the generic contracts-page card.

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -441,6 +441,12 @@ export function applyCardFilters(roleId, searchQuery) {
 
   const lowerQuery = searchQuery ? searchQuery.toLowerCase().trim() : ''
 
+  // An active search hides the hero so the results sit directly under the
+  // header instead of below the fold; clearing the query restores it. The
+  // role filter alone deliberately leaves the hero in place (#615).
+  const hero = document.getElementById('hero')
+  if (hero) hero.style.display = lowerQuery ? 'none' : ''
+
   // Use full-text search if index is ready and query exists
   let matchingAnchorIds = null
   if (lowerQuery && isIndexReady()) {

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -139,3 +139,38 @@ describe('category quick-nav', () => {
     expect(html).toContain('data-i18n-title="categories.testing-quality"')
   })
 })
+
+describe('hero visibility during search (#615)', () => {
+  function setupDom() {
+    document.body.innerHTML = `
+      <section id="hero">Hero</section>
+      <div class="category-section">
+        <div class="anchor-card" data-roles="" data-tags="mece" data-anchor="mece" style="display: block">
+          <span class="anchor-card-title">MECE</span>
+        </div>
+      </div>
+      <span id="visible-count">0</span><span id="total-count">0</span>`
+  }
+
+  it('hides the hero while a search query is active', async () => {
+    setupDom()
+    const { applyCardFilters } = await import('./card-grid.js')
+    applyCardFilters('', 'mece')
+    expect(document.getElementById('hero').style.display).toBe('none')
+  })
+
+  it('restores the hero when the query is cleared', async () => {
+    setupDom()
+    const { applyCardFilters } = await import('./card-grid.js')
+    applyCardFilters('', 'mece')
+    applyCardFilters('', '')
+    expect(document.getElementById('hero').style.display).toBe('')
+  })
+
+  it('keeps the hero visible when only the role filter is active', async () => {
+    setupDom()
+    const { applyCardFilters } = await import('./card-grid.js')
+    applyCardFilters('software-architect', '')
+    expect(document.getElementById('hero').style.display).toBe('')
+  })
+})

--- a/website/src/components/main-content.js
+++ b/website/src/components/main-content.js
@@ -13,7 +13,7 @@ export function renderMain() {
   return `
     <main class="flex-1">
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <section class="mb-10">
+        <section id="hero" class="mb-10">
           <h1 class="text-3xl sm:text-4xl font-bold text-[var(--color-text)] mb-3 leading-tight" data-i18n="hero.title">
             ${i18n.t('hero.title')}
           </h1>

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -27,7 +27,7 @@ import {
 } from './components/onboarding-modal.js'
 import { renderContractsPage, initContractsPage } from './components/contracts-page.js'
 
-const APP_VERSION = '0.7.0'
+const APP_VERSION = '0.8.0'
 
 window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   const url = `${window.location.origin}${import.meta.env.BASE_URL}anchor/${anchorId}`
@@ -181,7 +181,16 @@ function initApp() {
   updateActiveNavLink()
 
   createOnboardingModal()
+
+  // The anchor counter only means something next to the home grid — hide it
+  // on every other route (#615).
+  const syncAnchorCountVisibility = (path) => {
+    document.getElementById('anchor-count')?.classList.toggle('hidden', path !== '/')
+  }
+  document.addEventListener('route:changed', (e) => syncAnchorCountVisibility(e.detail.path))
+
   initRouter()
+  syncAnchorCountVisibility(getCurrentRouteSync())
 
   if (shouldShowOnboarding()) {
     showOnboarding()
@@ -409,6 +418,17 @@ function initCardGridVisualization() {
 
   bindRoleFilter()
   bindSearchInput()
+
+  // A search started on another route arrives here with the query still in
+  // the header input — apply it as soon as the grid exists (#615).
+  const pendingQuery = document.getElementById('header-search-input')?.value || ''
+  if (pendingQuery.trim()) {
+    triggerSearchIndexBuild()
+    const mainSearch = document.getElementById('search-input')
+    if (mainSearch) mainSearch.value = pendingQuery
+    const roleId = document.getElementById('header-role-filter')?.value || ''
+    applyCardFilters(roleId, pendingQuery)
+  }
 }
 
 function bindRoleFilter() {
@@ -505,13 +525,22 @@ function bindHeaderSearchInput() {
 
   searchInput.oninput = (e) => {
     const query = e.target.value
-    // Sync the main content search input if it exists
-    const mainSearch = document.getElementById('search-input')
-    if (mainSearch) mainSearch.value = query
 
     if (query.trim()) {
       triggerSearchIndexBuild()
     }
+
+    // Away from the home grid there is nothing to filter — jump home and let
+    // the grid initialization pick the typed text up from this input, which
+    // survives the route switch because the header is not re-rendered (#615).
+    if (getCurrentRouteSync() !== '/') {
+      navigate('/')
+      return
+    }
+
+    // Sync the main content search input if it exists
+    const mainSearch = document.getElementById('search-input')
+    if (mainSearch) mainSearch.value = query
 
     const roleId = document.getElementById('header-role-filter')?.value || ''
     applyCardFilters(roleId, query)

--- a/website/src/utils/router.js
+++ b/website/src/utils/router.js
@@ -15,6 +15,13 @@ let scrollBeforeModal = 0
 const CONTRACT_HIGHLIGHT_CLASSES = ['ring-2', 'ring-blue-400']
 let highlightedContractCard = null
 
+// Routing is decided here, but route-dependent chrome (e.g. the header
+// anchor counter, visible only on the home grid) lives elsewhere — announce
+// every resolved route as a DOM event instead of importing UI modules (#615).
+function announceRoute(path) {
+  document.dispatchEvent(new CustomEvent('route:changed', { detail: { path } }))
+}
+
 function clearContractHighlight() {
   if (highlightedContractCard) {
     highlightedContractCard.classList.remove(...CONTRACT_HIGHLIGHT_CLASSES)
@@ -297,6 +304,7 @@ function handleRoute() {
       highlightedContractCard = card
     }
     locateContractCard()
+    announceRoute(path)
     return
   }
 
@@ -313,6 +321,7 @@ function handleRoute() {
     document.title = ROUTE_TITLES[path] || 'Semantic Anchors'
     handler()
     trackPageview()
+    announceRoute(path)
   } else {
     // Default to home if route not found
     const homeHandler = routes.get('/')
@@ -320,6 +329,7 @@ function handleRoute() {
       currentRoute = '/'
       document.title = ROUTE_TITLES['/']
       homeHandler()
+      announceRoute('/')
     }
   }
 }

--- a/website/src/utils/router.test.js
+++ b/website/src/utils/router.test.js
@@ -91,6 +91,28 @@ describe('router language prefix (/de)', () => {
   })
 })
 
+describe('router route-change event (#615)', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/')
+    window.location.hash = ''
+    localStorage.clear()
+    i18n.init()
+  })
+
+  it('dispatches route:changed with the resolved path', () => {
+    const listener = vi.fn()
+    document.addEventListener('route:changed', listener)
+    addRoute('/event-test', vi.fn())
+    history.replaceState(null, '', '/event-test')
+
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    expect(listener).toHaveBeenCalled()
+    expect(listener.mock.calls.at(-1)[0].detail.path).toBe('/event-test')
+    document.removeEventListener('route:changed', listener)
+  })
+})
+
 describe('router contract route (/contract/:id)', () => {
   beforeEach(() => {
     history.replaceState(null, '', '/')

--- a/website/tests/e2e/website.spec.js
+++ b/website/tests/e2e/website.spec.js
@@ -95,6 +95,17 @@ test.describe('Homepage - Card Grid', () => {
     expect(allCards).toBeGreaterThan(visibleCards)
   })
 
+  test('hides the hero while searching and restores it on clear (#615)', async ({ page }) => {
+    await page.waitForSelector('.anchor-card', { timeout: 10000 })
+    await expect(page.locator('#hero')).toBeVisible()
+
+    await page.fill('#header-search-input', 'TDD')
+    await expect(page.locator('#hero')).toBeHidden()
+
+    await page.fill('#header-search-input', '')
+    await expect(page.locator('#hero')).toBeVisible()
+  })
+
   test('should open anchor modal on card click', async ({ page }) => {
     await page.waitForSelector('.anchor-card', { timeout: 10000 })
 
@@ -165,6 +176,29 @@ test.describe('Homepage - Card Grid', () => {
     const proposeLink = page.locator('a[href*="issues/new"]')
     await expect(proposeLink).toBeVisible()
     await expect(proposeLink).toContainText('Propose New Anchor')
+  })
+})
+
+test.describe('Search away from the home grid (#615)', () => {
+  test('hides the anchor counter on non-home routes', async ({ page }) => {
+    await page.goto('/Semantic-Anchors/about/')
+    await expect(page.locator('#anchor-count')).toBeHidden()
+  })
+
+  test('typing in the header search jumps home and applies the query', async ({ page }) => {
+    await page.goto('/Semantic-Anchors/about/')
+    await page.waitForSelector('#header-search-input')
+
+    await page.fill('#header-search-input', 'TDD')
+
+    // The grid arrives filtered — wait for a card that survived the query,
+    // not for the first card in DOM order (which the filter may hide).
+    await page.waitForSelector('.anchor-card:visible', { timeout: 10000 })
+    await expect(page).toHaveURL(/\/Semantic-Anchors\/$/)
+    await expect(page.locator('#hero')).toBeHidden()
+    const visibleCards = await page.locator('.anchor-card:visible').count()
+    expect(visibleCards).toBeGreaterThan(0)
+    await expect(page.locator('#anchor-count')).toBeVisible()
   })
 })
 


### PR DESCRIPTION
## Summary

Implements the agreed UX direction from #615.

### 1. Search results were invisible (home)

An active search query now hides the hero section, so results appear directly under the header; clearing the query restores it. Toggled in `applyCardFilters()` — the single funnel both search inputs (desktop header + mobile) already flow through. The role filter alone deliberately leaves the hero in place.

### 2. Search was dead on non-home routes

Typing in the header search anywhere else now navigates to the home page and applies the query there — the home page acts as the search-results page. No polling needed: the header (and the typed text in it) survives the route switch because only `#page-content` is re-rendered; grid initialization picks the pending query up from the input.

### 3. "0/0 anchors" counter on doc pages

The router now announces resolved routes via a `route:changed` CustomEvent (kept free of UI knowledge); `main.js` hides the `#anchor-count` element on every route except home.

## Verification

- **TDD:** 4 new unit tests (hero hides on query / restores on clear / stays for role-only filter; router dispatches `route:changed`) — 115/115 pass
- **E2E:** 3 new scenarios (hero hide/restore while typing; counter hidden on `/about/`; typing on `/about/` lands on `/` with filtered grid and visible counter) — 38/38 pass locally
- **Playwright against the built preview:** hero `block → none → block` on query/clear, 3 visible cards + counter "3" for "tdd"; static no-JS home unchanged (hero markup present via curl)
- Lint + Prettier clean; app version 0.7.0 → 0.8.0

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Neue Funktionen**
  * Suche funktioniert nun von jeder Seite aus – Suchanfragen navigieren automatisch zur Startseite und filtern Ergebnisse dort
  * Hero-Bereich wird bei aktiver Suche ausgeblendet, um Suchergebnisse besser sichtbar zu machen
  * Anchor-Counter wird auf Seiten ohne Ergebnisse ausgeblendet

* **Tests**
  * Tests für Such-UX-Verbesserungen und Router-Ereignisse hinzugefügt

* **Dokumentation**
  * Changelog aktualisiert für Version 0.8.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->