### PR TITLE
Add German translations for INVEST and test-double anchors

### DIFF
--- a/docs/anchors/invest.de.adoc
+++ b/docs/anchors/invest.de.adoc
@@ -1,0 +1,48 @@
+= INVEST
+:categories: requirements-engineering
+:roles: product-owner, business-analyst, team-lead, software-developer
+:related: user-story-mapping, moscow
+:proponents: Bill Wake
+:tags: user-stories, agile, scrum, acceptance-criteria, story-quality
+:tier: 3
+
+[%collapsible]
+====
+Vollständiger Name:: INVEST-Kriterien für User Stories
+
+Auch bekannt als:: INVEST-Checkliste, INVEST-Merkhilfe
+
+[discrete]
+== *Kernkonzepte*:
+
+INVEST = **I**ndependent / **N**egotiable / **V**aluable / **E**stimable / **S**mall / **T**estable
+
+Independent (Unabhängig):: Stories sollten in sich abgeschlossen und in beliebiger Reihenfolge lieferbar sein; Abhängigkeiten zwischen Stories vermeiden, die eine feste Implementierungsreihenfolge erzwingen
+
+Negotiable (Verhandelbar):: Stories sind keine Verträge; die Details bleiben zwischen Team und Stakeholdern verhandelbar, bis sie in einen Sprint eingehen
+
+Valuable (Wertvoll):: Jede Story muss dem Nutzer oder dem Business einen klaren Wert liefern; Stories, die nur technischen Zwecken dienen, sollten in nutzersichtbaren Wert eingebettet werden
+
+Estimable (Schätzbar):: Das Team muss die Größe der Story schätzen können; ist das nicht möglich, ist die Story zu groß, zu vage oder erfordert einen Spike
+
+Small (Klein):: Stories sollten klein genug sein, um innerhalb eines Sprints abgeschlossen zu werden; große Epics müssen vor dem Sprint heruntergebrochen werden
+
+Testable (Testbar):: Stories brauchen konkrete Akzeptanzkriterien, damit Entwickler und Tester die Fertigstellung verifizieren können; nicht testbare Stories verstecken Mehrdeutigkeit
+
+
+Schlüsselvertreter:: Bill Wake ("INVEST in Good Stories, and SMART Tasks", 2003)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Review von User Stories vor dem Sprint Planning zur Beurteilung der Bereitschaft
+* Aufteilen von Epics in kleinere, lieferbare Stories
+* Coaching von Teams, was eine gut geformte User Story ausmacht
+* Während des Backlog Refinements, um Stories zu identifizieren, die mehr Arbeit benötigen
+* Als Definition-of-Ready-Checkliste für die Aufnahme einer Story in einen Sprint
+
+*Verwandte Anker*:
+
+* <<user-story-mapping,User Story Mapping>>
+* <<moscow,MoSCoW>>
+====

