### PR TITLE
feat: animate hero collapse, hide search controls on non-home routes (#615 follow-up)

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -6,9 +6,8 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 *Search UX (#615):*
 
-* *Search results were invisible:* typing in the search box filtered the catalog grid, but the hero section above it pushed the results below the fold. An active search now hides the hero (it returns the moment the query is cleared), so results appear directly under the header.
-* *Search works from every page:* the header search box used to be dead outside the home page — no grid to filter, no results page. Typing on any route now jumps to the home page and applies the query there; the typed text survives the switch.
-* The anchor counter ("N / M anchors") is hidden on routes where it has no grid to count — it previously sat at a meaningless "0 / 0" everywhere outside the catalog.
+* *Search results were invisible:* typing in the search box filtered the catalog grid, but the hero section above it pushed the results below the fold. An active search now collapses the hero with a smooth 300ms animation (it slides back the moment the query is cleared), so results appear directly under the header. Honors `prefers-reduced-motion`.
+* *Search controls only where they work:* the header search box, role filter, and anchor counter used to appear on every page while being dead outside the home catalog (no grid to filter, the counter stuck at "0 / 0"). The whole control row is now shown only on the home route.
 
 *Direct links to contracts (#611):*
 

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -445,7 +445,7 @@ export function applyCardFilters(roleId, searchQuery) {
   // header instead of below the fold; clearing the query restores it. The
   // role filter alone deliberately leaves the hero in place (#615).
   const hero = document.getElementById('hero')
-  if (hero) hero.style.display = lowerQuery ? 'none' : ''
+  if (hero) hero.classList.toggle('hero-collapsed', !!lowerQuery)
 
   // Use full-text search if index is ready and query exists
   let matchingAnchorIds = null

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -152,11 +152,11 @@ describe('hero visibility during search (#615)', () => {
       <span id="visible-count">0</span><span id="total-count">0</span>`
   }
 
-  it('hides the hero while a search query is active', async () => {
+  it('collapses the hero while a search query is active', async () => {
     setupDom()
     const { applyCardFilters } = await import('./card-grid.js')
     applyCardFilters('', 'mece')
-    expect(document.getElementById('hero').style.display).toBe('none')
+    expect(document.getElementById('hero').classList.contains('hero-collapsed')).toBe(true)
   })
 
   it('restores the hero when the query is cleared', async () => {
@@ -164,13 +164,13 @@ describe('hero visibility during search (#615)', () => {
     const { applyCardFilters } = await import('./card-grid.js')
     applyCardFilters('', 'mece')
     applyCardFilters('', '')
-    expect(document.getElementById('hero').style.display).toBe('')
+    expect(document.getElementById('hero').classList.contains('hero-collapsed')).toBe(false)
   })
 
   it('keeps the hero visible when only the role filter is active', async () => {
     setupDom()
     const { applyCardFilters } = await import('./card-grid.js')
     applyCardFilters('software-architect', '')
-    expect(document.getElementById('hero').style.display).toBe('')
+    expect(document.getElementById('hero').classList.contains('hero-collapsed')).toBe(false)
   })
 })

--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -74,8 +74,9 @@ export function renderHeader() {
                 </button>
               </div>
             </div>
-            <!-- Row 2: Search + Role filter + Anchor count -->
-            <div class="flex items-center gap-3">
+            <!-- Row 2: Search + Role filter + Anchor count — catalog-only
+                 controls, hidden on every other route (#615) -->
+            <div id="header-catalog-controls" class="flex items-center gap-3">
               <input
                 id="header-search-input"
                 type="search"

--- a/website/src/components/main-content.js
+++ b/website/src/components/main-content.js
@@ -14,6 +14,7 @@ export function renderMain() {
     <main class="flex-1">
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <section id="hero" class="mb-10">
+        <div>
           <h1 class="text-3xl sm:text-4xl font-bold text-[var(--color-text)] mb-3 leading-tight" data-i18n="hero.title">
             ${i18n.t('hero.title')}
           </h1>
@@ -114,6 +115,7 @@ export function renderMain() {
               data-i18n="hero.skipToCatalog"
             >${i18n.t('hero.skipToCatalog')}</a>
           </div>
+        </div>
         </section>
 
         <section id="filters" class="mb-6 flex flex-wrap gap-3 items-center">

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -27,7 +27,7 @@ import {
 } from './components/onboarding-modal.js'
 import { renderContractsPage, initContractsPage } from './components/contracts-page.js'
 
-const APP_VERSION = '0.8.0'
+const APP_VERSION = '0.8.1'
 
 window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   const url = `${window.location.origin}${import.meta.env.BASE_URL}anchor/${anchorId}`
@@ -182,15 +182,15 @@ function initApp() {
 
   createOnboardingModal()
 
-  // The anchor counter only means something next to the home grid — hide it
-  // on every other route (#615).
-  const syncAnchorCountVisibility = (path) => {
-    document.getElementById('anchor-count')?.classList.toggle('hidden', path !== '/')
+  // Search, role filter and counter only mean something next to the home
+  // grid — hide the whole control row on every other route (#615).
+  const syncCatalogControlsVisibility = (path) => {
+    document.getElementById('header-catalog-controls')?.classList.toggle('hidden', path !== '/')
   }
-  document.addEventListener('route:changed', (e) => syncAnchorCountVisibility(e.detail.path))
+  document.addEventListener('route:changed', (e) => syncCatalogControlsVisibility(e.detail.path))
 
   initRouter()
-  syncAnchorCountVisibility(getCurrentRouteSync())
+  syncCatalogControlsVisibility(getCurrentRouteSync())
 
   if (shouldShowOnboarding()) {
     showOnboarding()
@@ -528,14 +528,6 @@ function bindHeaderSearchInput() {
 
     if (query.trim()) {
       triggerSearchIndexBuild()
-    }
-
-    // Away from the home grid there is nothing to filter — jump home and let
-    // the grid initialization pick the typed text up from this input, which
-    // survives the route switch because the header is not re-rendered (#615).
-    if (getCurrentRouteSync() !== '/') {
-      navigate('/')
-      return
     }
 
     // Sync the main content search input if it exists

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -83,6 +83,43 @@ body {
   font-family: Inter, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif !important;
 }
 
+/* Hero collapse during an active search (#615): grid-template-rows 1fr->0fr
+   transitions smoothly where display:none cannot. visibility flips after the
+   transition so the collapsed hero's links leave the tab order. */
+#hero {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition:
+    grid-template-rows 300ms ease,
+    opacity 300ms ease,
+    margin-bottom 300ms ease,
+    visibility 0s 0s;
+}
+
+#hero > div {
+  min-height: 0;
+  overflow: hidden;
+}
+
+#hero.hero-collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  margin-bottom: 0;
+  visibility: hidden;
+  transition:
+    grid-template-rows 300ms ease,
+    opacity 300ms ease,
+    margin-bottom 300ms ease,
+    visibility 0s 300ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #hero,
+  #hero.hero-collapsed {
+    transition: none;
+  }
+}
+
 .category-section {
   @apply mb-12;
   /* Clear the sticky category quick-nav when jumped to via #category-<id> */

--- a/website/tests/e2e/website.spec.js
+++ b/website/tests/e2e/website.spec.js
@@ -180,24 +180,17 @@ test.describe('Homepage - Card Grid', () => {
 })
 
 test.describe('Search away from the home grid (#615)', () => {
-  test('hides the anchor counter on non-home routes', async ({ page }) => {
+  test('hides the search controls on non-home routes', async ({ page }) => {
     await page.goto('/Semantic-Anchors/about/')
+    await page.waitForSelector('#doc-content h1', { timeout: 10000 })
+    await expect(page.locator('#header-search-input')).toBeHidden()
     await expect(page.locator('#anchor-count')).toBeHidden()
   })
 
-  test('typing in the header search jumps home and applies the query', async ({ page }) => {
-    await page.goto('/Semantic-Anchors/about/')
-    await page.waitForSelector('#header-search-input')
-
-    await page.fill('#header-search-input', 'TDD')
-
-    // The grid arrives filtered — wait for a card that survived the query,
-    // not for the first card in DOM order (which the filter may hide).
-    await page.waitForSelector('.anchor-card:visible', { timeout: 10000 })
-    await expect(page).toHaveURL(/\/Semantic-Anchors\/$/)
-    await expect(page.locator('#hero')).toBeHidden()
-    const visibleCards = await page.locator('.anchor-card:visible').count()
-    expect(visibleCards).toBeGreaterThan(0)
+  test('shows the search controls on the home route', async ({ page }) => {
+    await page.goto('/Semantic-Anchors/')
+    await page.waitForSelector('.anchor-card', { timeout: 10000 })
+    await expect(page.locator('#header-search-input')).toBeVisible()
     await expect(page.locator('#anchor-count')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Two refinements on the merged #616, from user testing:

### 1. Animated hero collapse

The hero vanished abruptly (`display: none` cannot transition). It now collapses via a `grid-template-rows: 1fr → 0fr` transition (300 ms, together with opacity and margin) and slides back on clearing the query. `visibility` flips after the transition so the collapsed hero's links leave the tab order; `prefers-reduced-motion` disables the animation. Measured mid-transition via Playwright: 547 px → 141 px → 0 px and cleanly back to 547 px.

### 2. Direction change: hide search controls off-home

Instead of jumping to the home page, the search controls now disappear entirely on non-home routes — the search input, role filter, and anchor counter form one `#header-catalog-controls` row toggled by the existing `route:changed` listener. The jump-to-home code from #616 is removed; a query left in the input still re-applies when returning to the catalog.

## Verification

- 115/115 unit tests (hero tests updated to the class-based collapse), 38/38 E2E (controls hidden on `/about/`, visible on `/`)
- Playwright on the built preview: smooth collapse/restore measured, hero layout unchanged, static no-JS home unaffected
- App version 0.8.0 → 0.8.1

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sanfte Hero-Kollaps-Animation (300ms) beim Aktivieren der Suche.

* **Bug Fixes**
  * Suchsteuerelemente nur auf der Startseite sichtbar; auf anderen Routen ausgeblendet.
  * Unterstützung für `prefers-reduced-motion` implementiert.

* **Chores**
  * App-Version auf 0.8.1 aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->