--- a/docs/anchors/test-double-dummy.de.adoc
+++ b/docs/anchors/test-double-dummy.de.adoc
@@ -1,0 +1,35 @@
+= Test Double: Dummy (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer
+:proponents: Gerard Meszaros
+:related: test-double-meszaros, test-double-stub
+:tags: test-double, dummy, testing, isolation
+:tier: 3
+:parent-anchor: test-double-meszaros
+
+[%collapsible]
+====
+[discrete]
+== *Kernkonzepte*:
+
+Zweck:: Ein Objekt, das übergeben wird, um einen erforderlichen Parameter zu füllen, im Test aber nie tatsächlich verwendet wird. Die einfachste Form eines Test Doubles.
+
+Verhalten:: Hat kein Verhalten. Aufrufe an einen Dummy sollten nicht vorkommen — falls doch, stimmt etwas mit dem Test-Setup nicht.
+
+Typische Verwendung:: Erfüllen von Konstruktor- oder Methodensignaturen, bei denen der Parameter für das Testszenario irrelevant ist.
+
+Schlüsselvertreter:: Gerard Meszaros ("xUnit Test Patterns", 2007)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einem LLM sagen: "Erzeuge ein Dummy-Test-Double für diesen Parameter — es sollte nie aufgerufen werden"
+* Wenn eine Methode Parameter erfordert, die für das getestete Verhalten irrelevant sind
+* Befüllen von Dependency-Injection-Containern mit ungenutzten Abhängigkeiten
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<test-double-meszaros,Test Double (Meszaros)>> — übergreifende Taxonomie
+* <<test-double-stub,Stub>> — wenn vorgefertigte Antworten benötigt werden (ein Dummy liefert keine)
+====

--- a/docs/anchors/test-double-fake.de.adoc
+++ b/docs/anchors/test-double-fake.de.adoc
@@ -1,0 +1,38 @@
+= Test Double: Fake (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer
+:proponents: Gerard Meszaros
+:related: test-double-meszaros, test-double-stub
+:tags: test-double, fake, testing, isolation, in-memory
+:tier: 3
+:parent-anchor: test-double-meszaros
+
+[%collapsible]
+====
+[discrete]
+== *Kernkonzepte*:
+
+Zweck:: Eine funktionierende, aber vereinfachte Implementierung, die für die Produktion ungeeignet ist. Hat echtes Verhalten, nimmt aber Abkürzungen.
+
+Verhalten:: Verarbeitet Eingaben tatsächlich und erzeugt Ausgaben — anders als Stubs, die feste Daten zurückgeben. Die Vereinfachung macht ihn schnell und vorhersehbar für Tests.
+
+Typische Beispiele:: In-Memory-Datenbank statt echter Datenbank, In-Memory-Dateisystem, lokaler E-Mail-Sender, der in eine Liste schreibt statt zu senden, vereinfachte Authentifizierung, die immer gelingt.
+
+Abgrenzung zum Stub:: Ein Stub gibt vorgefertigte Daten zurück. Ein Fake hat *echte Logik*, nur vereinfacht.
+
+Schlüsselvertreter:: Gerard Meszaros ("xUnit Test Patterns", 2007)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einem LLM sagen: "Erzeuge eine Fake-Implementierung dieses Repositories mit einem In-Memory-Store"
+* Integrationsähnliche Tests ohne externe Infrastruktur
+* Wenn Stubs zu simpel sind und die echte Implementierung zu langsam/komplex ist
+* Lokale Entwicklungsumgebungen, die realistische, aber schnelle Abhängigkeiten brauchen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<test-double-meszaros,Test Double (Meszaros)>> — übergreifende Taxonomie
+* <<test-double-stub,Stub>> — einfachere Alternative mit festen Antworten
+====

--- a/docs/anchors/test-double-mock.de.adoc
+++ b/docs/anchors/test-double-mock.de.adoc
@@ -1,0 +1,39 @@
+= Test Double: Mock (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer
+:proponents: Gerard Meszaros
+:related: test-double-meszaros, test-double-spy, test-double-stub, tdd-london-school
+:tags: test-double, mock, testing, isolation, interaction-verification
+:tier: 3
+:parent-anchor: test-double-meszaros
+
+[%collapsible]
+====
+[discrete]
+== *Kernkonzepte*:
+
+Zweck:: Vorprogrammiert mit Erwartungen, welche Aufrufe erfolgen sollen. Verifiziert, dass bestimmte Interaktionen stattgefunden haben — der Test schlägt fehl, wenn die erwarteten Interaktionen ausbleiben.
+
+Verhalten:: Hat eingebaute Assertions. Ruft das System Under Test die falsche Methode, mit falschen Argumenten oder in der falschen Reihenfolge auf, lässt der Mock den Test sofort fehlschlagen.
+
+Abgrenzung zum Stub:: Ein Stub liefert Daten passiv. Ein Mock *verifiziert Verhalten* aktiv.
+
+Abgrenzung zum Spy:: Ein Spy zeichnet Aufrufe für *nachträgliche* Assertion auf. Ein Mock erzwingt Erwartungen *während* der Ausführung.
+
+Schlüsselvertreter:: Gerard Meszaros ("xUnit Test Patterns", 2007)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einem LLM sagen: "Erzeuge ein Mock-Test-Double, das diese Interaktionen verifiziert"
+* Interaktionsbasiertes Testen (London School TDD)
+* Wenn das *Verhalten* mehr zählt als das *Ergebnis*
+* Verifizieren, dass eine Benachrichtigung gesendet, ein Log geschrieben oder ein Service korrekt aufgerufen wurde
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<test-double-meszaros,Test Double (Meszaros)>> — übergreifende Taxonomie
+* <<test-double-spy,Spy>> — nachträgliche Assertion statt Erwartungen
+* <<tdd-london-school,TDD, London School>> — bevorzugt Mocks für Outside-in-Design
+====

--- a/docs/anchors/test-double-spy.de.adoc
+++ b/docs/anchors/test-double-spy.de.adoc
@@ -1,0 +1,37 @@
+= Test Double: Spy (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer
+:proponents: Gerard Meszaros
+:related: test-double-meszaros, test-double-stub, test-double-mock
+:tags: test-double, spy, testing, isolation, call-recording
+:tier: 3
+:parent-anchor: test-double-meszaros
+
+[%collapsible]
+====
+[discrete]
+== *Kernkonzepte*:
+
+Zweck:: Ein Stub, der zusätzlich aufzeichnet, wie er aufgerufen wurde — welche Methoden, mit welchen Argumenten, wie oft. Assertions erfolgen *nach* der Aktion, nicht als Erwartungen *davor*.
+
+Verhalten:: Gibt vorgefertigte Antworten zurück (wie ein Stub) und zeichnet alle Interaktionen stillschweigend zur späteren Inspektion auf.
+
+Abgrenzung zum Mock:: Ein Spy zeichnet auf und lässt *dich* hinterher prüfen. Ein Mock hat vorprogrammierte Erwartungen, die sofort fehlschlagen, wenn sie verletzt werden.
+
+Schlüsselvertreter:: Gerard Meszaros ("xUnit Test Patterns", 2007)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einem LLM sagen: "Erzeuge ein Spy-Test-Double, das Aufrufe zur späteren Assertion aufzeichnet"
+* Wenn Interaktionen verifiziert werden sollen, die Assertions aber im Testkörper statt im Setup stehen sollen
+* Auditieren, was während eines Tests geschah, ohne die Reihenfolge der Operationen einzuschränken
+* Wenn das genaue Interaktionsmuster zählt, die Assertion aber flexibel bleiben soll
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<test-double-meszaros,Test Double (Meszaros)>> — übergreifende Taxonomie
+* <<test-double-stub,Stub>> — Spy ohne Aufruf-Aufzeichnung
+* <<test-double-mock,Mock>> — vorprogrammierte Erwartungen statt nachträglicher Assertion
+====

--- a/docs/anchors/test-double-stub.de.adoc
+++ b/docs/anchors/test-double-stub.de.adoc
@@ -1,0 +1,38 @@
+= Test Double: Stub (Meszaros)
+:categories: testing-quality
+:roles: software-developer, qa-engineer
+:proponents: Gerard Meszaros
+:related: test-double-meszaros, test-double-spy, test-double-mock
+:tags: test-double, stub, testing, isolation, canned-response
+:tier: 3
+:parent-anchor: test-double-meszaros
+
+[%collapsible]
+====
+[discrete]
+== *Kernkonzepte*:
+
+Zweck:: Liefert vordefinierte (vorgefertigte) Antworten auf Aufrufe während eines Tests. Verifiziert keine Interaktionen — stellt nur Daten bereit.
+
+Verhalten:: Gibt feste Werte unabhängig von der Eingabe zurück. Keine Assertion darüber, ob oder wie er aufgerufen wurde.
+
+Abgrenzung zum Mock:: Ein Stub lässt einen Test nie fehlschlagen. Er liefert nur Daten. Ein Mock hat Erwartungen und kann den Test fehlschlagen lassen, wenn die Interaktionen falsch sind.
+
+Schlüsselvertreter:: Gerard Meszaros ("xUnit Test Patterns", 2007)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einem LLM sagen: "Erzeuge ein Stub-Test-Double, das diese festen Daten zurückgibt"
+* Isolieren des System Under Test von externen Abhängigkeiten (Datenbank, API)
+* Zustandsbasiertes Testen (Chicago School TDD)
+* Wenn das *Ergebnis* zählt, nicht *wie* es zustande kam
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<test-double-meszaros,Test Double (Meszaros)>> — übergreifende Taxonomie
+* <<test-double-spy,Spy>> — ein Stub, der zusätzlich Aufrufe aufzeichnet
+* <<test-double-mock,Mock>> — wenn Interaktionsverifikation benötigt wird
+* <<tdd-chicago-school,TDD, Chicago School>> — bevorzugt Stubs gegenüber Mocks
+====


### PR DESCRIPTION
## What

Adds the six missing German translations that were breaking the catalog's otherwise complete EN/DE parity:

- `invest.de.adoc`
- `test-double-dummy.de.adoc`
- `test-double-stub.de.adoc`
- `test-double-spy.de.adoc`
- `test-double-mock.de.adoc`
- `test-double-fake.de.adoc`

Before this PR, every EN anchor had a `.de` counterpart **except** these six.

## How

- Each `.de.adoc` mirrors its English source's metadata verbatim (`:categories:`, `:roles:`, `:proponents:`, `:related:`, `:tags:`, `:tier:`, `:parent-anchor:`).
- Body translated following the existing `test-double-meszaros.de.adoc` pattern (`Kernkonzepte` / `Wann zu verwenden` / `Verwandte Anker`, straight ASCII quotes, cross-reference IDs unchanged).
- Technical terms (Dummy, Stub, Mock, Spy, Fake, Repository, In-Memory) kept as-is; INVEST mnemonic letters kept English with a German gloss.

## Validation

Both gates run locally — clean:

- Repo `asciidoc-linter` (`.asciidoc-linter.yml`): `✓ No issues found`
- tpo42 adoc container (`ghcr.io/tpo42/adoc:0`) `validate`: all files valid

## Scope

Translation-only. No EN content, metadata, or tooling changed; no catalog update needed (the AgentSkill catalog tracks anchors, not translations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Neue deutschsprachige Ankerseiten zu INVEST-Kriterien sowie zu mehreren Test-Double-Typen ergänzt.
  * Inhalte erklären die jeweiligen Begriffe, typische Einsatzfälle und Abgrenzungen zu verwandten Konzepten.
  * Zusätzliche Verweise erleichtern das Navigieren zwischen thematisch verwandten Dokumentationsseiten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->