### PR TITLE
feat: add 18 semantic anchors (EN+DE) from proposal triage

### DIFF
--- a/docs/anchors/addie-model.adoc
+++ b/docs/anchors/addie-model.adoc
@@ -1,0 +1,61 @@
+= ADDIE Model
+:categories: knowledge-management
+:roles: educator, technical-writer, consultant
+:related: blooms-taxonomy, 4mat, feynman-technique, double-diamond
+:proponents: Florida State University (origin); Robert Maribe Branch (codification)
+:tags: instructional-design, training, learning-design, evaluation, education
+:tier: 3
+
+[%collapsible]
+====
+Also known as:: ADDIE, Instructional Systems Design (ISD)
+
+Full Name:: Analysis, Design, Development, Implementation, Evaluation
+
+[discrete]
+== *Core Concepts*:
+
+Analysis:: Clarify the instructional problem; identify needs, audience characteristics, learning goals, constraints, and the existing knowledge gap
+
+Design:: Define measurable learning objectives, assessment instruments, content structure, and media selection — the blueprint produced before any materials are built
+
+Development:: Build and assemble the actual learning materials (content, storyboards, media, technology) against the design blueprint; includes pilot testing
+
+Implementation:: Deliver the instruction — train facilitators, prepare learners, and run the program in its intended environment
+
+Evaluation:: Assess effectiveness through both formative (ongoing, each phase) and summative (final outcome) evaluation; frequently paired with Kirkpatrick's four levels
+
+Iterative, not strictly waterfall:: Though originally sequential, modern ADDIE is drawn as a cyclical, dynamic process where Evaluation feeds back into every phase
+
+Key Proponents:: Florida State University's Center for Educational Technology (~1975, for the US Army, later all US armed forces via the IPISD framework); Robert Maribe Branch ("Instructional Design: The ADDIE Approach", Springer, 2009) — a key modern codification. ADDIE is a generic label for the ISD process rather than a single-author model.
+
+[discrete]
+== *When to Use*:
+
+* Designing structured training, courses, or learning materials from scratch
+* Producing documentation or onboarding programs that require measurable learning outcomes
+* Coaching or consulting engagements that build organizational capability
+* Establishing a shared vocabulary for an instructional-design or e-learning team
+* Prompting an LLM to scaffold a curriculum or training plan along defined phases
+
+[discrete]
+== *Related Anchors*:
+
+* <<blooms-taxonomy,Bloom's Taxonomy>> — frames the learning objectives set in the Design phase
+* <<4mat,4MAT>> — a learning-cycle model that complements ADDIE's structure
+* <<feynman-technique,Feynman Technique>> — a learning method usable within Development
+* <<double-diamond,Double Diamond>> — a comparable diverge/converge process model from design
+
+[discrete]
+== *Criticism*:
+
+* Roundtable Learning, https://roundtablelearning.com/what-is-the-addie-model-less-than-100-words/["What is the ADDIE Model? Strengths & Weaknesses"] — criticizes ADDIE for its linear nature, overly-detailed approach, and the time required to create and implement it; defects surface only in late phases
+* Michael Allen / Allen Interactions, https://elearningindustry.com/sam-successive-approximation-model-for-rapid-instructional-design["SAM: A Rapid Design And Development Model"] (eLearning Industry) — calls ADDIE "rigid and too linear," "slow to evaluate," and burdened by the "waterfall nature of execution"; proposes SAM (Successive Approximation Model), a rapid, iterative, agile alternative that always keeps something usable in front of learners
+* Broader discourse pairs this with Agile / rapid-prototyping instructional design as the modern answer to ADDIE's front-loaded sequencing
+
+[discrete]
+== *Current Status*:
+
+* Still the most widely taught ISD framework, but increasingly presented as iterative rather than strict waterfall; Branch's 2009 codification (https://link.springer.com/book/10.1007/978-0-387-09506-6[Springer]) is the common modern reference
+* SAM and Agile ID are the main contemporary alternatives for fast-moving, multimedia, and online-learning projects (https://en.wikipedia.org/wiki/ADDIE_model[ADDIE model, Wikipedia])
+====

--- a/docs/anchors/addie-model.de.adoc
+++ b/docs/anchors/addie-model.de.adoc
@@ -4,6 +4,7 @@
 :related: blooms-taxonomy, 4mat, feynman-technique, double-diamond
 :proponents: Florida State University (origin); Robert Maribe Branch (codification)
 :tags: instructional-design, training, learning-design, evaluation, education
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/addie-model.de.adoc
+++ b/docs/anchors/addie-model.de.adoc
@@ -1,0 +1,60 @@
+= ADDIE Model
+:categories: knowledge-management
+:roles: educator, technical-writer, consultant
+:related: blooms-taxonomy, 4mat, feynman-technique, double-diamond
+:proponents: Florida State University (origin); Robert Maribe Branch (codification)
+:tags: instructional-design, training, learning-design, evaluation, education
+
+[%collapsible]
+====
+Auch bekannt als:: ADDIE, Instructional Systems Design (ISD)
+
+Vollständiger Name:: Analysis, Design, Development, Implementation, Evaluation
+
+[discrete]
+== *Kernkonzepte*:
+
+Analysis:: Das Lernproblem klären; Bedarf, Zielgruppenmerkmale, Lernziele, Rahmenbedingungen und die vorhandene Wissenslücke ermitteln
+
+Design:: Messbare Lernziele, Bewertungsinstrumente, Inhaltsstruktur und Medienauswahl definieren — der Bauplan, der vor jeder Materialerstellung entsteht
+
+Development:: Die eigentlichen Lernmaterialien (Inhalte, Storyboards, Medien, Technik) gemäß dem Design-Bauplan erstellen und zusammenstellen; umfasst Pilottests
+
+Implementation:: Die Schulung durchführen — Trainer schulen, Lernende vorbereiten und das Programm in der vorgesehenen Umgebung ausführen
+
+Evaluation:: Die Wirksamkeit sowohl formativ (laufend, in jeder Phase) als auch summativ (Endergebnis) bewerten; häufig mit Kirkpatricks vier Ebenen kombiniert
+
+Iterativ, nicht streng wasserfallartig:: Ursprünglich sequenziell, wird modernes ADDIE als zyklischer, dynamischer Prozess dargestellt, bei dem die Evaluation in jede Phase zurückwirkt
+
+Schlüsselvertreter:: Florida State University, Center for Educational Technology (~1975, für die US Army, später alle US-Streitkräfte über das IPISD-Framework); Robert Maribe Branch ("Instructional Design: The ADDIE Approach", Springer, 2009) — eine maßgebliche moderne Kodifizierung. ADDIE ist eher eine generische Bezeichnung für den ISD-Prozess als ein Modell eines einzelnen Autors.
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Strukturierte Schulungen, Kurse oder Lernmaterialien von Grund auf entwerfen
+* Dokumentation oder Onboarding-Programme erstellen, die messbare Lernergebnisse erfordern
+* Coaching- oder Beratungsmandate, die organisatorische Fähigkeiten aufbauen
+* Eine gemeinsame Terminologie für ein Instructional-Design- oder E-Learning-Team etablieren
+* Ein LLM anleiten, ein Curriculum oder einen Trainingsplan entlang definierter Phasen zu strukturieren
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<blooms-taxonomy,Bloom's Taxonomy>> — rahmt die in der Design-Phase gesetzten Lernziele
+* <<4mat,4MAT>> — ein Lernzyklus-Modell, das ADDIEs Struktur ergänzt
+* <<feynman-technique,Feynman Technique>> — eine Lernmethode, die innerhalb von Development einsetzbar ist
+* <<double-diamond,Double Diamond>> — ein vergleichbares Diverge/Converge-Prozessmodell aus dem Design
+
+[discrete]
+== *Kritik*:
+
+* Roundtable Learning, https://roundtablelearning.com/what-is-the-addie-model-less-than-100-words/["What is the ADDIE Model? Strengths & Weaknesses"] — kritisiert ADDIE für seine lineare Natur, den übermäßig detaillierten Ansatz und den Zeitaufwand für Erstellung und Umsetzung; Mängel zeigen sich erst in späten Phasen
+* Michael Allen / Allen Interactions, https://elearningindustry.com/sam-successive-approximation-model-for-rapid-instructional-design["SAM: A Rapid Design And Development Model"] (eLearning Industry) — nennt ADDIE "rigid and too linear", "slow to evaluate" und belastet durch die "waterfall nature of execution"; schlägt SAM (Successive Approximation Model) vor, eine schnelle, iterative, agile Alternative, die Lernenden stets etwas Nutzbares vorlegt
+* Der breitere Diskurs verbindet dies mit Agile / Rapid-Prototyping Instructional Design als moderne Antwort auf ADDIEs vorgelagerte Sequenzierung
+
+[discrete]
+== *Aktueller Status*:
+
+* Weiterhin das am häufigsten gelehrte ISD-Framework, aber zunehmend iterativ statt streng wasserfallartig dargestellt; Branchs Kodifizierung von 2009 (https://link.springer.com/book/10.1007/978-0-387-09506-6[Springer]) ist die gängige moderne Referenz
+* SAM und Agile ID sind die wichtigsten zeitgenössischen Alternativen für schnelllebige, multimediale und Online-Learning-Projekte (https://en.wikipedia.org/wiki/ADDIE_model[ADDIE model, Wikipedia])
+====

--- a/docs/anchors/circuit-breaker.adoc
+++ b/docs/anchors/circuit-breaker.adoc
@@ -1,0 +1,55 @@
+= Circuit Breaker
+:categories: software-architecture
+:roles: software-developer, software-architect, devops-engineer
+:related: fallacies-of-distributed-computing, cap-theorem, event-driven-architecture
+:proponents: Michael Nygard, Martin Fowler
+:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: Circuit Breaker stability pattern
+
+[discrete]
+== *Core Concepts*:
+
+Closed state:: Normal operation; calls pass through to the protected resource while the breaker counts failures
+
+Open state:: Once failures cross the threshold the breaker trips; further calls fail immediately (fail-fast) without invoking the protected call, preventing resource exhaustion and cascading failure
+
+Half-open state:: After a reset timeout the breaker tentatively lets a trial call through to probe whether the dependency has recovered; success closes the breaker, failure re-opens it
+
+Failure threshold:: Configured count or rate of failures that trips the breaker from closed to open
+
+Fail-fast:: Returning an error instantly instead of blocking on a call known to be failing, freeing threads and connections
+
+Fallback:: The client-side strategy when the breaker is open — return cached data, a default, a queued request, or a graceful error
+
+Composes with:: Pairs with timeout (bound each call), retry (recover from transient faults), and bulkhead (isolate failures) as a stability-pattern set
+
+Key Proponents:: Michael Nygard ("Release It!", Pragmatic Bookshelf, 2007), who introduced it as a stability pattern; Martin Fowler (https://martinfowler.com/bliki/CircuitBreaker.html[bliki: CircuitBreaker]), who popularized it further
+
+[discrete]
+== *When to Use*:
+
+* Calls across a network boundary to a remote service or dependency that can become slow or unavailable
+* Microservice architectures where one failing service must not cascade into a system-wide outage
+* Integrations with third-party APIs of uncertain reliability
+* Any operation that can exhaust threads, connections, or other bounded resources while waiting on a stuck dependency
+* Prompting an LLM to add resilience to inter-service communication
+
+[discrete]
+== *Related Anchors*:
+
+* <<fallacies-of-distributed-computing,Fallacies of Distributed Computing>>
+* <<cap-theorem,CAP Theorem>>
+* <<event-driven-architecture,Event-Driven Architecture>>
+
+[discrete]
+== *Current Status*:
+
+* The reference Java implementation in training-data priors is often Netflix Hystrix, which is now frozen. Its https://github.com/Netflix/Hystrix[README] states: "Hystrix is no longer in active development, and is currently in maintenance mode." (final stable release 1.5.18, November 2018)
+* Netflix's own guidance points elsewhere: "we intend to continue using Hystrix for existing applications, and to leverage open and active projects like resilience4j for new internal projects. We are beginning to recommend others do the same." (https://github.com/Netflix/Hystrix[Netflix/Hystrix])
+* https://resilience4j.readme.io/[Resilience4j] is the maintained successor in the Java/Spring ecosystem and is recommended by Spring Cloud as the default circuit breaker
+* In service-mesh deployments, circuit breaking is increasingly handled at the infrastructure layer by the sidecar proxy (e.g. https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking[Envoy circuit breaking], used by https://istio.io/latest/docs/tasks/traffic-management/circuit-breaking/[Istio]) rather than in application code
+====

--- a/docs/anchors/circuit-breaker.de.adoc
+++ b/docs/anchors/circuit-breaker.de.adoc
@@ -4,6 +4,7 @@
 :related: fallacies-of-distributed-computing, cap-theorem, event-driven-architecture
 :proponents: Michael Nygard, Martin Fowler
 :tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/circuit-breaker.de.adoc
+++ b/docs/anchors/circuit-breaker.de.adoc
@@ -1,0 +1,54 @@
+= Circuit Breaker
+:categories: software-architecture
+:roles: software-developer, software-architect, devops-engineer
+:related: fallacies-of-distributed-computing, cap-theorem, event-driven-architecture
+:proponents: Michael Nygard, Martin Fowler
+:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
+
+[%collapsible]
+====
+Auch bekannt als:: Circuit-Breaker-Stabilitätsmuster
+
+[discrete]
+== *Kernkonzepte*:
+
+Geschlossener Zustand (Closed):: Normalbetrieb; Aufrufe gehen zur geschützten Ressource durch, während der Breaker Fehler zählt
+
+Offener Zustand (Open):: Sobald die Fehler den Schwellwert überschreiten, löst der Breaker aus; weitere Aufrufe schlagen sofort fehl (Fail-Fast), ohne den geschützten Aufruf auszuführen — das verhindert Ressourcenerschöpfung und kaskadierende Ausfälle
+
+Halb-offener Zustand (Half-Open):: Nach einem Reset-Timeout lässt der Breaker probeweise einen Testaufruf durch, um zu prüfen, ob die Abhängigkeit sich erholt hat; Erfolg schließt den Breaker, Fehlschlag öffnet ihn erneut
+
+Fehlerschwellwert:: Konfigurierte Anzahl oder Rate von Fehlern, die den Breaker von geschlossen auf offen umschaltet
+
+Fail-Fast:: Sofortige Rückgabe eines Fehlers statt Blockierung bei einem als fehlerhaft bekannten Aufruf; gibt Threads und Verbindungen frei
+
+Fallback:: Die clientseitige Strategie bei offenem Breaker — zwischengespeicherte Daten, ein Standardwert, ein eingereihter Request oder ein kontrollierter Fehler
+
+Kombinierbar mit:: Ergänzt Timeout (jeden Aufruf begrenzen), Retry (von transienten Fehlern erholen) und Bulkhead (Fehler isolieren) als Satz von Stabilitätsmustern
+
+Schlüsselvertreter:: Michael Nygard ("Release It!", Pragmatic Bookshelf, 2007), der es als Stabilitätsmuster einführte; Martin Fowler (https://martinfowler.com/bliki/CircuitBreaker.html[bliki: CircuitBreaker]), der es weiter bekannt machte
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Aufrufe über eine Netzwerkgrenze zu einem entfernten Dienst oder einer Abhängigkeit, die langsam oder nicht verfügbar werden kann
+* Microservice-Architekturen, in denen ein ausfallender Dienst keinen systemweiten Ausfall auslösen darf
+* Integrationen mit Drittanbieter-APIs unsicherer Zuverlässigkeit
+* Jede Operation, die Threads, Verbindungen oder andere begrenzte Ressourcen erschöpfen kann, während sie auf eine hängende Abhängigkeit wartet
+* Beim Prompting eines LLM, um Resilienz in der Dienst-zu-Dienst-Kommunikation hinzuzufügen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<fallacies-of-distributed-computing,Fallacies of Distributed Computing>>
+* <<cap-theorem,CAP Theorem>>
+* <<event-driven-architecture,Event-Driven Architecture>>
+
+[discrete]
+== *Aktueller Status*:
+
+* Die in den Trainingsdaten verankerte Java-Referenzimplementierung ist häufig Netflix Hystrix, das inzwischen eingefroren ist. Die https://github.com/Netflix/Hystrix[README] besagt: "Hystrix is no longer in active development, and is currently in maintenance mode." (letztes stabiles Release 1.5.18, November 2018)
+* Netflix' eigene Empfehlung verweist anderswohin: "we intend to continue using Hystrix for existing applications, and to leverage open and active projects like resilience4j for new internal projects. We are beginning to recommend others do the same." (https://github.com/Netflix/Hystrix[Netflix/Hystrix])
+* https://resilience4j.readme.io/[Resilience4j] ist der gepflegte Nachfolger im Java/Spring-Ökosystem und wird von Spring Cloud als Standard-Circuit-Breaker empfohlen
+* In Service-Mesh-Deployments wird Circuit Breaking zunehmend auf der Infrastrukturebene durch den Sidecar-Proxy erledigt (z. B. https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking[Envoy Circuit Breaking], genutzt von https://istio.io/latest/docs/tasks/traffic-management/circuit-breaking/[Istio]) statt im Anwendungscode
+====

--- a/docs/anchors/consent-vs-consensus.adoc
+++ b/docs/anchors/consent-vs-consensus.adoc
@@ -1,0 +1,50 @@
+= Consent vs. Consensus
+:categories: strategic-planning
+:roles: team-lead, consultant, product-owner
+:related: cynefin-framework, devils-advocate, double-diamond
+:proponents: Gerard Endenburg, Brian Robertson
+:tags: decision-making, sociocracy, holacracy, governance, facilitation
+:tier: 3
+
+[%collapsible]
+====
+Also known as:: Consent-based decision-making vs. consensus decision-making
+
+[discrete]
+== *Core Concepts*:
+
+Consensus:: Active agreement of everyone — each participant must be *for* the proposal ("yes"). Seeks the option everyone prefers; a veto can block without an argument. Risks slow decisions, lowest-common-denominator outcomes, and groupthink.
+
+Consent:: Absence of a *paramount, reasoned objection* — participants need only be *not against* ("no objection"). The test is "good enough for now, safe enough to try", not "does everyone love it".
+
+Paramount objection:: An objection must be argued and show how the proposal would harm the group's aim or impair someone's ability to work toward it. Mere preference or "I'd do it differently" is not an objection.
+
+Objection integration:: Valid objections are harvested and integrated into an amended proposal, rather than triggering a veto — the proposal evolves until no paramount objection remains.
+
+Sociocracy (Sociocratic Circle Method):: Gerard Endenburg formalized consent-based governance in the 1970s (building on Kees Boeke's Quaker-rooted consensus practice at the Werkplaats school). Consent is one of four principles, alongside circles, double-linking, and elections.
+
+Holacracy (Integrative Decision-Making):: Brian Robertson's structured governance process (HolacracyOne, 2007): propose, react, amend, then test for objections. Decisions are anchored in *roles' needs*, not personal preference or ego.
+
+Key Proponents:: Gerard Endenburg (Sociocratic Circle-Organizing Method); Brian Robertson ("Holacracy: The New Management System for a Rapidly Changing World"); roots in Kees Boeke and the Quaker "sense of the meeting"
+
+[discrete]
+== *When to Use*:
+
+* Naming why a group is stuck seeking unanimous enthusiasm when "no objection" would suffice
+* Designing or facilitating fast, non-blocking governance decisions
+* Distinguishing a reasoned, integrable objection from a personal preference or veto
+* Explaining self-management practices in sociocratic or Holacratic organizations
+* Contrasting with relatives: Quaker "sense of the meeting", IETF "rough consensus", "lazy consensus", and "disagree and commit"
+
+[discrete]
+== *Related Anchors*:
+
+* <<cynefin-framework,Cynefin Framework>>
+* <<devils-advocate,Devil's Advocate>>
+* <<double-diamond,Double Diamond>>
+
+[discrete]
+== *Current Status*:
+
+* Classic sociocracy (Endenburg) has a documented modular successor: https://patterns.sociocracy30.org/[Sociocracy 3.0 (S3)], created by Bernhard Bockelbrink, James Priest, and Liliana David (launched 2015), which deconstructs the integrated method into 70+ adoptable patterns and adds principles such as empiricism and transparency. See https://en.wikipedia.org/wiki/Sociocracy[Sociocracy (Wikipedia)] for the lineage from Kees Boeke through Endenburg.
+====

--- a/docs/anchors/consent-vs-consensus.de.adoc
+++ b/docs/anchors/consent-vs-consensus.de.adoc
@@ -4,6 +4,7 @@
 :related: cynefin-framework, devils-advocate, double-diamond
 :proponents: Gerard Endenburg, Brian Robertson
 :tags: decision-making, sociocracy, holacracy, governance, facilitation
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/consent-vs-consensus.de.adoc
+++ b/docs/anchors/consent-vs-consensus.de.adoc
@@ -1,0 +1,49 @@
+= Consent vs. Consensus
+:categories: strategic-planning
+:roles: team-lead, consultant, product-owner
+:related: cynefin-framework, devils-advocate, double-diamond
+:proponents: Gerard Endenburg, Brian Robertson
+:tags: decision-making, sociocracy, holacracy, governance, facilitation
+
+[%collapsible]
+====
+Auch bekannt als:: Konsent-basierte Entscheidungsfindung vs. Konsens-Entscheidungsfindung
+
+[discrete]
+== *Kernkonzepte*:
+
+Konsens (Consensus):: Aktive Zustimmung aller — jede Person muss *für* den Vorschlag sein ("Ja"). Sucht die Option, die alle bevorzugen; ein Veto kann ohne Begründung blockieren. Risiken: langsame Entscheidungen, Ergebnisse auf dem kleinsten gemeinsamen Nenner und Groupthink.
+
+Konsent (Consent):: Fehlen eines *schwerwiegenden, begründeten Einwands* — Teilnehmende müssen nur *nicht dagegen* sein ("kein Einwand"). Der Prüfstein ist "gut genug für jetzt, sicher genug zum Ausprobieren", nicht "lieben es alle".
+
+Schwerwiegender Einwand (paramount objection):: Ein Einwand muss begründet sein und zeigen, wie der Vorschlag dem Ziel der Gruppe schaden oder die Arbeit darauf hin beeinträchtigen würde. Eine bloße Präferenz oder "ich würde es anders machen" ist kein Einwand.
+
+Integration von Einwänden:: Gültige Einwände werden gesammelt und in einen überarbeiteten Vorschlag integriert, statt ein Veto auszulösen — der Vorschlag entwickelt sich weiter, bis kein schwerwiegender Einwand mehr besteht.
+
+Soziokratie (Sociocratic Circle Method):: Gerard Endenburg formalisierte die konsent-basierte Governance in den 1970er-Jahren (aufbauend auf Kees Boekes Quaker-geprägter Konsenspraxis an der Werkplaats-Schule). Konsent ist eines von vier Prinzipien, neben Kreisen, Doppelter Verknüpfung und Wahlen.
+
+Holacracy (Integrative Decision-Making):: Brian Robertsons strukturierter Governance-Prozess (HolacracyOne, 2007): vorschlagen, reagieren, überarbeiten, dann auf Einwände prüfen. Entscheidungen sind in den *Bedürfnissen der Rollen* verankert, nicht in persönlicher Präferenz oder Ego.
+
+Schlüsselvertreter:: Gerard Endenburg (Sociocratic Circle-Organizing Method); Brian Robertson ("Holacracy: The New Management System for a Rapidly Changing World"); Wurzeln bei Kees Boeke und dem Quaker "sense of the meeting"
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Benennen, warum eine Gruppe feststeckt, weil sie einstimmige Begeisterung sucht, wo "kein Einwand" genügen würde
+* Gestaltung oder Facilitierung schneller, nicht-blockierender Governance-Entscheidungen
+* Unterscheidung eines begründeten, integrierbaren Einwands von einer persönlichen Präferenz oder einem Veto
+* Erläuterung von Selbstorganisationspraktiken in soziokratischen oder Holacratic-Organisationen
+* Abgrenzung zu Verwandten: Quaker "sense of the meeting", IETF "rough consensus", "lazy consensus" und "disagree and commit"
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<cynefin-framework,Cynefin Framework>>
+* <<devils-advocate,Devil's Advocate>>
+* <<double-diamond,Double Diamond>>
+
+[discrete]
+== *Aktueller Stand*:
+
+* Die klassische Soziokratie (Endenburg) hat einen dokumentierten modularen Nachfolger: https://patterns.sociocracy30.org/[Sociocracy 3.0 (S3)], entwickelt von Bernhard Bockelbrink, James Priest und Liliana David (gestartet 2015), das die integrierte Methode in über 70 adoptierbare Patterns zerlegt und Prinzipien wie Empirie und Transparenz ergänzt. Siehe https://en.wikipedia.org/wiki/Sociocracy[Sociocracy (Wikipedia)] für die Linie von Kees Boeke über Endenburg.
+====

--- a/docs/anchors/curse-of-knowledge.adoc
+++ b/docs/anchors/curse-of-knowledge.adoc
@@ -1,0 +1,49 @@
+= Curse of Knowledge
+:categories: communication-presentation
+:roles: technical-writer, educator, software-developer
+:related: feynman-technique, blooms-taxonomy, bluf, inverted-pyramid-style
+:proponents: Colin Camerer, George Loewenstein, Martin Weber, Chip Heath, Dan Heath
+:tags: cognitive-bias, communication, audience, jargon, empathy-gap
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: Curse of Expertise, Knowledge Gap Bias
+
+[discrete]
+== *Core Concepts*:
+
+Knowing makes un-knowing impossible:: Once you understand something, you cannot easily reconstruct what it was like not to know it; the mental state of the novice becomes inaccessible.
+
+Overestimated shared context:: Experts systematically assume the audience holds background, vocabulary, and intermediate steps that the audience does not actually have.
+
+Unexplained jargon and skipped steps:: The bias surfaces as opaque terms left undefined and logical links the writer "divines" but the reader cannot.
+
+Empathy gap:: A failure to model the audience's actual knowledge state, not a failure of the audience's intelligence.
+
+Antidote — surface and externalize:: Make hidden assumptions explicit, define terms, spell out skipped steps, and test against a representative reader instead of yourself.
+
+Key Proponents:: Colin Camerer, George Loewenstein, Martin Weber (https://www.journals.uchicago.edu/doi/abs/10.1086/261651["The Curse of Knowledge in Economic Settings: An Experimental Analysis", Journal of Political Economy 97(5):1232-1254, 1989] — coined the term); Chip Heath, Dan Heath (https://heathbrothers.com/made-to-stick-introduction/["Made to Stick", 2007] — popularized it, citing Elizabeth Newton's 1990 "tappers and listeners" study); Steven Pinker (https://www.psychologicalscience.org/observer/the-curse-of-knowledge-pinker-describes-a-key-cause-of-bad-writing["The Sense of Style", 2014] — names it the chief cause of bad writing)
+
+[discrete]
+== *When to Use*:
+
+* Reviewing documentation, tutorials, or onboarding material for an audience less expert than the author
+* Diagnosing why an explanation, talk, or error message confuses its readers
+* Teaching: deciding which steps and terms must be made explicit rather than assumed
+* Prompting an LLM to write for a non-expert audience, or to surface and state its own assumptions and defined terms
+* Code review of comments, API docs, and commit messages that assume too much context
+
+[discrete]
+== *Related Anchors*:
+
+* <<feynman-technique,Feynman Technique>>
+* <<blooms-taxonomy,Bloom's Taxonomy>>
+* <<bluf,BLUF>>
+* <<inverted-pyramid-style,Inverted Pyramid Style>>
+
+[discrete]
+== *Current Status*:
+
+* Steven Pinker reframed the bias as a writing problem in https://www.psychologicalscience.org/observer/the-curse-of-knowledge-pinker-describes-a-key-cause-of-bad-writing["The Sense of Style" (2014)], calling it "the single best explanation I know of why good people write bad prose" and prescribing testing prose against a representative reader — the framing most likely to dominate present-day discussion of the term outside economics
+====

--- a/docs/anchors/curse-of-knowledge.de.adoc
+++ b/docs/anchors/curse-of-knowledge.de.adoc
@@ -4,6 +4,7 @@
 :related: feynman-technique, blooms-taxonomy, bluf, inverted-pyramid-style
 :proponents: Colin Camerer, George Loewenstein, Martin Weber, Chip Heath, Dan Heath
 :tags: cognitive-bias, communication, audience, jargon, empathy-gap
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/curse-of-knowledge.de.adoc
+++ b/docs/anchors/curse-of-knowledge.de.adoc
@@ -1,0 +1,48 @@
+= Curse of Knowledge
+:categories: communication-presentation
+:roles: technical-writer, educator, software-developer
+:related: feynman-technique, blooms-taxonomy, bluf, inverted-pyramid-style
+:proponents: Colin Camerer, George Loewenstein, Martin Weber, Chip Heath, Dan Heath
+:tags: cognitive-bias, communication, audience, jargon, empathy-gap
+
+[%collapsible]
+====
+Auch bekannt als:: Curse of Expertise, Fluch des Wissens
+
+[discrete]
+== *Kernkonzepte*:
+
+Wissen macht Nicht-Wissen unmöglich:: Sobald man etwas verstanden hat, kann man nur schwer rekonstruieren, wie es war, es nicht zu wissen; der Geisteszustand des Anfängers wird unzugänglich.
+
+Überschätzter geteilter Kontext:: Experten setzen systematisch Hintergrundwissen, Vokabular und Zwischenschritte voraus, über die das Publikum tatsächlich nicht verfügt.
+
+Unerklärter Jargon und übersprungene Schritte:: Der Bias zeigt sich als undefinierte Fachbegriffe und logische Verbindungen, die der Autor "errät", der Leser aber nicht nachvollziehen kann.
+
+Empathielücke:: Ein Versäumnis, den tatsächlichen Wissensstand des Publikums zu modellieren, nicht ein Mangel an Intelligenz beim Publikum.
+
+Gegenmittel — offenlegen und externalisieren:: Verborgene Annahmen explizit machen, Begriffe definieren, übersprungene Schritte ausformulieren und gegen einen repräsentativen Leser testen statt gegen sich selbst.
+
+Schlüsselvertreter:: Colin Camerer, George Loewenstein, Martin Weber (https://www.journals.uchicago.edu/doi/abs/10.1086/261651["The Curse of Knowledge in Economic Settings: An Experimental Analysis", Journal of Political Economy 97(5):1232-1254, 1989] — prägten den Begriff); Chip Heath, Dan Heath (https://heathbrothers.com/made-to-stick-introduction/["Made to Stick", 2007] — machten ihn bekannt und beriefen sich auf Elizabeth Newtons "Tapper und Zuhörer"-Studie von 1990); Steven Pinker (https://www.psychologicalscience.org/observer/the-curse-of-knowledge-pinker-describes-a-key-cause-of-bad-writing["The Sense of Style", 2014] — benennt ihn als Hauptursache schlechten Schreibens)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Begutachtung von Dokumentation, Tutorials oder Onboarding-Material für ein Publikum, das weniger Experte ist als der Autor
+* Diagnose, warum eine Erklärung, ein Vortrag oder eine Fehlermeldung die Leser verwirrt
+* Lehre: Entscheiden, welche Schritte und Begriffe explizit gemacht statt vorausgesetzt werden müssen
+* Einen LLM anweisen, für ein Nicht-Experten-Publikum zu schreiben oder seine eigenen Annahmen und definierten Begriffe offenzulegen
+* Code-Review von Kommentaren, API-Dokumentation und Commit-Nachrichten, die zu viel Kontext voraussetzen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<feynman-technique,Feynman Technique>>
+* <<blooms-taxonomy,Bloom's Taxonomy>>
+* <<bluf,BLUF>>
+* <<inverted-pyramid-style,Inverted Pyramid Style>>
+
+[discrete]
+== *Aktueller Status*:
+
+* Steven Pinker fasste den Bias in https://www.psychologicalscience.org/observer/the-curse-of-knowledge-pinker-describes-a-key-cause-of-bad-writing["The Sense of Style" (2014)] als Schreibproblem neu, nannte ihn "the single best explanation I know of why good people write bad prose" und empfahl, Texte gegen einen repräsentativen Leser zu testen — die Deutung, die die heutige Diskussion des Begriffs außerhalb der Ökonomie am wahrscheinlichsten dominiert
+====

--- a/docs/anchors/design-by-contract.adoc
+++ b/docs/anchors/design-by-contract.adoc
@@ -1,0 +1,62 @@
+= Design by Contract
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: solid-lsp, solid-principles, postels-law, ears-requirements
+:proponents: Bertrand Meyer
+:tags: preconditions, postconditions, invariants, correctness, eiffel
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: DbC, Programming by Contract
+
+[discrete]
+== *Core Concepts*:
+
+Precondition:: The caller's obligation — a condition that must hold before a routine is called. If it is violated, the bug is in the *client*, not the supplier.
+
+Postcondition:: The supplier's guarantee — a condition the routine promises to establish on return, provided its preconditions held. If it is violated, the bug is in the *supplier*.
+
+Class invariant:: A consistency condition that holds for every instance in every observable state, before and after each public routine. It constrains the abstraction across its whole lifetime.
+
+Client/supplier metaphor:: A routine is a contract between caller (client) and implementation (supplier): each party's obligation is the other's benefit. The supplier need not handle states its preconditions exclude.
+
+Blame assignment:: Because each clause has a single responsible party, a violated assertion localizes the defect: a broken precondition blames the caller, a broken postcondition or invariant blames the implementation. No defensive double-checking on both sides.
+
+Contract inheritance:: Subclasses may *weaken* preconditions (demand no more than the parent) and *strengthen* postconditions and invariants (promise no less). This is exactly behavioural subtyping.
+
+Relation to LSP:: The inheritance rules above are the contract-level statement of the <<solid-lsp,Liskov Substitution Principle>>. A subtype that obeys them is substitutable for its supertype without surprising clients.
+
+Scope tension with Postel's Law:: DbC says be *strict* about preconditions and fail hard on violation. <<postels-law,Postel's Law>> says be *liberal* in what you accept. They apply at different boundaries — DbC governs trusted internal module seams; Postel governs untrusted external inputs at the system edge. Confusing the two leaks invalid state inward.
+
+Key Proponent:: Bertrand Meyer, who coined the term for the https://www.eiffel.com/values/design-by-contract/[Eiffel] language (~1986) and developed it in _Object-Oriented Software Construction_ (1988, 1997). "Design by Contract" is a https://www.eiffel.com/values/design-by-contract/[trademark of Eiffel Software] (registered 2004).
+
+[discrete]
+== *When to Use*:
+
+* Specifying the obligations and guarantees of a module's public API precisely
+* Designing class hierarchies that must remain substitutable (behavioural subtyping)
+* Pushing input validation to a single, well-defined seam instead of scattering defensive checks
+* Prompting an LLM to generate routines with explicit pre/postconditions and invariants
+* Reasoning about correctness before reaching for exhaustive tests (complements, not replaces, testing)
+
+[discrete]
+== *Related Anchors*:
+
+* <<solid-lsp,Liskov Substitution Principle>> — DbC's inheritance rules formalize behavioural subtyping
+* <<solid-principles,SOLID Principles>> — DbC reinforces the substitutability guarantee SOLID depends on
+* <<postels-law,Postel's Law>> — opposing stance on input strictness; reconciled by boundary scope
+* <<ears-requirements,EARS Requirements>> — pre/postconditions express requirements as checkable assertions
+
+[discrete]
+== *Criticism*:
+
+* Bjarne Stroustrup, on the C++26 contracts design (https://www.theregister.com/2026/03/31/cplusplus26_approved/[The Register], 2026) — "It's claimed to be a minimal viable product. It's not minimal, it's not viable" — and recommended not using contracts in C++. Native, end-to-end DbC stays largely confined to Eiffel; mainstream languages get only partial or contested support.
+* Expressiveness limit (https://www.researchgate.net/publication/2929130_Supporting_Design_by_Contract_in_Java[Supporting Design by Contract in Java]) — contracts written in a subset of the host language often lack the power to state full functional correctness, forcing cumbersome workarounds; runtime-checked contracts catch violations late rather than proving absence of them.
+
+[discrete]
+== *Current Status*:
+
+* C++ contracts were *removed* from the C++20 working draft in 2019, restarted by study group SG21, and only landed in the standard as part of C++26 (https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2899r1.pdf[P2899 Rationale]; https://www.theregister.com/2026/03/31/cplusplus26_approved/[The Register], 2026) — so language-level DbC remains young and contested outside Eiffel. Training-data priors from before 2026 likely treat C++ contracts as absent or experimental.
+* Native support exists in Ada 2012, https://www.eiffel.com/values/design-by-contract/[Eiffel], D, Kotlin, and others; Python relies on third-party libraries (e.g. `deal`, `icontract`) rather than a language feature.
+====

--- a/docs/anchors/design-by-contract.de.adoc
+++ b/docs/anchors/design-by-contract.de.adoc
@@ -1,0 +1,61 @@
+= Design by Contract
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: solid-lsp, solid-principles, postels-law, ears-requirements
+:proponents: Bertrand Meyer
+:tags: preconditions, postconditions, invariants, correctness, eiffel
+
+[%collapsible]
+====
+Auch bekannt als:: DbC, Programming by Contract
+
+[discrete]
+== *Kernkonzepte*:
+
+Vorbedingung (Precondition):: Die Pflicht des Aufrufers — eine Bedingung, die vor dem Aufruf einer Routine gelten muss. Wird sie verletzt, liegt der Fehler beim *Client*, nicht beim Supplier.
+
+Nachbedingung (Postcondition):: Die Zusicherung des Suppliers — eine Bedingung, deren Erfüllung die Routine beim Rücksprung garantiert, sofern die Vorbedingungen galten. Wird sie verletzt, liegt der Fehler beim *Supplier*.
+
+Klasseninvariante (Class invariant):: Eine Konsistenzbedingung, die für jede Instanz in jedem beobachtbaren Zustand gilt — vor und nach jeder öffentlichen Routine. Sie schränkt die Abstraktion über ihre gesamte Lebensdauer ein.
+
+Client/Supplier-Metapher:: Eine Routine ist ein Vertrag zwischen Aufrufer (Client) und Implementierung (Supplier): Die Pflicht jeder Partei ist der Vorteil der anderen. Der Supplier muss Zustände, die seine Vorbedingungen ausschließen, nicht behandeln.
+
+Schuldzuweisung (Blame assignment):: Da jede Klausel genau eine verantwortliche Partei hat, lokalisiert eine verletzte Zusicherung den Defekt: eine gebrochene Vorbedingung beschuldigt den Aufrufer, eine gebrochene Nachbedingung oder Invariante die Implementierung. Keine defensive Doppelprüfung auf beiden Seiten.
+
+Vertragsvererbung (Contract inheritance):: Subklassen dürfen Vorbedingungen *abschwächen* (nicht mehr verlangen als die Oberklasse) und Nachbedingungen sowie Invarianten *verstärken* (nicht weniger zusichern). Das ist genau verhaltensbasierte Subtypisierung.
+
+Bezug zum LSP:: Die obigen Vererbungsregeln sind die vertragsbezogene Formulierung des <<solid-lsp,Liskovschen Substitutionsprinzips>>. Ein Subtyp, der sie einhält, ist ohne Überraschungen für Clients gegen seinen Obertyp austauschbar.
+
+Spannung mit Postels Gesetz:: DbC sagt, sei *strikt* bei Vorbedingungen und scheitere hart bei Verletzung. <<postels-law,Postels Gesetz>> sagt, sei *liberal* in dem, was du akzeptierst. Beide gelten an verschiedenen Grenzen — DbC regelt vertrauenswürdige interne Modulnähte; Postel regelt nicht vertrauenswürdige externe Eingaben am Systemrand. Eine Verwechslung lässt ungültigen Zustand nach innen lecken.
+
+Schlüsselvertreter:: Bertrand Meyer, der den Begriff für die Sprache https://www.eiffel.com/values/design-by-contract/[Eiffel] prägte (~1986) und ihn in _Object-Oriented Software Construction_ (1988, 1997) ausarbeitete. "Design by Contract" ist eine https://www.eiffel.com/values/design-by-contract/[Marke von Eiffel Software] (registriert 2004).
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Die Pflichten und Zusicherungen der öffentlichen API eines Moduls präzise spezifizieren
+* Klassenhierarchien entwerfen, die austauschbar bleiben müssen (verhaltensbasierte Subtypisierung)
+* Eingabevalidierung an eine einzige, klar definierte Naht schieben, statt defensive Prüfungen zu verstreuen
+* Ein LLM anweisen, Routinen mit expliziten Vor-/Nachbedingungen und Invarianten zu generieren
+* Über Korrektheit nachdenken, bevor man zu erschöpfenden Tests greift (ergänzt das Testen, ersetzt es nicht)
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<solid-lsp,Liskovsches Substitutionsprinzip>> — die Vererbungsregeln von DbC formalisieren verhaltensbasierte Subtypisierung
+* <<solid-principles,SOLID-Prinzipien>> — DbC stärkt die Austauschbarkeitsgarantie, auf die SOLID baut
+* <<postels-law,Postels Gesetz>> — gegensätzliche Haltung zur Eingabestriktheit; über die Grenzenscope versöhnt
+* <<ears-requirements,EARS Requirements>> — Vor-/Nachbedingungen formulieren Anforderungen als prüfbare Zusicherungen
+
+[discrete]
+== *Kritik*:
+
+* Bjarne Stroustrup zum C++26-Contracts-Entwurf (https://www.theregister.com/2026/03/31/cplusplus26_approved/[The Register], 2026) — "It's claimed to be a minimal viable product. It's not minimal, it's not viable" — und er empfahl, Contracts in C++ nicht zu verwenden. Natives, durchgängiges DbC bleibt weitgehend auf Eiffel beschränkt; Mainstream-Sprachen erhalten nur teilweise oder umstrittene Unterstützung.
+* Ausdrucksgrenze (https://www.researchgate.net/publication/2929130_Supporting_Design_by_Contract_in_Java[Supporting Design by Contract in Java]) — in einer Teilmenge der Wirtssprache geschriebene Verträge können oft volle funktionale Korrektheit nicht ausdrücken und erzwingen umständliche Umwege; zur Laufzeit geprüfte Verträge fangen Verletzungen spät ab, statt ihre Abwesenheit zu beweisen.
+
+[discrete]
+== *Aktueller Status*:
+
+* C++-Contracts wurden 2019 aus dem C++20-Arbeitsentwurf *entfernt*, von der Study Group SG21 neu begonnen und erst mit C++26 in den Standard aufgenommen (https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2899r1.pdf[P2899 Rationale]; https://www.theregister.com/2026/03/31/cplusplus26_approved/[The Register], 2026) — DbC auf Sprachebene bleibt außerhalb von Eiffel also jung und umstritten. Trainingsdaten-Priors vor 2026 behandeln C++-Contracts wahrscheinlich als fehlend oder experimentell.
+* Native Unterstützung gibt es in Ada 2012, https://www.eiffel.com/values/design-by-contract/[Eiffel], D, Kotlin und anderen; Python setzt auf Drittanbieter-Bibliotheken (z. B. `deal`, `icontract`) statt auf ein Sprachfeature.
+====

--- a/docs/anchors/design-by-contract.de.adoc
+++ b/docs/anchors/design-by-contract.de.adoc
@@ -4,6 +4,7 @@
 :related: solid-lsp, solid-principles, postels-law, ears-requirements
 :proponents: Bertrand Meyer
 :tags: preconditions, postconditions, invariants, correctness, eiffel
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/dreyfus-skill-acquisition.adoc
+++ b/docs/anchors/dreyfus-skill-acquisition.adoc
@@ -1,0 +1,57 @@
+= Dreyfus Model of Skill Acquisition
+:categories: knowledge-management
+:roles: educator, consultant, team-lead
+:related: blooms-taxonomy, feynman-technique, 4mat
+:proponents: Stuart Dreyfus, Hubert Dreyfus
+:tags: skill-acquisition, learning, expertise, mentoring, competence
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Dreyfus Model of Skill Acquisition according to Stuart E. and Hubert L. Dreyfus
+
+Also known as:: Five-Stage Model of Adult Skill Acquisition, Novice-to-Expert model
+
+[discrete]
+== *Core Concepts*:
+
+Five stages::
++
+Novice::: Follows context-free rules rigidly; recognizes no situational nuance; needs explicit instructions
+Advanced Beginner::: Applies situational maxims drawn from experience; still rule-oriented but starts reading context
+Competent::: Plans consciously and sets goals; copes with complexity by deliberately choosing what matters; feels responsibility for outcomes
+Proficient::: Perceives situations holistically; intuition emerges, though responses are still decided analytically
+Expert::: Acts with fluid, intuitive mastery; perception and action merge; deliberates only when something unfamiliar appears
+
+Analytical-to-intuitive progression:: Skill develops from detached rule-following toward involved, intuitive pattern recognition — not by accumulating more rules
+
+Stage-matched instruction:: Each stage needs a different kind of guidance; novices want rules and recipes, experts want holistic context and are hindered by step-by-step rules
+
+Key Proponents:: Stuart E. and Hubert L. Dreyfus, https://www.researchgate.net/publication/235125013_A_Five-Stage_Model_of_the_Mental_Activities_Involved_in_Directed_Skill_Acquisition["A Five-Stage Model of the Mental Activities Involved in Directed Skill Acquisition"] (1980, UC Berkeley Operations Research Center for the U.S. Air Force Office of Scientific Research); applied to nursing by Patricia Benner ("From Novice to Expert", 1984) and to software by Andy Hunt ("Pragmatic Thinking and Learning: Refactor Your Wetware", 2008)
+
+[discrete]
+== *When to Use*:
+
+* Calibrating teaching or explanation depth to a learner's stage
+* Designing mentoring and onboarding paths that move people from rules to intuition
+* Diagnosing why rule-heavy documentation helps novices but frustrates experts
+* Structuring competency frameworks and skill matrices for a team
+* Framing how an LLM should adjust the granularity of its guidance to the user's expertise
+
+[discrete]
+== *Related Anchors*:
+
+* <<blooms-taxonomy,Bloom's Taxonomy>>
+* <<feynman-technique,Feynman Technique>>
+* <<4mat,4MAT>>
+
+[discrete]
+== *Criticism*:
+
+* Fernand Gobet and Philippe Chassy, https://www.tandfonline.com/doi/full/10.3402/meo.v15i0.4846["The Dreyfus model of clinical problem-solving skills acquisition: a critical perspective"] and their 2008 paper in the _International Journal of Nursing Studies_ (45: 129-139) — argue there is no empirical evidence for discrete stages in the development of expertise, and that experts in fact use slow analytical problem-solving (e.g. look-ahead search in chess), contrary to the model's "experts act only intuitively" claim; they propose an alternative theory of intuition based on chunking
+
+[discrete]
+== *Current Status*:
+
+* The Dreyfus brothers later added a sixth stage of *mastery* and reframed the model (Rousse & Dreyfus, https://philarchive.org/archive/ROURTS["Revisiting the Six Stages of Skill Acquisition"]); training-data priors most often reflect the original five-stage version popularized by Benner and Hunt
+====

--- a/docs/anchors/dreyfus-skill-acquisition.de.adoc
+++ b/docs/anchors/dreyfus-skill-acquisition.de.adoc
@@ -4,6 +4,7 @@
 :related: blooms-taxonomy, feynman-technique, 4mat
 :proponents: Stuart Dreyfus, Hubert Dreyfus
 :tags: skill-acquisition, learning, expertise, mentoring, competence
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/dreyfus-skill-acquisition.de.adoc
+++ b/docs/anchors/dreyfus-skill-acquisition.de.adoc
@@ -1,0 +1,56 @@
+= Dreyfus Model of Skill Acquisition
+:categories: knowledge-management
+:roles: educator, consultant, team-lead
+:related: blooms-taxonomy, feynman-technique, 4mat
+:proponents: Stuart Dreyfus, Hubert Dreyfus
+:tags: skill-acquisition, learning, expertise, mentoring, competence
+
+[%collapsible]
+====
+Vollständiger Name:: Dreyfus Model of Skill Acquisition nach Stuart E. und Hubert L. Dreyfus
+
+Auch bekannt als:: Five-Stage Model of Adult Skill Acquisition, Novice-to-Expert-Modell
+
+[discrete]
+== *Kernkonzepte*:
+
+Fünf Stufen::
++
+Novice (Anfänger)::: Folgt kontextfreien Regeln starr; erkennt keine situativen Nuancen; benötigt explizite Anweisungen
+Advanced Beginner (Fortgeschrittener Anfänger)::: Wendet aus Erfahrung gewonnene situative Maximen an; noch regelorientiert, beginnt aber den Kontext zu lesen
+Competent (Kompetent)::: Plant bewusst und setzt Ziele; bewältigt Komplexität durch gezielte Auswahl des Wesentlichen; übernimmt Verantwortung für Ergebnisse
+Proficient (Gewandt)::: Nimmt Situationen ganzheitlich wahr; Intuition entsteht, Reaktionen werden aber noch analytisch entschieden
+Expert (Experte)::: Handelt mit fließender, intuitiver Meisterschaft; Wahrnehmung und Handlung verschmelzen; deliberiert nur, wenn etwas Unbekanntes auftaucht
+
+Übergang von analytisch zu intuitiv:: Kompetenz entwickelt sich vom distanzierten Regelbefolgen hin zu involvierter, intuitiver Mustererkennung — nicht durch das Anhäufen weiterer Regeln
+
+Stufengerechte Vermittlung:: Jede Stufe braucht eine andere Art der Anleitung; Anfänger wollen Regeln und Rezepte, Experten wollen ganzheitlichen Kontext und werden durch Schritt-für-Schritt-Regeln behindert
+
+Schlüsselvertreter:: Stuart E. und Hubert L. Dreyfus, https://www.researchgate.net/publication/235125013_A_Five-Stage_Model_of_the_Mental_Activities_Involved_in_Directed_Skill_Acquisition["A Five-Stage Model of the Mental Activities Involved in Directed Skill Acquisition"] (1980, UC Berkeley Operations Research Center für das U.S. Air Force Office of Scientific Research); angewendet auf die Pflege durch Patricia Benner ("From Novice to Expert", 1984) und auf Software durch Andy Hunt ("Pragmatic Thinking and Learning: Refactor Your Wetware", 2008)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Anpassung der Vermittlungs- oder Erklärungstiefe an die Stufe der lernenden Person
+* Gestaltung von Mentoring- und Onboarding-Pfaden, die Menschen von Regeln zur Intuition führen
+* Diagnose, warum regellastige Dokumentation Anfängern hilft, Experten aber frustriert
+* Strukturierung von Kompetenzrahmen und Skill-Matrizen für ein Team
+* Festlegung, wie ein LLM die Granularität seiner Anleitung an die Expertise der Nutzenden anpassen soll
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<blooms-taxonomy,Bloom's Taxonomy>>
+* <<feynman-technique,Feynman Technique>>
+* <<4mat,4MAT>>
+
+[discrete]
+== *Kritik*:
+
+* Fernand Gobet und Philippe Chassy, https://www.tandfonline.com/doi/full/10.3402/meo.v15i0.4846["The Dreyfus model of clinical problem-solving skills acquisition: a critical perspective"] sowie ihr Beitrag von 2008 im _International Journal of Nursing Studies_ (45: 129-139) — argumentieren, dass es keine empirischen Belege für klar abgegrenzte Stufen in der Entwicklung von Expertise gibt und dass Experten tatsächlich langsames analytisches Problemlösen einsetzen (z. B. Vorausberechnung im Schach), entgegen der These des Modells, Experten handelten nur intuitiv; sie schlagen eine alternative Theorie der Intuition auf Basis von Chunking vor
+
+[discrete]
+== *Aktueller Status*:
+
+* Die Dreyfus-Brüder ergänzten später eine sechste Stufe der *Meisterschaft* und reformulierten das Modell (Rousse & Dreyfus, https://philarchive.org/archive/ROURTS["Revisiting the Six Stages of Skill Acquisition"]); Trainingsdaten-Priors spiegeln meist die ursprüngliche Fünf-Stufen-Version wider, die durch Benner und Hunt verbreitet wurde
+====

--- a/docs/anchors/effective-java.adoc
+++ b/docs/anchors/effective-java.adoc
@@ -1,0 +1,58 @@
+= Effective Java
+:categories: development-workflow
+:roles: software-developer, software-architect
+:related: effective-go, gof-builder-pattern, solid-principles
+:proponents: Joshua Bloch
+:tags: java, best-practices, idiomatic, api-design, style-guide
+:tier: 3
+
+[%collapsible]
+====
+
+[discrete]
+== *Core Concepts*:
+
+Items format:: A catalog of ~90 short, self-contained "Items", each a concrete best-practice rule with rationale and trade-offs
+
+Object creation:: Static factory methods over constructors; the Builder pattern for many parameters; enforce singletons and non-instantiability deliberately
+
+The general object contracts:: Obey the `equals`/`hashCode`/`compareTo`/`clone` contracts; always override `hashCode` when overriding `equals`; consistently override `toString`
+
+Classes and interfaces:: Minimize accessibility and mutability (favour immutable classes); favour composition over inheritance; prefer interfaces to abstract classes; design and document for inheritance or prohibit it
+
+Generics:: Eliminate unchecked warnings; prefer lists to arrays and generic types/methods; use bounded wildcards by the PECS rule (Producer-Extends, Consumer-Super)
+
+Enums and annotations:: Use enums instead of `int` constants; use the `EnumMap`/`EnumSet`; prefer annotations to naming patterns; consistently use `@Override`
+
+Lambdas and streams:: Prefer lambdas to anonymous classes and method references to lambdas; use streams judiciously and favour side-effect-free functions (Java 8 features, added in the 3rd edition)
+
+Methods and exceptions:: Check parameters for validity; design method signatures carefully; use exceptions only for exceptional conditions; favour standard exceptions; document all thrown exceptions
+
+Resource and concurrency hygiene:: Prefer try-with-resources to `try`-`finally`; prefer executors and tasks to threads; favour concurrency utilities over `wait`/`notify`; document thread safety
+
+Key Proponent:: Joshua Bloch ("Effective Java", Addison-Wesley) — former Sun/Google engineer who led the design of the Java Collections Framework and other core APIs
+
+[discrete]
+== *When to Use*:
+
+* Onboarding Java developers to idiomatic, robust API and class design
+* Code review discussions grounded in a shared, citable rule set ("Item 17: minimize mutability")
+* Establishing team-wide Java coding standards and design conventions
+* Explaining Java-specific contracts (`equals`/`hashCode`, generics, PECS) and their pitfalls
+* Prompting an LLM to produce idiomatic, robust Java code
+
+[discrete]
+== *Related Anchors*:
+
+* <<effective-go,Effective Go>>
+* <<gof-builder-pattern,Builder Pattern>>
+* <<solid-principles,SOLID Principles>>
+
+[discrete]
+== *Current Status*:
+
+* The 3rd edition (Addison-Wesley, https://www.pearson.com/en-us/subject-catalog/p/effective-java/P200000000138/9780134685991[published December 2017], commonly cited as 2018) is the current edition. It added items for Java 7-9 features — lambdas, streams, the `java.time` package, and try-with-resources
+* Because it predates Java's six-month release cadence, some Item advice now has newer language alternatives: *records* (Java 16) replace much hand-written immutable-class and Builder boilerplate; *sealed classes* (Java 17) and *pattern matching for `switch`* (Java 21) supersede some inheritance and `instanceof` guidance; *virtual threads* (Java 21) change the "prefer executors to threads" calculus
+* The book's design principles (favour immutability, composition over inheritance, the object contracts, PECS) remain valid; only the mechanics for some Items have shifted. A training-data prior keyed on "Effective Java" most plausibly reflects the 3rd edition and is therefore silent on records, sealed classes, and virtual threads
+
+====

--- a/docs/anchors/effective-java.de.adoc
+++ b/docs/anchors/effective-java.de.adoc
@@ -4,6 +4,7 @@
 :related: effective-go, gof-builder-pattern, solid-principles
 :proponents: Joshua Bloch
 :tags: java, best-practices, idiomatic, api-design, style-guide
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/effective-java.de.adoc
+++ b/docs/anchors/effective-java.de.adoc
@@ -1,0 +1,57 @@
+= Effective Java
+:categories: development-workflow
+:roles: software-developer, software-architect
+:related: effective-go, gof-builder-pattern, solid-principles
+:proponents: Joshua Bloch
+:tags: java, best-practices, idiomatic, api-design, style-guide
+
+[%collapsible]
+====
+
+[discrete]
+== *Kernkonzepte*:
+
+Item-Format:: Ein Katalog von ~90 kurzen, in sich geschlossenen "Items", jedes eine konkrete Best-Practice-Regel mit Begründung und Trade-offs
+
+Objekterzeugung:: Statische Factory-Methoden statt Konstruktoren; das Builder-Pattern bei vielen Parametern; Singletons und Nicht-Instanziierbarkeit bewusst erzwingen
+
+Die allgemeinen Objekt-Verträge:: Die Verträge von `equals`/`hashCode`/`compareTo`/`clone` einhalten; bei Überschreiben von `equals` stets `hashCode` überschreiben; `toString` konsistent überschreiben
+
+Klassen und Interfaces:: Sichtbarkeit und Veränderlichkeit minimieren (unveränderliche Klassen bevorzugen); Komposition statt Vererbung; Interfaces gegenüber abstrakten Klassen bevorzugen; für Vererbung entwerfen und dokumentieren oder sie verbieten
+
+Generics:: Unchecked-Warnungen beseitigen; Listen gegenüber Arrays und generische Typen/Methoden bevorzugen; beschränkte Wildcards nach der PECS-Regel (Producer-Extends, Consumer-Super) verwenden
+
+Enums und Annotationen:: Enums statt `int`-Konstanten verwenden; `EnumMap`/`EnumSet` nutzen; Annotationen gegenüber Namenskonventionen bevorzugen; `@Override` konsequent verwenden
+
+Lambdas und Streams:: Lambdas gegenüber anonymen Klassen und Methodenreferenzen gegenüber Lambdas bevorzugen; Streams mit Bedacht einsetzen und seiteneffektfreie Funktionen bevorzugen (Java-8-Features, ergänzt in der 3. Auflage)
+
+Methoden und Exceptions:: Parameter auf Gültigkeit prüfen; Methodensignaturen sorgfältig entwerfen; Exceptions nur für Ausnahmesituationen verwenden; Standard-Exceptions bevorzugen; alle geworfenen Exceptions dokumentieren
+
+Ressourcen- und Nebenläufigkeits-Hygiene:: try-with-resources gegenüber `try`-`finally` bevorzugen; Executors und Tasks gegenüber Threads bevorzugen; Concurrency-Utilities gegenüber `wait`/`notify` bevorzugen; Thread-Sicherheit dokumentieren
+
+Schlüsselvertreter:: Joshua Bloch ("Effective Java", Addison-Wesley) — ehemaliger Sun-/Google-Ingenieur, der den Entwurf des Java Collections Framework und anderer Kern-APIs leitete
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einarbeitung von Java-Entwicklern in idiomatisches, robustes API- und Klassendesign
+* Code-Review-Diskussionen auf Basis eines gemeinsamen, zitierbaren Regelsatzes ("Item 17: minimize mutability")
+* Etablierung teamweiter Java-Coding-Standards und Design-Konventionen
+* Erklärung Java-spezifischer Verträge (`equals`/`hashCode`, Generics, PECS) und ihrer Fallstricke
+* Aufforderung an ein LLM, idiomatischen, robusten Java-Code zu erzeugen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<effective-go,Effective Go>>
+* <<gof-builder-pattern,Builder Pattern>>
+* <<solid-principles,SOLID Principles>>
+
+[discrete]
+== *Aktueller Status*:
+
+* Die 3. Auflage (Addison-Wesley, https://www.pearson.com/en-us/subject-catalog/p/effective-java/P200000000138/9780134685991[erschienen im Dezember 2017], häufig als 2018 zitiert) ist die aktuelle Auflage. Sie ergänzte Items für Java-7-9-Features — Lambdas, Streams, das `java.time`-Paket und try-with-resources
+* Da sie dem Sechs-Monats-Release-Zyklus von Java vorausgeht, gibt es zu einigen Items inzwischen neuere Sprachalternativen: *Records* (Java 16) ersetzen viel handgeschriebenen Boilerplate für unveränderliche Klassen und Builder; *Sealed Classes* (Java 17) und *Pattern Matching für `switch`* (Java 21) lösen einen Teil der Vererbungs- und `instanceof`-Empfehlungen ab; *Virtual Threads* (Java 21) verändern die Abwägung "Executors statt Threads bevorzugen"
+* Die Designprinzipien des Buches (Unveränderlichkeit bevorzugen, Komposition statt Vererbung, die Objekt-Verträge, PECS) bleiben gültig; nur die Mechanik einiger Items hat sich verschoben. Ein auf "Effective Java" geprägter Trainingsdaten-Prior spiegelt am ehesten die 3. Auflage wider und schweigt daher zu Records, Sealed Classes und Virtual Threads
+
+====

--- a/docs/anchors/eisenhower-matrix.adoc
+++ b/docs/anchors/eisenhower-matrix.adoc
@@ -1,0 +1,50 @@
+= Eisenhower Matrix
+:categories: strategic-planning
+:roles: team-lead, product-owner, consultant
+:related: mece, cynefin-framework, decisional-balance-sheet
+:proponents: Dwight D. Eisenhower, Stephen Covey
+:tags: prioritization, time-management, urgency, importance, productivity
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: Urgent-Important Matrix, Eisenhower Box, Time Management Matrix
+
+[discrete]
+== *Core Concepts*:
+
+Two axes:: Every task is plotted on two independent dimensions — *urgency* (does it demand attention now?) and *importance* (does it contribute to your goals and values?). The central insight is that the two are not the same.
+
+Four quadrants:: The 2x2 grid yields four prioritization actions::
++
+Do (urgent + important)::: Crises, deadlines, pressing problems — handle immediately yourself
+Schedule (important, not urgent)::: Planning, prevention, relationship-building, learning — block time deliberately; Covey calls this Quadrant II "the heart of effective personal management"
+Delegate (urgent, not important)::: Interruptions, some meetings and calls — hand to someone else
+Delete (neither urgent nor important)::: Busywork, trivia, time-wasters — drop entirely
+
+Key Proponents:: Dwight D. Eisenhower (attrib.) — popularized the urgent/important distinction in an https://quoteinvestigator.com/2014/05/09/urgent/[August 19, 1954 speech] to the World Council of Churches, where he quoted an unnamed "former college president" (popularly traced to Dr J. Roscoe Miller, president of Northwestern University): "I have two kinds of problems, the urgent and the important. The urgent are not important, and the important are never urgent." Stephen R. Covey turned the distinction into the four-quadrant "Time Management Matrix" in *The 7 Habits of Highly Effective People* (1989), Habit 3 ("Put First Things First")
+
+[discrete]
+== *When to Use*:
+
+* Triaging a backlog or to-do list when everything feels equally pressing
+* Coaching teams to separate genuine importance from manufactured urgency
+* Personal time management and weekly planning
+* Deciding what to do, delegate, defer, or drop
+
+[discrete]
+== *Related Anchors*:
+
+* <<mece,MECE>>
+* <<cynefin-framework,Cynefin Framework>>
+* <<decisional-balance-sheet,Decisional Balance Sheet>>
+
+[discrete]
+== *Criticism*:
+
+* Meng Zhu, Yang Yang & Christopher K. Hsee, https://academic.oup.com/jcr/article-abstract/45/3/673/4847790["The Mere Urgency Effect", Journal of Consumer Research 45(3): 673–690] (2018; open copy: https://pmc.ncbi.nlm.nih.gov/articles/PMC10159458/[PMC10159458]) — across five experiments people systematically chose tasks merely because they were urgent, even when those tasks were objectively worse than important alternatives. This "mere urgency effect" suggests the matrix's clean two-axis logic fights a deep cognitive bias: simply *seeing* the axes does not stop people from over-weighting urgency.
+* Stephen Covey himself, in https://www.franklincovey.com/the-7-habits/[The 7 Habits], cautions that an urgency-driven life crowds out Quadrant II ("important, not urgent") — the very quadrant he calls the heart of effectiveness. The critique is internal to the framework: its proponent warns the matrix is easy to misuse by living reactively in Quadrants I and III.
+* General critique that a 2x2 grid oversimplifies prioritization — it treats "importance" and "urgency" as binary and independent, ignoring dependencies, effort/cost, value magnitude, and time-decay, dimensions that richer methods (e.g. weighted scoring, cost-of-delay) make explicit.
+
+The Criticism section reports the discourse; it does not adjudicate it.
+====

--- a/docs/anchors/eisenhower-matrix.de.adoc
+++ b/docs/anchors/eisenhower-matrix.de.adoc
@@ -1,0 +1,49 @@
+= Eisenhower Matrix
+:categories: strategic-planning
+:roles: team-lead, product-owner, consultant
+:related: mece, cynefin-framework, decisional-balance-sheet
+:proponents: Dwight D. Eisenhower, Stephen Covey
+:tags: prioritization, time-management, urgency, importance, productivity
+
+[%collapsible]
+====
+Auch bekannt als:: Dringend-Wichtig-Matrix, Eisenhower-Box, Time Management Matrix
+
+[discrete]
+== *Kernkonzepte*:
+
+Zwei Achsen:: Jede Aufgabe wird auf zwei unabhängigen Dimensionen verortet — *Dringlichkeit* (verlangt sie jetzt Aufmerksamkeit?) und *Wichtigkeit* (trägt sie zu Zielen und Werten bei?). Die zentrale Einsicht: Beides ist nicht dasselbe.
+
+Vier Quadranten:: Das 2x2-Raster ergibt vier Priorisierungs-Aktionen::
++
+Erledigen (dringend + wichtig)::: Krisen, Deadlines, drängende Probleme — sofort selbst bearbeiten
+Planen (wichtig, nicht dringend)::: Planung, Prävention, Beziehungspflege, Lernen — bewusst Zeit blocken; Covey nennt diesen Quadranten II "das Herz wirksamer persönlicher Führung"
+Delegieren (dringend, nicht wichtig)::: Unterbrechungen, manche Meetings und Anrufe — an andere abgeben
+Streichen (weder dringend noch wichtig)::: Beschäftigung, Belangloses, Zeitfresser — ganz weglassen
+
+Schlüsselvertreter:: Dwight D. Eisenhower (zugeschrieben) — popularisierte die Dringend/Wichtig-Unterscheidung in einer https://quoteinvestigator.com/2014/05/09/urgent/[Rede vom 19. August 1954] vor dem Ökumenischen Rat der Kirchen, in der er einen ungenannten "ehemaligen Universitätspräsidenten" zitierte (gemeinhin Dr J. Roscoe Miller, Präsident der Northwestern University, zugeschrieben): "I have two kinds of problems, the urgent and the important. The urgent are not important, and the important are never urgent." Stephen R. Covey machte daraus die Vier-Quadranten-"Time Management Matrix" in *The 7 Habits of Highly Effective People* (1989), Habit 3 ("Put First Things First")
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Triage einer Aufgabenliste, wenn alles gleich dringend erscheint
+* Teams coachen, echte Wichtigkeit von erzeugter Dringlichkeit zu trennen
+* Persönliches Zeitmanagement und Wochenplanung
+* Entscheiden, was zu tun, delegieren, aufschieben oder streichen ist
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<mece,MECE>>
+* <<cynefin-framework,Cynefin Framework>>
+* <<decisional-balance-sheet,Decisional Balance Sheet>>
+
+[discrete]
+== *Kritik*:
+
+* Meng Zhu, Yang Yang & Christopher K. Hsee, https://academic.oup.com/jcr/article-abstract/45/3/673/4847790["The Mere Urgency Effect", Journal of Consumer Research 45(3): 673–690] (2018; freie Kopie: https://pmc.ncbi.nlm.nih.gov/articles/PMC10159458/[PMC10159458]) — in fünf Experimenten wählten Menschen systematisch Aufgaben allein wegen ihrer Dringlichkeit, selbst wenn diese objektiv schlechter waren als wichtige Alternativen. Dieser "mere urgency effect" legt nahe, dass die saubere Zwei-Achsen-Logik der Matrix gegen eine tiefe kognitive Verzerrung ankämpft: Die Achsen bloß zu *sehen* hindert Menschen nicht daran, Dringlichkeit überzugewichten.
+* Stephen Covey selbst warnt in https://www.franklincovey.com/the-7-habits/[The 7 Habits], dass ein von Dringlichkeit getriebenes Leben den Quadranten II ("wichtig, nicht dringend") verdrängt — genau jenen Quadranten, den er das Herz der Wirksamkeit nennt. Die Kritik ist dem Framework selbst eigen: Sein Urheber warnt, dass die Matrix leicht missbraucht wird, indem man reaktiv in den Quadranten I und III lebt.
+* Allgemeine Kritik, dass ein 2x2-Raster Priorisierung übervereinfacht — es behandelt "Wichtigkeit" und "Dringlichkeit" als binär und unabhängig und ignoriert Abhängigkeiten, Aufwand/Kosten, Wertgröße und Zeit-Verfall, also Dimensionen, die reichere Methoden (z. B. gewichtete Bewertung, Cost of Delay) explizit machen.
+
+Der Kritik-Abschnitt gibt den Diskurs wieder; er entscheidet ihn nicht.
+====

--- a/docs/anchors/eisenhower-matrix.de.adoc
+++ b/docs/anchors/eisenhower-matrix.de.adoc
@@ -4,6 +4,7 @@
 :related: mece, cynefin-framework, decisional-balance-sheet
 :proponents: Dwight D. Eisenhower, Stephen Covey
 :tags: prioritization, time-management, urgency, importance, productivity
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/fermi-estimation.adoc
+++ b/docs/anchors/fermi-estimation.adoc
@@ -1,0 +1,45 @@
+= Fermi Estimation
+:categories: problem-solving
+:roles: software-architect, data-scientist, software-developer, consultant
+:related: first-principles-thinking, mece, five-whys
+:proponents: Enrico Fermi
+:tags: estimation, order-of-magnitude, back-of-envelope, approximation, decomposition
+:tier: 3
+
+[%collapsible]
+====
+Also known as:: Order-of-Magnitude Estimation, Back-of-the-Envelope Calculation, Fermi Problem, Guesstimation
+
+[discrete]
+== *Core Concepts*:
+
+Decomposition:: Break an unknown quantity into a chain of smaller sub-quantities you can each estimate with some confidence
+
+Order-of-magnitude reasoning:: Reason in powers of ten; aim to land the right power of ten rather than an exact figure
+
+Bracketing:: For each sub-quantity, pick a plausible lower and upper bound, then take the geometric mean of the bounds as the estimate
+
+Error cancellation:: Independent over- and under-estimates tend to cancel, so the product of many rough guesses is often within a factor of 2-3 of the true value
+
+Sanity check / sizing:: Use the estimate to test whether a claim, design, or measured number is even plausible before investing in precision
+
+The piano-tuner problem:: Fermi's classic teaching example — "How many piano tuners are there in Chicago?" — solved by chaining population, pianos per household, tuning frequency, and tuner throughput
+
+Key Proponents:: Enrico Fermi (estimated the Trinity-test yield by dropping paper scraps in the blast wave, landing within an order of magnitude); Lawrence Weinstein and John A. Adam (https://press.princeton.edu/books/paperback/9780691129495/guesstimation["Guesstimation: Solving the World's Problems on the Back of a Cocktail Napkin"], Princeton University Press, 2008)
+
+[discrete]
+== *When to Use*:
+
+* Sizing a system before committing to detailed analysis (capacity, cost, traffic)
+* Build-vs-buy and feasibility checks where exact numbers are unavailable
+* Interview and whiteboard estimation problems
+* Validating a surprising metric or vendor claim against rough physical limits
+* Prompting an LLM to sanity-check a quantitative estimate by decomposing it and reasoning in powers of ten
+
+[discrete]
+== *Related Anchors*:
+
+* <<first-principles-thinking,First Principles Thinking>>
+* <<mece,MECE>>
+* <<five-whys,Five Whys>>
+====

--- a/docs/anchors/fermi-estimation.de.adoc
+++ b/docs/anchors/fermi-estimation.de.adoc
@@ -4,6 +4,7 @@
 :related: first-principles-thinking, mece, five-whys
 :proponents: Enrico Fermi
 :tags: estimation, order-of-magnitude, back-of-envelope, approximation, decomposition
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/fermi-estimation.de.adoc
+++ b/docs/anchors/fermi-estimation.de.adoc
@@ -1,0 +1,44 @@
+= Fermi Estimation
+:categories: problem-solving
+:roles: software-architect, data-scientist, software-developer, consultant
+:related: first-principles-thinking, mece, five-whys
+:proponents: Enrico Fermi
+:tags: estimation, order-of-magnitude, back-of-envelope, approximation, decomposition
+
+[%collapsible]
+====
+Auch bekannt als:: Order-of-Magnitude Estimation, Back-of-the-Envelope Calculation, Fermi-Problem, Guesstimation
+
+[discrete]
+== *Kernkonzepte*:
+
+Zerlegung:: Eine unbekannte Größe in eine Kette kleinerer Teilgrößen aufteilen, die sich jeweils mit gewisser Sicherheit schätzen lassen
+
+Größenordnungs-Denken:: In Zehnerpotenzen denken; das Ziel ist die richtige Zehnerpotenz, nicht der exakte Wert
+
+Eingrenzung (Bracketing):: Für jede Teilgröße eine plausible Unter- und Obergrenze wählen und das geometrische Mittel der Grenzen als Schätzwert nehmen
+
+Fehlerausgleich:: Unabhängige Über- und Unterschätzungen heben sich tendenziell auf, sodass das Produkt vieler grober Schätzungen oft innerhalb eines Faktors 2-3 vom wahren Wert liegt
+
+Plausibilitätsprüfung / Dimensionierung:: Mit der Schätzung prüfen, ob eine Behauptung, ein Design oder eine gemessene Zahl überhaupt plausibel ist, bevor man in Präzision investiert
+
+Das Klavierstimmer-Problem:: Fermis klassisches Lehrbeispiel — "Wie viele Klavierstimmer gibt es in Chicago?" — gelöst durch Verkettung von Bevölkerung, Klavieren pro Haushalt, Stimmhäufigkeit und Durchsatz pro Stimmer
+
+Schlüsselvertreter:: Enrico Fermi (schätzte die Sprengkraft des Trinity-Tests, indem er Papierschnipsel in die Druckwelle fallen ließ, und lag innerhalb einer Größenordnung); Lawrence Weinstein und John A. Adam (https://press.princeton.edu/books/paperback/9780691129495/guesstimation["Guesstimation: Solving the World's Problems on the Back of a Cocktail Napkin"], Princeton University Press, 2008)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Dimensionierung eines Systems vor detaillierter Analyse (Kapazität, Kosten, Traffic)
+* Build-vs-Buy- und Machbarkeitsprüfungen, wenn exakte Zahlen fehlen
+* Schätzaufgaben in Interviews und am Whiteboard
+* Prüfung einer überraschenden Kennzahl oder Hersteller-Behauptung gegen grobe physikalische Grenzen
+* Einen LLM auffordern, eine quantitative Schätzung zu plausibilisieren, indem er sie zerlegt und in Zehnerpotenzen rechnet
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<first-principles-thinking,First Principles Thinking>>
+* <<mece,MECE>>
+* <<five-whys,Five Whys>>
+====

--- a/docs/anchors/four-sides-model.adoc
+++ b/docs/anchors/four-sides-model.adoc
@@ -1,0 +1,40 @@
+= Four-Sides Model (Schulz von Thun)
+:categories: communication-presentation
+:roles: consultant, team-lead, educator
+:proponents: Friedemann Schulz von Thun
+:tags: communication, psychology, message, misunderstanding, interpersonal
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: Four-Sides Model of Communication according to Friedemann Schulz von Thun
+
+Also known as:: Communication Square, Four-Ears Model, Vier-Seiten-Modell
+
+[discrete]
+== *Core Concepts*:
+
+Four sides of a message:: Every message carries four facets simultaneously; the sender speaks with "four beaks" and the receiver listens with "four ears"
++
+Factual information (Sachinhalt)::: The data and facts the message states; the receiver checks it for truth, relevance, and completeness
+Self-revelation (Selbstoffenbarung)::: What the message discloses about the sender — motives, values, emotions, intentions, consciously or not
+Relationship (Beziehung)::: What the sender thinks of the receiver and how they stand to each other, carried by tone, phrasing, and body language
+Appeal (Appell)::: What the sender wants the receiver to do, think, or feel — open advice or hidden manipulation
+
+Four ears:: The receiver decodes through four matching ears; a one-sidedly developed ear (for example an over-sensitive relationship ear) causes recurring misunderstanding
+
+Mismatched ears:: Misunderstanding arises when the sender stresses one side but the receiver hears another; the classic example is the passenger saying "The traffic light is green" — a factual remark heard as an appeal or a relationship message
+
+Theoretical roots:: Combines Karl Bühler's Organon model (sender, receiver, subject) with Paul Watzlawick's axiom that every message has a content and a relationship aspect
+
+Key Proponents:: Friedemann Schulz von Thun ("Miteinander reden 1: Störungen und Klärungen", 1981)
+
+[discrete]
+== *When to Use*:
+
+* Diagnosing recurring misunderstandings in teams or coaching conversations
+* Teaching active listening and feedback skills
+* Giving or receiving feedback by separating the factual side from the relationship side
+* Defusing conflict by surfacing the self-revelation and appeal layers of a charged statement
+* Prompting an LLM to analyze a message on all four communication levels
+====

--- a/docs/anchors/four-sides-model.de.adoc
+++ b/docs/anchors/four-sides-model.de.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator
 :proponents: Friedemann Schulz von Thun
 :tags: communication, psychology, message, misunderstanding, interpersonal
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/four-sides-model.de.adoc
+++ b/docs/anchors/four-sides-model.de.adoc
@@ -1,0 +1,39 @@
+= Vier-Seiten-Modell (Schulz von Thun)
+:categories: communication-presentation
+:roles: consultant, team-lead, educator
+:proponents: Friedemann Schulz von Thun
+:tags: communication, psychology, message, misunderstanding, interpersonal
+
+[%collapsible]
+====
+Vollständiger Name:: Vier-Seiten-Modell der Kommunikation nach Friedemann Schulz von Thun
+
+Auch bekannt als:: Kommunikationsquadrat, Vier-Ohren-Modell, Four-Sides Model
+
+[discrete]
+== *Kernkonzepte*:
+
+Vier Seiten einer Nachricht:: Jede Nachricht trägt vier Aspekte zugleich; der Sender spricht mit "vier Schnäbeln", der Empfänger hört mit "vier Ohren"
++
+Sachinhalt::: Die Daten und Fakten, über die die Nachricht informiert; der Empfänger prüft sie auf Wahrheit, Relevanz und Vollständigkeit
+Selbstoffenbarung::: Was die Nachricht über den Sender preisgibt — Motive, Werte, Gefühle, Absichten, bewusst oder unbewusst
+Beziehung::: Was der Sender vom Empfänger hält und wie beide zueinander stehen, transportiert über Ton, Formulierung und Körpersprache
+Appell::: Wozu der Sender den Empfänger bewegen will — offene Bitte oder verdeckte Manipulation
+
+Vier Ohren:: Der Empfänger entschlüsselt mit vier passenden Ohren; ein einseitig ausgeprägtes Ohr (etwa ein überempfindliches Beziehungsohr) führt zu wiederkehrenden Missverständnissen
+
+Unpassende Ohren:: Missverständnisse entstehen, wenn der Sender eine Seite betont, der Empfänger aber eine andere hört; das klassische Beispiel ist die Aussage "Die Ampel ist grün" — eine Sachaussage, die als Appell oder Beziehungsbotschaft gehört wird
+
+Theoretische Wurzeln:: Verbindet Karl Bühlers Organon-Modell (Sender, Empfänger, Gegenstand) mit Paul Watzlawicks Axiom, dass jede Nachricht einen Inhalts- und einen Beziehungsaspekt hat
+
+Schlüsselvertreter:: Friedemann Schulz von Thun ("Miteinander reden 1: Störungen und Klärungen", 1981)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Diagnose wiederkehrender Missverständnisse in Teams oder im Coaching
+* Vermittlung von aktivem Zuhören und Feedback-Kompetenzen
+* Feedback geben oder nehmen, indem man die Sachseite von der Beziehungsseite trennt
+* Konflikte entschärfen, indem man die Selbstoffenbarungs- und Appellebene einer aufgeladenen Aussage sichtbar macht
+* Eine LLM auffordern, eine Nachricht auf allen vier Kommunikationsebenen zu analysieren
+====

--- a/docs/anchors/laddering.adoc
+++ b/docs/anchors/laddering.adoc
@@ -1,0 +1,57 @@
+= Laddering (Interview Technique)
+:categories: requirements-engineering
+:roles: business-analyst, ux-designer, product-owner
+:related: five-whys, jobs-to-be-done
+:proponents: George Kelly, Dennis Hinkle, Thomas Reynolds, Jonathan Gutman
+:tags: interview, elicitation, means-end, user-research, requirements
+:tier: 3
+
+[%collapsible]
+====
+Also known as:: Means-End Laddering, Laddering Interview
+
+[discrete]
+== *Core Concepts*:
+
+Means-end chain:: A laddering interview reconstructs the chain attribute -> consequence -> value: a concrete feature of a product or solution, the consequence it produces for the user, and the personal value that consequence serves. The chain is the unit of insight, not any single answer.
+
+Laddering up:: Probe toward abstraction with "Why is that important to you?" repeatedly, climbing from attributes through consequences toward the respondent's underlying goals and values.
+
+Laddering down:: Probe toward specifics with "How?" or "Can you give an example?" to move from a stated value or abstract need back down to concrete attributes and observable behaviour.
+
+Bidirectional movement:: Unlike single-direction questioning, a skilled interviewer moves both up and down the ladder within one session to map the whole value hierarchy and to verify links.
+
+Contrast with Five Whys:: Five Whys is a unidirectional root-cause technique that drills down one causal chain to a single defect or systemic cause. Laddering is bidirectional and surfaces a hierarchy of personal values and motivations, not a single root cause — it asks "why does this matter to *you*" (motivational), not "why did this fail" (causal).
+
+Hierarchical value map:: The aggregate analytical output across respondents — a graph linking common attributes, consequences, and values, used to find the dominant means-end paths a design or message should target.
+
+Soft vs. hard laddering:: Soft laddering uses free, probe-driven personal interviews; hard laddering uses structured forms or surveys that force the respondent up the ladder. Soft yields richer data, hard scales better and reduces interviewer bias.
+
+Key Proponents:: George Kelly (Personal Construct Psychology, 1955) and Dennis Hinkle (Ohio State PhD dissertation, 1965, "The change of personal constructs from the viewpoint of a theory of construct implications") originated laddering of constructs; Thomas J. Reynolds and Jonathan Gutman adapted it for means-end marketing research ("Laddering Theory, Method, Analysis, and Interpretation", Journal of Advertising Research, 1988)
+
+[discrete]
+== *When to Use*:
+
+* Eliciting the *why* behind a stated requirement or feature request, when the surface ask hides a deeper goal
+* User and customer research where motivations and personal values drive adoption
+* Designing product messaging, positioning, or value propositions grounded in user values
+* Prioritising features by tracing each back to the value it ultimately serves
+* Moving an interview past superficial preferences toward actionable, goal-level insight
+
+[discrete]
+== *Related Anchors*:
+
+* <<five-whys,Five Whys>>
+* <<jobs-to-be-done,Jobs to be Done>>
+
+[discrete]
+== *Criticism*:
+
+* Klaus G. Grunert and Suzanne C. Grunert, https://doi.org/10.1016/0167-8116(95)00022-T["Measuring subjective meaning structures by the laddering method: Theoretical considerations and methodological problems"] (International Journal of Research in Marketing, 1995) — identify validity threats across data collection, coding, and analysis: respondents may produce post-hoc rationalisations rather than report real cognitive structures, and forced upward probing ("hard" laddering) cannot represent level-skipping chains that genuinely exist in memory.
+* Practitioner accounts warn of interviewer-induced error: leading the respondent with suggestive probes ("Does that make you feel more successful?") and stopping too early by mistaking a consequence for a terminal value (https://www.userintuition.ai/reference-guides/laddering-technique-qualitative-research/[User Intuition, "The Laddering Technique in Qualitative Research"]).
+
+[discrete]
+== *Current Status*:
+
+* Originating in 1950s-60s clinical Personal Construct Psychology, laddering crossed into marketing and consumer research via Reynolds and Gutman (1988) and is now standard in UX research, requirements elicitation, and brand strategy. The hard/soft distinction (Grunert and Grunert, 1995) remains the live methodological axis, with recent work extending laddering to online and remote interview settings.
+====

--- a/docs/anchors/laddering.de.adoc
+++ b/docs/anchors/laddering.de.adoc
@@ -1,0 +1,56 @@
+= Laddering (Interviewtechnik)
+:categories: requirements-engineering
+:roles: business-analyst, ux-designer, product-owner
+:related: five-whys, jobs-to-be-done
+:proponents: George Kelly, Dennis Hinkle, Thomas Reynolds, Jonathan Gutman
+:tags: interview, elicitation, means-end, user-research, requirements
+
+[%collapsible]
+====
+Auch bekannt als:: Means-End Laddering, Laddering Interview
+
+[discrete]
+== *Kernkonzepte*:
+
+Means-End-Kette:: Ein Laddering-Interview rekonstruiert die Kette Attribut -> Konsequenz -> Wert: ein konkretes Merkmal eines Produkts oder einer Lösung, die Konsequenz, die es für den Nutzer erzeugt, und der persönliche Wert, dem diese Konsequenz dient. Die Kette ist die Erkenntniseinheit, nicht eine einzelne Antwort.
+
+Laddering nach oben:: Mit "Warum ist Ihnen das wichtig?" wiederholt in Richtung Abstraktion fragen und so von Attributen über Konsequenzen zu den zugrunde liegenden Zielen und Werten des Befragten aufsteigen.
+
+Laddering nach unten:: Mit "Wie?" oder "Können Sie ein Beispiel geben?" in Richtung Konkretes fragen, um von einem genannten Wert oder abstrakten Bedürfnis zurück zu konkreten Attributen und beobachtbarem Verhalten zu gelangen.
+
+Bidirektionale Bewegung:: Anders als bei einseitigem Fragen bewegt sich eine geübte Interviewerin innerhalb einer Sitzung sowohl nach oben als auch nach unten, um die gesamte Werthierarchie abzubilden und Verknüpfungen zu prüfen.
+
+Abgrenzung zu Five Whys:: Five Whys ist eine unidirektionale Ursachenanalyse, die eine Kausalkette bis zu einem einzelnen Defekt oder einer systemischen Ursache hinunterbohrt. Laddering ist bidirektional und legt eine Hierarchie persönlicher Werte und Motive offen, keine einzelne Grundursache — es fragt "Warum ist das *Ihnen* wichtig" (motivational), nicht "Warum ist das fehlgeschlagen" (kausal).
+
+Hierarchical Value Map:: Das aggregierte Analyseergebnis über alle Befragten — ein Graph, der häufige Attribute, Konsequenzen und Werte verknüpft, um die dominanten Means-End-Pfade zu finden, die ein Design oder eine Botschaft adressieren sollte.
+
+Soft vs. Hard Laddering:: Soft Laddering nutzt freie, sondierende Einzelinterviews; Hard Laddering nutzt strukturierte Formulare oder Umfragen, die den Befragten die Leiter hinaufzwingen. Soft liefert reichere Daten, Hard skaliert besser und reduziert Interviewer-Bias.
+
+Schlüsselvertreter:: George Kelly (Personal Construct Psychology, 1955) und Dennis Hinkle (Dissertation Ohio State, 1965, "The change of personal constructs from the viewpoint of a theory of construct implications") begründeten das Laddering von Konstrukten; Thomas J. Reynolds und Jonathan Gutman adaptierten es für die Means-End-Marktforschung ("Laddering Theory, Method, Analysis, and Interpretation", Journal of Advertising Research, 1988)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Das *Warum* hinter einer genannten Anforderung oder einem Feature-Wunsch herausarbeiten, wenn die Oberflächen-Bitte ein tieferes Ziel verbirgt
+* Nutzer- und Kundenforschung, bei der Motive und persönliche Werte die Akzeptanz treiben
+* Gestaltung von Produktbotschaften, Positionierung oder Wertversprechen auf Basis von Nutzerwerten
+* Priorisierung von Features, indem jedes auf den letztlich bedienten Wert zurückgeführt wird
+* Ein Interview über oberflächliche Präferenzen hinaus zu handlungsleitender Erkenntnis auf Zielebene führen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<five-whys,Five Whys>>
+* <<jobs-to-be-done,Jobs to be Done>>
+
+[discrete]
+== *Kritik*:
+
+* Klaus G. Grunert und Suzanne C. Grunert, https://doi.org/10.1016/0167-8116(95)00022-T["Measuring subjective meaning structures by the laddering method: Theoretical considerations and methodological problems"] (International Journal of Research in Marketing, 1995) — benennen Validitätsrisiken in Datenerhebung, Codierung und Analyse: Befragte liefern möglicherweise nachträgliche Rationalisierungen statt echte kognitive Strukturen, und erzwungenes Aufwärtsfragen ("Hard" Laddering) kann ebenenüberspringende Ketten, die im Gedächtnis tatsächlich existieren, nicht abbilden.
+* Praxisberichte warnen vor interviewerbedingten Fehlern: das Lenken des Befragten durch suggestive Fragen ("Macht Sie das erfolgreicher?") und zu frühes Abbrechen, indem eine Konsequenz mit einem Endwert verwechselt wird (https://www.userintuition.ai/reference-guides/laddering-technique-qualitative-research/[User Intuition, "The Laddering Technique in Qualitative Research"]).
+
+[discrete]
+== *Aktueller Status*:
+
+* Laddering entstand in der klinischen Personal Construct Psychology der 1950er/60er Jahre, gelangte über Reynolds und Gutman (1988) in die Markt- und Konsumforschung und ist heute Standard in UX-Forschung, Anforderungserhebung und Markenstrategie. Die Unterscheidung Hard/Soft (Grunert und Grunert, 1995) bleibt die zentrale methodische Achse, wobei neuere Arbeiten Laddering auf Online- und Remote-Interviewsettings ausweiten.
+====

--- a/docs/anchors/laddering.de.adoc
+++ b/docs/anchors/laddering.de.adoc
@@ -4,6 +4,7 @@
 :related: five-whys, jobs-to-be-done
 :proponents: George Kelly, Dennis Hinkle, Thomas Reynolds, Jonathan Gutman
 :tags: interview, elicitation, means-end, user-research, requirements
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/okr.adoc
+++ b/docs/anchors/okr.adoc
@@ -1,0 +1,63 @@
+= OKR (Objectives and Key Results)
+:categories: strategic-planning
+:roles: product-owner, team-lead, consultant
+:related: definition-of-done
+:proponents: Andy Grove, John Doerr
+:tags: goal-setting, objectives, key-results, alignment, okr
+:tier: 2
+
+[%collapsible]
+====
+Full Name:: Objectives and Key Results
+
+Also known as:: OKRs; descended from Intel's iMBO (Intel Management by Objectives)
+
+[discrete]
+== *Core Concepts*:
+
+Objective:: A single qualitative, inspirational, time-bound statement of *what* you want to achieve; memorable and direction-setting, not a metric
+
+Key Results:: Typically 3-5 quantitative, measurable outcomes that prove the Objective is met; answer *how* you know you got there — outcomes, not a task list
+
+Objective + Key Results:: One Objective is paired with its Key Results; "if the Objective is the destination, the Key Results are the milestones that measure progress toward it"
+
+Quarterly cadence:: OKRs are usually set and reviewed on a quarterly rhythm, nested under annual or strategic OKRs
+
+Ambitious / stretch goals:: Aspirational "moonshot" OKRs are calibrated so that scoring ~0.7 of the way (70%) is considered success; consistently scoring 1.0 signals goals set too low
+
+Grading (0.0-1.0):: At cycle end each Key Result is scored on a 0-1 scale; the score drives a conversation, not a verdict
+
+Transparency / alignment:: OKRs are public across the organization so teams can see and connect to each other's goals; alignment by visibility, not by mechanical cascade
+
+Decoupled from compensation:: OKRs are deliberately separated from bonuses and performance reviews, so people set honest stretch goals instead of sandbagging
+
+Key Proponents:: Andy Grove (originated the approach at Intel as "iMBO", documented in "High Output Management", 1983); John Doerr (learned it from Grove at Intel, introduced it to Google in 1999, popularized it in "Measure What Matters", 2018, https://www.whatmatters.com/[whatmatters.com])
+
+[discrete]
+== *When to Use*:
+
+* Translating strategy into focused, measurable quarterly goals for teams
+* Creating organization-wide alignment and transparency around priorities
+* Shifting a team's focus from output (tasks shipped) to outcomes (value delivered)
+* Setting ambitious stretch goals where ~70% attainment counts as success
+* Prompting an LLM to draft, critique, or grade an Objective with its Key Results
+
+[discrete]
+== *Related Anchors*:
+
+* <<definition-of-done,Definition of Done>>
+
+[discrete]
+== *Criticism*:
+
+* Goodhart's Law ("when a measure becomes a target, it ceases to be a good measure") is the recurring failure mode: once a Key Result is the target, people optimise the number rather than the outcome. McKenna Agile Consultants, https://www.mckennaagileconsultants.com/applying-goodharts-law-in-okrs-avoiding-common-pitfalls-in-strategic-execution/["Applying Goodhart's Law in OKRs"] — the proposed mitigation is to pair quantity KRs with quality/guardrail KRs and to keep OKRs decoupled from rewards
+* Ant Murphy, https://www.antmurphy.me/newsletter/escape-okr-theatre["Escape OKR Theatre"] — *cascading* OKRs assume strategy perfectly mirrors the org chart, which it rarely does; cascading is often a symptom of missing strategy and produces a "sea of OKRs". Murphy argues OKRs should *align, not cascade*, favouring fewer, strategy-derived OKRs
+* "OKR theatre" / performance theatre: teams fluently discuss "driving key metrics" while struggling to name the problem they solve. Bjørn Broum, https://bbroum.substack.com/p/the-okr-performance-theater["The OKR Performance Theater"]
+
+[discrete]
+== *Current Status*:
+
+* The framework remains widely adopted but reportedly hard to sustain: per https://en.wikipedia.org/wiki/Objectives_and_key_results[Wikipedia's OKR article], Google's Rick Klau later advised skipping *individual* OKRs to avoid a waterfall/cascade trap — a shift from the individual-level usage many training-data examples assume
+* The canonical modern reference is Doerr's "Measure What Matters" (2018) and https://www.whatmatters.com/[whatmatters.com]; the original Grove formulation predates the term "OKR" and lives in "High Output Management" (1983)
+
+====

--- a/docs/anchors/okr.de.adoc
+++ b/docs/anchors/okr.de.adoc
@@ -4,6 +4,7 @@
 :related: definition-of-done
 :proponents: Andy Grove, John Doerr
 :tags: goal-setting, objectives, key-results, alignment, okr
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/okr.de.adoc
+++ b/docs/anchors/okr.de.adoc
@@ -1,0 +1,62 @@
+= OKR (Objectives and Key Results)
+:categories: strategic-planning
+:roles: product-owner, team-lead, consultant
+:related: definition-of-done
+:proponents: Andy Grove, John Doerr
+:tags: goal-setting, objectives, key-results, alignment, okr
+
+[%collapsible]
+====
+Vollständiger Name:: Objectives and Key Results
+
+Auch bekannt als:: OKRs; hervorgegangen aus Intels iMBO (Intel Management by Objectives)
+
+[discrete]
+== *Kernkonzepte*:
+
+Objective:: Eine einzelne qualitative, inspirierende, zeitlich begrenzte Aussage darüber, *was* du erreichen willst; einprägsam und richtungsweisend, keine Kennzahl
+
+Key Results:: Typischerweise 3-5 quantitative, messbare Ergebnisse, die belegen, dass das Objective erreicht ist; sie beantworten, *woran* du das erkennst — Outcomes, keine Aufgabenliste
+
+Objective + Key Results:: Ein Objective wird mit seinen Key Results gepaart; "ist das Objective das Ziel, sind die Key Results die Meilensteine, die den Fortschritt messen"
+
+Quartals-Rhythmus:: OKRs werden meist im Quartalsrhythmus gesetzt und überprüft, eingebettet in jährliche oder strategische OKRs
+
+Ambitionierte / Stretch-Goals:: Aspirational "Moonshot"-OKRs sind so kalibriert, dass ein Erreichen von ~0,7 (70 %) bereits als Erfolg gilt; durchgängig 1,0 zu erreichen signalisiert zu niedrig gesteckte Ziele
+
+Bewertung (0,0-1,0):: Am Zyklusende wird jedes Key Result auf einer Skala von 0 bis 1 bewertet; der Wert treibt ein Gespräch an, kein Urteil
+
+Transparenz / Alignment:: OKRs sind organisationsweit öffentlich, sodass Teams die Ziele der anderen sehen und sich daran ausrichten können; Alignment durch Sichtbarkeit, nicht durch mechanisches Kaskadieren
+
+Entkoppelt von der Vergütung:: OKRs werden bewusst von Boni und Leistungsbeurteilungen getrennt, damit Menschen ehrliche Stretch-Goals setzen statt zu untertreiben
+
+Schlüsselvertreter:: Andy Grove (begründete den Ansatz bei Intel als "iMBO", dokumentiert in "High Output Management", 1983); John Doerr (lernte ihn bei Intel von Grove, führte ihn 1999 bei Google ein, machte ihn mit "Measure What Matters", 2018, populär, https://www.whatmatters.com/[whatmatters.com])
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Übersetzung von Strategie in fokussierte, messbare Quartalsziele für Teams
+* Schaffung organisationsweiter Ausrichtung und Transparenz über Prioritäten
+* Verlagerung des Team-Fokus von Output (gelieferte Aufgaben) zu Outcome (geliefertem Wert)
+* Setzen ambitionierter Stretch-Goals, bei denen ~70 % Zielerreichung als Erfolg zählt
+* Aufforderung an ein LLM, ein Objective mit seinen Key Results zu entwerfen, zu kritisieren oder zu bewerten
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<definition-of-done,Definition of Done>>
+
+[discrete]
+== *Kritik*:
+
+* Goodharts Gesetz ("Wird ein Maß zum Ziel, taugt es nicht mehr als Maß") ist der wiederkehrende Fehlermodus: Sobald ein Key Result das Ziel ist, optimieren Menschen die Zahl statt das Outcome. McKenna Agile Consultants, https://www.mckennaagileconsultants.com/applying-goodharts-law-in-okrs-avoiding-common-pitfalls-in-strategic-execution/["Applying Goodhart's Law in OKRs"] — die vorgeschlagene Gegenmaßnahme ist, Mengen-KRs mit Qualitäts-/Guardrail-KRs zu paaren und OKRs von Belohnungen entkoppelt zu halten
+* Ant Murphy, https://www.antmurphy.me/newsletter/escape-okr-theatre["Escape OKR Theatre"] — *kaskadierende* OKRs setzen voraus, dass die Strategie das Organigramm exakt abbildet, was sie selten tut; Kaskadieren ist oft ein Symptom fehlender Strategie und erzeugt ein "Meer von OKRs". Murphy argumentiert, OKRs sollten *ausrichten, nicht kaskadieren*, und plädiert für wenige, aus der Strategie abgeleitete OKRs
+* "OKR-Theater" / Performance-Theater: Teams sprechen flüssig über "Treiben von Key-Metriken", tun sich aber schwer zu benennen, welches Problem sie lösen. Bjørn Broum, https://bbroum.substack.com/p/the-okr-performance-theater["The OKR Performance Theater"]
+
+[discrete]
+== *Aktueller Status*:
+
+* Das Framework ist weiterhin weit verbreitet, aber Berichten zufolge schwer durchzuhalten: laut https://en.wikipedia.org/wiki/Objectives_and_key_results[Wikipedias OKR-Artikel] riet Googles Rick Klau später davon ab, *individuelle* OKRs zu setzen, um eine Wasserfall-/Kaskaden-Falle zu vermeiden — eine Abkehr von der Nutzung auf Einzelebene, die viele Trainingsdaten-Beispiele annehmen
+* Die kanonische moderne Referenz ist Doerrs "Measure What Matters" (2018) und https://www.whatmatters.com/[whatmatters.com]; die ursprüngliche Grove-Formulierung ist älter als der Begriff "OKR" und steht in "High Output Management" (1983)
+
+====

--- a/docs/anchors/req42.adoc
+++ b/docs/anchors/req42.adoc
@@ -1,0 +1,71 @@
+= req42
+:categories: requirements-engineering
+:roles: business-analyst, software-architect, product-owner
+:related: arc42, ears-requirements, cockburn-use-cases, docs-as-code
+:proponents: Peter Hruschka, Markus Meuten
+:tags: requirements, framework, agile, docs-as-code, arc42
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: req42 — Framework for Pragmatic, Agile Requirements
+
+Also known as:: the requirements companion to arc42
+
+[discrete]
+== *Core Concepts*:
+
+Twelve "drawers":: A lightweight template of twelve sections, deliberately mirroring arc42's structure, for capturing agile requirements without drifting into heavyweight specification. Fill only the drawers a project actually needs.
+
+01 Business Goals:: Why the product exists and what success looks like
+
+02 Stakeholders:: Who has an interest in the system and what they expect
+
+03 Scope:: What is in and out — the system boundary
+
+04 Product Backlog:: Features, user stories, and product ideas
+
+05 Supporting Models:: Diagrams and models that clarify the requirements (context, data, processes)
+
+06 Quality Requirements:: Quality goals and scenarios — the focus that sets req42 apart from pure backlog management
+
+07 Constraints:: Conditions that limit design and implementation decisions
+
+08 Domain Terminology:: Shared vocabulary; a glossary
+
+09 Assets:: Existing things to reuse or protect
+
+10 Teams:: Who builds the product
+
+11 Roadmap:: Planned sequence of delivery over time
+
+12 Risks / Assumptions:: Open risks and the assumptions the plan rests on
+
+Pairs with arc42:: req42 documents the requirements (the "what" and "why"); arc42 documents the architecture (the "how"). The two share authorship, structure, and tooling, so they combine seamlessly.
+
+Docs-as-code:: Distributed as an AsciiDoc template built with the arc42 generator; version-controllable, diffable, and toolchain-friendly. Licensed CC BY-SA 4.0 (free and open source).
+
+Key Proponents:: Dr. Peter Hruschka and Markus Meuten (https://req42.de). Hruschka is a principal of the Atlantic Systems Guild, IREB founding member, and co-creator of arc42; req42 also draws on the Volere requirements tradition.
+
+[discrete]
+== *When to Use*:
+
+* Documenting requirements in an agile context without abandoning structure
+* Giving a product backlog a frame for quality requirements, constraints, and risks — not just user stories
+* Pairing a requirements document with an arc42 architecture document so both share structure and tooling
+* Lightweight, docs-as-code requirements that live next to the code in version control
+
+[discrete]
+== *Related Anchors*:
+
+* <<arc42,arc42 Architecture Documentation>>
+* <<ears-requirements,EARS Requirements Syntax>>
+* <<cockburn-use-cases,Cockburn Use Cases>>
+* <<docs-as-code,Docs-as-Code>>
+
+[discrete]
+== *Current Status*:
+
+* Far less widely known than its sibling arc42. An LLM recognizes "req42" mainly *because* of arc42's name and structure; the training-data prior on req42's own twelve-section content is thin, so the model may extrapolate from arc42 rather than recall req42 accurately. Verify section names against the source (https://docs.req42.de, https://github.com/Hruschka/req42-framework) rather than trusting recall.
+* Actively maintained as a free, open-source template (CC BY-SA 4.0) on https://github.com/Hruschka/req42-framework[GitHub], with section-level guidance at https://docs.req42.de — the same docs-as-code model as arc42.
+====

--- a/docs/anchors/req42.de.adoc
+++ b/docs/anchors/req42.de.adoc
@@ -4,6 +4,7 @@
 :related: arc42, ears-requirements, cockburn-use-cases, docs-as-code
 :proponents: Peter Hruschka, Markus Meuten
 :tags: requirements, framework, agile, docs-as-code, arc42
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/req42.de.adoc
+++ b/docs/anchors/req42.de.adoc
@@ -1,0 +1,70 @@
+= req42
+:categories: requirements-engineering
+:roles: business-analyst, software-architect, product-owner
+:related: arc42, ears-requirements, cockburn-use-cases, docs-as-code
+:proponents: Peter Hruschka, Markus Meuten
+:tags: requirements, framework, agile, docs-as-code, arc42
+
+[%collapsible]
+====
+Vollständiger Name:: req42 — Framework für pragmatisches, agiles Requirements Engineering
+
+Auch bekannt als:: das Requirements-Gegenstück zu arc42
+
+[discrete]
+== *Kernkonzepte*:
+
+Zwölf "Schubladen":: Ein leichtgewichtiges Template aus zwölf Abschnitten, das bewusst die Struktur von arc42 spiegelt, um agile Requirements zu erfassen, ohne in eine schwergewichtige Spezifikation abzudriften. Nur die Schubladen füllen, die ein Projekt wirklich braucht.
+
+01 Business Goals:: Warum das Produkt existiert und woran sich Erfolg misst
+
+02 Stakeholders:: Wer ein Interesse am System hat und was er erwartet
+
+03 Scope:: Was drin und was draußen ist — die Systemgrenze
+
+04 Product Backlog:: Features, User Stories und Produktideen
+
+05 Supporting Models:: Diagramme und Modelle, die die Requirements verdeutlichen (Kontext, Daten, Prozesse)
+
+06 Quality Requirements:: Qualitätsziele und -szenarien — der Fokus, der req42 vom reinen Backlog-Management unterscheidet
+
+07 Constraints:: Randbedingungen, die Design- und Implementierungsentscheidungen einschränken
+
+08 Domain Terminology:: Gemeinsames Vokabular; ein Glossar
+
+09 Assets:: Vorhandenes, das wiederverwendet oder geschützt werden soll
+
+10 Teams:: Wer das Produkt baut
+
+11 Roadmap:: Geplante Reihenfolge der Auslieferung über die Zeit
+
+12 Risks / Assumptions:: Offene Risiken und die Annahmen, auf denen der Plan ruht
+
+Passt zu arc42:: req42 dokumentiert die Requirements (das "Was" und "Warum"), arc42 die Architektur (das "Wie"). Beide teilen Autorenschaft, Struktur und Tooling und lassen sich daher nahtlos kombinieren.
+
+Docs-as-Code:: Verteilt als AsciiDoc-Template, gebaut mit dem arc42-Generator; versionierbar, diff-fähig und toolchain-freundlich. Lizenziert unter CC BY-SA 4.0 (frei und Open Source).
+
+Schlüsselvertreter:: Dr. Peter Hruschka und Markus Meuten (https://req42.de). Hruschka ist Principal der Atlantic Systems Guild, Gründungsmitglied des IREB und Mitentwickler von arc42; req42 greift zudem auf die Volere-Tradition zurück.
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Requirements im agilen Kontext dokumentieren, ohne Struktur aufzugeben
+* Einem Product Backlog einen Rahmen für Qualitätsanforderungen, Constraints und Risiken geben — nicht nur User Stories
+* Ein Requirements-Dokument mit einem arc42-Architekturdokument paaren, sodass beide Struktur und Tooling teilen
+* Leichtgewichtige Docs-as-Code-Requirements, die neben dem Code in der Versionsverwaltung leben
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<arc42,arc42 Architecture Documentation>>
+* <<ears-requirements,EARS Requirements Syntax>>
+* <<cockburn-use-cases,Cockburn Use Cases>>
+* <<docs-as-code,Docs-as-Code>>
+
+[discrete]
+== *Aktueller Status*:
+
+* Deutlich weniger bekannt als das Schwester-Framework arc42. Ein LLM erkennt "req42" vor allem *wegen* des Namens und der Struktur von arc42; der Trainingsdaten-Prior zu req42s eigenem Inhalt der zwölf Abschnitte ist dünn, sodass das Modell eher von arc42 extrapoliert als req42 korrekt abruft. Abschnittsnamen gegen die Quelle (https://docs.req42.de, https://github.com/Hruschka/req42-framework) prüfen, statt auf das Gedächtnis zu vertrauen.
+* Aktiv gepflegt als freies, quelloffenes Template (CC BY-SA 4.0) auf https://github.com/Hruschka/req42-framework[GitHub], mit Hinweisen auf Abschnittsebene unter https://docs.req42.de — dasselbe Docs-as-Code-Modell wie arc42.
+====

--- a/docs/anchors/separation-of-concerns.adoc
+++ b/docs/anchors/separation-of-concerns.adoc
@@ -1,0 +1,49 @@
+= Separation of Concerns
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: cohesion-criteria, unix-philosophy, solid-srp, dry, clean-architecture
+:proponents: Edsger W. Dijkstra
+:tags: modularity, cohesion, coupling, srp, information-hiding
+:tier: 1
+
+[%collapsible]
+====
+Also known as:: SoC
+
+[discrete]
+== *Core Concepts*:
+
+Concern:: A distinct aspect or responsibility of a system — correctness vs. efficiency, business logic vs. presentation, persistence vs. domain rules
+
+Isolation:: Each concern is studied, designed, and changed in isolation, so that one aspect can be reasoned about without interference from the others
+
+Modularity:: Separating concerns into distinct units is the structural basis for modular software — high cohesion within a unit, low coupling between units
+
+Independent change:: When concerns are cleanly separated, a change to one aspect ripples minimally into the others
+
+Manifestations:: The principle shows up concretely as layering, modularization, MVC, microservices boundaries, and aspect-oriented programming
+
+Relation to information hiding:: David Parnas's information hiding (1972) is the complementary mechanism — Dijkstra separates concerns to *think* clearly, Parnas hides design decisions to *change* safely
+
+Relation to SRP:: The Single Responsibility Principle applies Separation of Concerns at the class/module granularity — "a module should have one reason to change"
+
+Key Proponent:: Edsger W. Dijkstra coined the term in https://www.cs.utexas.edu/~EWD/transcriptions/EWD04xx/EWD447.html["On the role of scientific thought" (EWD447, 1974)]: "the separation of concerns ... even if not perfectly possible, is yet the only available technique for effective ordering of one's thoughts"
+
+[discrete]
+== *When to Use*:
+
+* Decomposing a system into modules, layers, or services with clear boundaries
+* Reviewing code for tangled responsibilities (e.g. business logic mixed with I/O or presentation)
+* Justifying architectural seams — why persistence, domain, and UI are kept apart
+* Teaching why high cohesion and low coupling matter
+* Prompting an LLM to structure code into well-bounded, independently changeable units
+
+[discrete]
+== *Related Anchors*:
+
+* <<cohesion-criteria,Cohesion Criteria>>
+* <<unix-philosophy,Unix Philosophy>>
+* <<solid-srp,Single Responsibility Principle>>
+* <<dry,Don't Repeat Yourself>>
+* <<clean-architecture,Clean Architecture>>
+====

--- a/docs/anchors/separation-of-concerns.de.adoc
+++ b/docs/anchors/separation-of-concerns.de.adoc
@@ -1,0 +1,48 @@
+= Separation of Concerns
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: cohesion-criteria, unix-philosophy, solid-srp, dry, clean-architecture
+:proponents: Edsger W. Dijkstra
+:tags: modularity, cohesion, coupling, srp, information-hiding
+
+[%collapsible]
+====
+Auch bekannt als:: SoC, Trennung der Belange
+
+[discrete]
+== *Kernkonzepte*:
+
+Belang (Concern):: Ein eigenständiger Aspekt oder eine Verantwortlichkeit eines Systems — Korrektheit vs. Effizienz, Geschäftslogik vs. Präsentation, Persistenz vs. Domänenregeln
+
+Isolation:: Jeder Belang wird isoliert betrachtet, entworfen und geändert, sodass über einen Aspekt nachgedacht werden kann, ohne dass die anderen stören
+
+Modularität:: Das Trennen von Belangen in eigenständige Einheiten ist die strukturelle Grundlage modularer Software — hohe Kohäsion innerhalb einer Einheit, geringe Kopplung zwischen Einheiten
+
+Unabhängige Änderung:: Sind Belange sauber getrennt, wirkt sich eine Änderung an einem Aspekt nur minimal auf die anderen aus
+
+Ausprägungen:: Das Prinzip zeigt sich konkret als Schichtung (Layering), Modularisierung, MVC, Microservice-Grenzen und aspektorientierte Programmierung
+
+Bezug zu Information Hiding:: David Parnas' Information Hiding (1972) ist der komplementäre Mechanismus — Dijkstra trennt Belange, um klar zu *denken*, Parnas verbirgt Entwurfsentscheidungen, um sicher zu *ändern*
+
+Bezug zu SRP:: Das Single Responsibility Principle wendet Separation of Concerns auf Klassen-/Modulebene an — "ein Modul sollte nur einen Grund zur Änderung haben"
+
+Schlüsselvertreter:: Edsger W. Dijkstra prägte den Begriff in https://www.cs.utexas.edu/~EWD/transcriptions/EWD04xx/EWD447.html["On the role of scientific thought" (EWD447, 1974)]: "the separation of concerns ... even if not perfectly possible, is yet the only available technique for effective ordering of one's thoughts"
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Zerlegung eines Systems in Module, Schichten oder Services mit klaren Grenzen
+* Code-Review auf vermischte Verantwortlichkeiten (z. B. Geschäftslogik vermengt mit I/O oder Präsentation)
+* Begründung architektonischer Schnitte — warum Persistenz, Domäne und UI getrennt bleiben
+* Vermittlung, warum hohe Kohäsion und geringe Kopplung wichtig sind
+* Anweisung an ein LLM, Code in klar abgegrenzte, unabhängig änderbare Einheiten zu strukturieren
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<cohesion-criteria,Cohesion Criteria>>
+* <<unix-philosophy,Unix Philosophy>>
+* <<solid-srp,Single Responsibility Principle>>
+* <<dry,Don't Repeat Yourself>>
+* <<clean-architecture,Clean Architecture>>
+====

--- a/docs/anchors/separation-of-concerns.de.adoc
+++ b/docs/anchors/separation-of-concerns.de.adoc
@@ -4,6 +4,7 @@
 :related: cohesion-criteria, unix-philosophy, solid-srp, dry, clean-architecture
 :proponents: Edsger W. Dijkstra
 :tags: modularity, cohesion, coupling, srp, information-hiding
+:tier: 1
 
 [%collapsible]
 ====

--- a/docs/anchors/strangler-fig.adoc
+++ b/docs/anchors/strangler-fig.adoc
@@ -1,0 +1,60 @@
+= Strangler Fig
+:categories: software-architecture
+:roles: software-architect, software-developer, team-lead
+:related: domain-driven-design, event-driven-architecture, clean-architecture
+:proponents: Martin Fowler
+:tags: legacy-modernization, migration, refactoring, incremental, facade
+:tier: 2
+
+[%collapsible]
+====
+Full Name:: Strangler Fig Application
+
+Also known as:: Strangler Fig pattern, Strangler Application (original 2004 title, later renamed by Fowler)
+
+[discrete]
+== *Core Concepts*:
+
+Routing facade:: A proxy intercepts requests bound for the legacy system and routes each one to either the old system or its new replacement; clients keep the same interface and stay unaware that a migration is in progress
+
+Incremental replacement:: Functionality is migrated piece by piece rather than in a single big-bang rewrite; the new system grows around the old one until the legacy host can be decommissioned
+
+Botanical metaphor:: Named after the strangler fig vine that germinates in a host tree, sends roots to the ground, and gradually envelops the host until it stands self-supporting in its place — the new system "strangles" the legacy
+
+Event interception:: Intercepting the events or calls that flow into the legacy system so new behaviour can be layered in and routed away from the old code
+
+Asset capture:: Progressively taking ownership of the data and capabilities ("assets") that the legacy system holds, moving each into the new system as it is replaced
+
+Transitional architecture:: The facade and any anti-corruption layers are scaffolding meant to be torn down once migration completes; both systems coexist and may share data stores during the transition
+
+Avoids big-bang rewrite:: Reduces risk by keeping the legacy system live and rolling back-able throughout, instead of betting on a single cutover
+
+Key Proponent:: Martin Fowler (https://martinfowler.com/bliki/StranglerFigApplication.html[StranglerFigApplication], https://martinfowler.com/tags/2004.html[2004])
+
+[discrete]
+== *When to Use*:
+
+* Modernizing a large, complex, or legacy monolith where a full rewrite would be too risky
+* Decomposing a monolith into microservices by extracting one capability or domain at a time
+* When the original system can keep running for an extended period during migration
+* When requests to the back-end can be intercepted and the legacy source can be modified to redirect calls
+
+[discrete]
+== *Related Anchors*:
+
+* <<domain-driven-design,Domain-Driven Design>>
+* <<event-driven-architecture,Event-Driven Architecture>>
+* <<clean-architecture,Clean Architecture>>
+
+[discrete]
+== *Criticism*:
+
+* Microsoft, https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig[Azure Architecture Center — Strangler Fig pattern] (2026) — warns that the facade must keep pace with the migration and must not become a single point of failure or performance bottleneck, and that both systems sharing data stores requires careful concurrent access; recommends an Anti-corruption Layer for cross-system calls
+* Amazon Web Services, https://docs.aws.amazon.com/prescriptive-guidance/latest/modernization-decomposing-monoliths/strangler-fig.html[Decomposing monoliths into microservices — Strangler fig pattern] — notes the legacy and modernized systems "live together for a period of time," which imposes dual-maintenance cost; the pattern is unsuitable when requests cannot be intercepted, the legacy source is inaccessible, or the system must be fully decommissioned quickly
+
+[discrete]
+== *Current Status*:
+
+* Widely adopted in cloud-modernization guidance beyond Fowler's original essay: documented as a first-class pattern by both the https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig[Microsoft Azure Architecture Center] and https://docs.aws.amazon.com/prescriptive-guidance/latest/modernization-decomposing-monoliths/strangler-fig.html[AWS Prescriptive Guidance], typically framed as monolith-to-microservices decomposition
+* Naming drift: Fowler originally titled it "Strangler Application" and later renamed it "Strangler Fig Application" to restore the botanical metaphor (https://martinfowler.com/bliki/OriginalStranglerFigApplication.html[Original Strangler Fig Application]); training-data priors may still surface the older "Strangler" / "Strangler Application" label
+====

--- a/docs/anchors/strangler-fig.de.adoc
+++ b/docs/anchors/strangler-fig.de.adoc
@@ -1,0 +1,59 @@
+= Strangler Fig
+:categories: software-architecture
+:roles: software-architect, software-developer, team-lead
+:related: domain-driven-design, event-driven-architecture, clean-architecture
+:proponents: Martin Fowler
+:tags: legacy-modernization, migration, refactoring, incremental, facade
+
+[%collapsible]
+====
+Vollständiger Name:: Strangler Fig Application
+
+Auch bekannt als:: Strangler-Fig-Pattern, Strangler Application (ursprünglicher Titel von 2004, später von Fowler umbenannt)
+
+[discrete]
+== *Kernkonzepte*:
+
+Routing-Facade:: Ein Proxy fängt die an das Legacy-System gerichteten Requests ab und leitet jeden einzeln entweder an das alte System oder an seinen neuen Ersatz weiter; Clients behalten dieselbe Schnittstelle und merken nichts von der laufenden Migration
+
+Inkrementelle Ablösung:: Funktionalität wird Stück für Stück migriert statt in einem einzigen Big-Bang-Rewrite; das neue System wächst um das alte herum, bis der Legacy-Host stillgelegt werden kann
+
+Botanische Metapher:: Benannt nach der Würgefeige, die in einem Wirtsbaum keimt, Wurzeln zum Boden treibt und den Wirt allmählich umschließt, bis sie selbsttragend an seiner Stelle steht — das neue System "erwürgt" das Legacy-System
+
+Event Interception:: Abfangen der Events oder Aufrufe, die in das Legacy-System fließen, sodass neues Verhalten eingezogen und vom alten Code weggeleitet werden kann
+
+Asset Capture:: Schrittweises Übernehmen der Daten und Fähigkeiten ("Assets") des Legacy-Systems, wobei jedes beim Ersetzen in das neue System überführt wird
+
+Transitionsarchitektur:: Die Facade und etwaige Anti-Corruption-Layer sind Gerüst, das nach Abschluss der Migration wieder abgebaut wird; beide Systeme koexistieren und teilen sich während des Übergangs ggf. Datenspeicher
+
+Vermeidet Big-Bang-Rewrite:: Reduziert das Risiko, indem das Legacy-System durchgängig lauffähig und rollback-fähig bleibt, statt auf einen einzigen Cutover zu setzen
+
+Schlüsselvertreter:: Martin Fowler (https://martinfowler.com/bliki/StranglerFigApplication.html[StranglerFigApplication], https://martinfowler.com/tags/2004.html[2004])
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Modernisierung eines großen, komplexen oder Legacy-Monolithen, bei dem ein vollständiger Rewrite zu riskant wäre
+* Zerlegung eines Monolithen in Microservices durch Herauslösen jeweils einer Fähigkeit oder Domäne
+* Wenn das ursprüngliche System während der Migration über einen längeren Zeitraum weiterlaufen kann
+* Wenn Requests an das Back-End abgefangen werden können und der Legacy-Quellcode zum Umleiten von Aufrufen anpassbar ist
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<domain-driven-design,Domain-Driven Design>>
+* <<event-driven-architecture,Event-Driven Architecture>>
+* <<clean-architecture,Clean Architecture>>
+
+[discrete]
+== *Kritik*:
+
+* Microsoft, https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig[Azure Architecture Center — Strangler Fig pattern] (2026) — warnt, dass die Facade mit der Migration Schritt halten muss und nicht zum Single Point of Failure oder Performance-Engpass werden darf, und dass die gemeinsame Nutzung von Datenspeichern durch beide Systeme sorgfältigen gleichzeitigen Zugriff erfordert; empfiehlt einen Anti-Corruption-Layer für systemübergreifende Aufrufe
+* Amazon Web Services, https://docs.aws.amazon.com/prescriptive-guidance/latest/modernization-decomposing-monoliths/strangler-fig.html[Decomposing monoliths into microservices — Strangler fig pattern] — weist darauf hin, dass Legacy- und modernisiertes System "für eine gewisse Zeit nebeneinander leben", was Doppelpflege-Kosten verursacht; das Muster ist ungeeignet, wenn Requests nicht abgefangen werden können, der Legacy-Quellcode unzugänglich ist oder das System schnell vollständig stillgelegt werden muss
+
+[discrete]
+== *Aktueller Status*:
+
+* Über Fowlers ursprünglichen Essay hinaus in der Cloud-Modernisierungsliteratur breit übernommen: als eigenständiges Muster dokumentiert vom https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig[Microsoft Azure Architecture Center] und von der https://docs.aws.amazon.com/prescriptive-guidance/latest/modernization-decomposing-monoliths/strangler-fig.html[AWS Prescriptive Guidance], meist als Monolith-zu-Microservices-Zerlegung gerahmt
+* Namensdrift: Fowler betitelte es ursprünglich "Strangler Application" und benannte es später in "Strangler Fig Application" um, um die botanische Metapher wiederherzustellen (https://martinfowler.com/bliki/OriginalStranglerFigApplication.html[Original Strangler Fig Application]); Trainingsdaten-Priors zeigen womöglich noch das ältere Label "Strangler" / "Strangler Application"
+====

--- a/docs/anchors/strangler-fig.de.adoc
+++ b/docs/anchors/strangler-fig.de.adoc
@@ -4,6 +4,7 @@
 :related: domain-driven-design, event-driven-architecture, clean-architecture
 :proponents: Martin Fowler
 :tags: legacy-modernization, migration, refactoring, incremental, facade
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/team-topologies.adoc
+++ b/docs/anchors/team-topologies.adoc
@@ -1,0 +1,65 @@
+= Team Topologies
+:categories: software-architecture
+:roles: software-architect, team-lead, product-owner
+:related: conways-law, domain-driven-design, cynefin-framework
+:proponents: Matthew Skelton, Manuel Pais
+:tags: org-design, team-structure, cognitive-load, conways-law, flow
+:tier: 2
+
+[%collapsible]
+====
+Full Name:: Team Topologies: Organizing Business and Technology Teams for Fast Flow
+
+[discrete]
+== *Core Concepts*:
+
+Four fundamental team types::
++
+Stream-aligned team::: Aligned to a single flow of work (a product, service, or user journey); the primary team type that delivers value end-to-end
+Enabling team::: Helps stream-aligned teams acquire missing capabilities; works as a temporary coach, not a permanent dependency
+Complicated-subsystem team::: Owns a part requiring deep specialist knowledge (e.g. a math-heavy or hardware-bound subsystem) to reduce the burden on stream-aligned teams
+Platform team::: Provides internal self-service products that reduce the cognitive load of stream-aligned teams
+
+Three interaction modes::
++
+Collaboration::: Two teams work closely together for a defined period to discover new patterns
+X-as-a-Service::: One team consumes something another team provides with minimal collaboration
+Facilitating::: One team helps or coaches another to remove impediments
+
+Cognitive load:: Team structures are designed to limit the amount a single team must hold in its head; the platform exists to offload it
+
+Conway's Law operationalized:: Team boundaries and communication paths are deliberately designed because organizations ship designs that copy their communication structures (the "Inverse Conway Maneuver")
+
+Team API:: Each team makes its interfaces explicit — code, services, documentation, and ways of working — so other teams know how to interact with it
+
+Fracture planes:: Natural boundaries (e.g. business domain, regulatory, change cadence) along which to split work into stream-aligned teams
+
+Key Proponents:: Matthew Skelton, Manuel Pais ("Team Topologies", IT Revolution, 2019)
+
+[discrete]
+== *When to Use*:
+
+* Designing or restructuring software-delivery organizations for fast flow
+* Reducing handoffs and dependencies between teams
+* Deciding whether a capability belongs in a platform, an enabling team, or a stream-aligned team
+* Reasoning about cognitive load when a team owns too much
+* Applying the Inverse Conway Maneuver to align architecture and org structure
+
+[discrete]
+== *Related Anchors*:
+
+* <<conways-law,Conway's Law>>
+* <<domain-driven-design,Domain-Driven Design>>
+* <<cynefin-framework,Cynefin Framework>>
+
+[discrete]
+== *Criticism*:
+
+* Patricia Aas, https://patricia.no/2025/05/24/team_topologies.html["The fundamental misunderstanding in Team Topologies"] (2025) — argues the book conflates Conway's Law (a descriptive observation) with the Inverse Conway Maneuver (a prescriptive recipe), commits the fallacy of "affirming the consequent," and that deliberately restricting team communication to force an architecture contradicts Conway's own case for adaptable organizations. She also questions the book's use of "cognitive load." The discourse she points toward favors broad collaboration over engineered communication barriers.
+
+[discrete]
+== *Current Status*:
+
+* A https://itrevolution.com/product/team-topologies-second-edition/[second edition] (IT Revolution, 2025) adds new cross-industry case studies and a new authors' foreword while keeping the four team types and three interaction modes intact. Training-data priors most plausibly reflect the 2019 first edition; the core vocabulary is unchanged between editions.
+
+====

--- a/docs/anchors/team-topologies.de.adoc
+++ b/docs/anchors/team-topologies.de.adoc
@@ -1,0 +1,64 @@
+= Team Topologies
+:categories: software-architecture
+:roles: software-architect, team-lead, product-owner
+:related: conways-law, domain-driven-design, cynefin-framework
+:proponents: Matthew Skelton, Manuel Pais
+:tags: org-design, team-structure, cognitive-load, conways-law, flow
+
+[%collapsible]
+====
+Vollständiger Name:: Team Topologies: Organizing Business and Technology Teams for Fast Flow
+
+[discrete]
+== *Kernkonzepte*:
+
+Vier grundlegende Teamtypen::
++
+Stream-aligned Team::: Auf einen einzelnen Wertstrom ausgerichtet (ein Produkt, ein Service oder eine User Journey); der primäre Teamtyp, der Wert durchgängig liefert
+Enabling Team::: Hilft Stream-aligned Teams, fehlende Fähigkeiten zu erwerben; wirkt als temporärer Coach, nicht als dauerhafte Abhängigkeit
+Complicated-Subsystem Team::: Besitzt einen Teil, der tiefes Spezialwissen erfordert (z. B. ein mathematik- oder hardwarelastiges Subsystem), um Stream-aligned Teams zu entlasten
+Platform Team::: Stellt interne Self-Service-Produkte bereit, die die kognitive Last der Stream-aligned Teams reduzieren
+
+Drei Interaktionsmodi::
++
+Collaboration::: Zwei Teams arbeiten für einen festgelegten Zeitraum eng zusammen, um neue Muster zu entdecken
+X-as-a-Service::: Ein Team nutzt etwas, das ein anderes Team bereitstellt, mit minimaler Zusammenarbeit
+Facilitating::: Ein Team unterstützt oder coacht ein anderes, um Hindernisse zu beseitigen
+
+Kognitive Last:: Teamstrukturen werden so gestaltet, dass ein einzelnes Team nicht mehr halten muss, als es kann; die Plattform existiert, um Last abzunehmen
+
+Conway's Law operationalisiert:: Teamgrenzen und Kommunikationswege werden bewusst gestaltet, weil Organisationen Designs liefern, die ihre Kommunikationsstrukturen abbilden (das "Inverse Conway Maneuver")
+
+Team API:: Jedes Team macht seine Schnittstellen explizit — Code, Services, Dokumentation und Arbeitsweisen — damit andere Teams wissen, wie sie damit interagieren
+
+Fracture Planes:: Natürliche Grenzen (z. B. fachliche Domäne, Regulatorik, Änderungstakt), entlang derer Arbeit in Stream-aligned Teams aufgeteilt wird
+
+Schlüsselvertreter:: Matthew Skelton, Manuel Pais ("Team Topologies", IT Revolution, 2019)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Gestaltung oder Umstrukturierung von Software-Lieferorganisationen für schnellen Flow
+* Reduzierung von Übergaben und Abhängigkeiten zwischen Teams
+* Entscheidung, ob eine Fähigkeit in eine Plattform, ein Enabling Team oder ein Stream-aligned Team gehört
+* Nachdenken über kognitive Last, wenn ein Team zu viel besitzt
+* Anwendung des Inverse Conway Maneuver zur Ausrichtung von Architektur und Organisationsstruktur
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<conways-law,Conway's Law>>
+* <<domain-driven-design,Domain-Driven Design>>
+* <<cynefin-framework,Cynefin Framework>>
+
+[discrete]
+== *Kritik*:
+
+* Patricia Aas, https://patricia.no/2025/05/24/team_topologies.html["The fundamental misunderstanding in Team Topologies"] (2025) — argumentiert, dass das Buch Conway's Law (eine deskriptive Beobachtung) mit dem Inverse Conway Maneuver (einem präskriptiven Rezept) vermischt, den Fehlschluss der "Bejahung des Konsequenten" begeht und dass das bewusste Einschränken der Teamkommunikation zur Erzwingung einer Architektur Conways eigenem Plädoyer für anpassungsfähige Organisationen widerspricht. Sie hinterfragt zudem den Gebrauch des Begriffs "kognitive Last". Der von ihr aufgezeigte Diskurs bevorzugt breite Zusammenarbeit gegenüber konstruierten Kommunikationsbarrieren.
+
+[discrete]
+== *Aktueller Status*:
+
+* Eine https://itrevolution.com/product/team-topologies-second-edition/[zweite Auflage] (IT Revolution, 2025) ergänzt neue branchenübergreifende Fallstudien und ein neues Vorwort der Autoren, behält jedoch die vier Teamtypen und drei Interaktionsmodi bei. Trainingsdaten-Priors spiegeln am ehesten die erste Auflage von 2019 wider; das Kernvokabular ist zwischen den Auflagen unverändert.
+
+====

--- a/docs/anchors/team-topologies.de.adoc
+++ b/docs/anchors/team-topologies.de.adoc
@@ -4,6 +4,7 @@
 :related: conways-law, domain-driven-design, cynefin-framework
 :proponents: Matthew Skelton, Manuel Pais
 :tags: org-design, team-structure, cognitive-load, conways-law, flow
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/twelve-factor-app.adoc
+++ b/docs/anchors/twelve-factor-app.adoc
@@ -1,0 +1,65 @@
+= Twelve-Factor App
+:categories: software-architecture
+:roles: software-developer, devops-engineer, software-architect
+:related: clean-architecture, fallacies-of-distributed-computing, conways-law
+:proponents: Adam Wiggins
+:tags: cloud-native, saas, config, stateless, deployment, heroku
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: 12-Factor App
+
+[discrete]
+== *Core Concepts*:
+
+Codebase:: One codebase tracked in revision control, many deploys; a one-to-one relationship between app and codebase
+
+Dependencies:: Explicitly declare and isolate dependencies; never rely on implicit system-wide packages
+
+Config in the environment:: Store config (credentials, hostnames, per-deploy values) in environment variables, strictly separated from code
+
+Backing services:: Treat databases, queues, caches and SMTP as attached resources, swappable by changing config without code edits
+
+Build, release, run:: Strictly separate the three stages; releases are immutable and append-only, every release has a unique ID
+
+Stateless, disposable processes:: Execute the app as one or more stateless, share-nothing processes; persist state only in backing services. Maximize robustness with fast startup and graceful shutdown (Disposability)
+
+Port binding:: Export the service by binding to a port; the app is self-contained and needs no runtime webserver injection
+
+Concurrency:: Scale out horizontally via the process model, treating processes as first-class citizens
+
+Dev/prod parity:: Keep development, staging and production as similar as possible — small time, personnel and tooling gaps
+
+Logs as event streams:: Treat logs as time-ordered event streams written to stdout; the execution environment handles routing and storage
+
+Admin processes:: Run admin and management tasks (migrations, REPLs) as one-off processes in an identical environment to the long-running ones
+
+Key Proponent:: Adam Wiggins (Heroku, https://12factor.net/[12factor.net], 2011)
+
+[discrete]
+== *When to Use*:
+
+* Designing or reviewing cloud-native and SaaS applications for portability and scalability
+* Establishing deployment, config and statelessness conventions for a containerized or PaaS workload
+* Onboarding developers to twelve-factor vocabulary (config-in-env, attached resources, build/release/run)
+* Prompting an LLM to scaffold a deployable, environment-portable service rather than a machine-bound one
+
+[discrete]
+== *Related Anchors*:
+
+* <<clean-architecture,Clean Architecture>>
+* <<fallacies-of-distributed-computing,Fallacies of Distributed Computing>>
+* <<conways-law,Conway's Law>>
+
+[discrete]
+== *Criticism*:
+
+* Kevin Hoffman, https://www.oreilly.com/library/view/beyond-the-twelve-factor/9781492042631/["Beyond the Twelve-Factor App"] (O'Reilly, 2016) — argues the original set is incomplete for modern cloud platforms and proposes a revised *fifteen-factor* methodology, adding *API First*, *Telemetry* and *Authentication and Authorization* as first-class factors
+
+[discrete]
+== *Current Status*:
+
+* The canonical https://12factor.net/[12factor.net] document was "Last updated 2017" and stood unchanged for roughly eight years; a training-data prior most plausibly serves this frozen 2011/2017 text
+* Salesforce/Heroku launched an official https://12factor.net/blog/evolving-twelve-factor[Twelve-Factor modernization initiative] (Brian Hammons, 10 Feb 2025), an open-source effort revisiting the principles for containers, Kubernetes and serverless and proposing a new *Identity* factor
+====

--- a/docs/anchors/twelve-factor-app.de.adoc
+++ b/docs/anchors/twelve-factor-app.de.adoc
@@ -1,0 +1,64 @@
+= Twelve-Factor App
+:categories: software-architecture
+:roles: software-developer, devops-engineer, software-architect
+:related: clean-architecture, fallacies-of-distributed-computing, conways-law
+:proponents: Adam Wiggins
+:tags: cloud-native, saas, config, stateless, deployment, heroku
+
+[%collapsible]
+====
+Auch bekannt als:: 12-Factor App
+
+[discrete]
+== *Kernkonzepte*:
+
+Codebase:: Eine Codebase unter Versionskontrolle, viele Deploys; eine Eins-zu-eins-Beziehung zwischen App und Codebase
+
+Abhängigkeiten:: Abhängigkeiten explizit deklarieren und isolieren; niemals auf implizite, systemweite Pakete verlassen
+
+Konfiguration in der Umgebung:: Konfiguration (Credentials, Hostnamen, deploy-spezifische Werte) in Umgebungsvariablen ablegen, strikt vom Code getrennt
+
+Backing Services:: Datenbanken, Queues, Caches und SMTP als angehängte Ressourcen behandeln, austauschbar allein über die Konfiguration ohne Codeänderung
+
+Build, Release, Run:: Die drei Phasen strikt trennen; Releases sind unveränderlich und nur anfügbar, jedes Release hat eine eindeutige ID
+
+Zustandslose, wegwerfbare Prozesse:: Die App als einen oder mehrere zustandslose, nichts teilende Prozesse ausführen; Zustand nur in Backing Services halten. Robustheit durch schnellen Start und sauberes Herunterfahren maximieren (Disposability)
+
+Port-Binding:: Den Dienst durch Binden an einen Port exportieren; die App ist eigenständig und benötigt keinen zur Laufzeit eingespeisten Webserver
+
+Nebenläufigkeit:: Horizontal über das Prozessmodell skalieren, Prozesse als erstklassige Bürger behandeln
+
+Dev/Prod-Parität:: Entwicklung, Staging und Produktion so ähnlich wie möglich halten — kleine Lücken bei Zeit, Personal und Werkzeugen
+
+Logs als Event-Streams:: Logs als zeitlich geordnete Event-Streams nach stdout behandeln; die Ausführungsumgebung übernimmt Routing und Speicherung
+
+Admin-Prozesse:: Administrations- und Verwaltungsaufgaben (Migrationen, REPLs) als einmalige Prozesse in einer mit den Langläufern identischen Umgebung ausführen
+
+Schlüsselvertreter:: Adam Wiggins (Heroku, https://12factor.net/[12factor.net], 2011)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Entwurf oder Review von Cloud-Native- und SaaS-Anwendungen im Hinblick auf Portabilität und Skalierbarkeit
+* Festlegen von Deployment-, Konfigurations- und Zustandslosigkeits-Konventionen für eine containerisierte oder PaaS-Last
+* Onboarding von Entwicklern auf das Twelve-Factor-Vokabular (Config-in-Env, angehängte Ressourcen, Build/Release/Run)
+* Einen LLM anweisen, einen deploybaren, umgebungsportablen Dienst zu erstellen statt eines maschinengebundenen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<clean-architecture,Clean Architecture>>
+* <<fallacies-of-distributed-computing,Fallacies of Distributed Computing>>
+* <<conways-law,Conway's Law>>
+
+[discrete]
+== *Kritik*:
+
+* Kevin Hoffman, https://www.oreilly.com/library/view/beyond-the-twelve-factor/9781492042631/["Beyond the Twelve-Factor App"] (O'Reilly, 2016) — hält das ursprüngliche Set für moderne Cloud-Plattformen für unvollständig und schlägt eine überarbeitete *Fifteen-Factor*-Methodik vor, die *API First*, *Telemetry* und *Authentication and Authorization* als eigenständige Faktoren ergänzt
+
+[discrete]
+== *Aktueller Stand*:
+
+* Das kanonische Dokument auf https://12factor.net/[12factor.net] trägt den Stand "Last updated 2017" und blieb rund acht Jahre unverändert; ein Trainingsdaten-Prior bedient höchstwahrscheinlich diesen eingefrorenen Text von 2011/2017
+* Salesforce/Heroku starteten eine offizielle https://12factor.net/blog/evolving-twelve-factor[Twelve-Factor-Modernisierungsinitiative] (Brian Hammons, 10. Feb. 2025), ein Open-Source-Vorhaben, das die Prinzipien für Container, Kubernetes und Serverless überarbeitet und einen neuen Faktor *Identity* vorschlägt
+====

--- a/docs/anchors/twelve-factor-app.de.adoc
+++ b/docs/anchors/twelve-factor-app.de.adoc
@@ -4,6 +4,7 @@
 :related: clean-architecture, fallacies-of-distributed-computing, conways-law
 :proponents: Adam Wiggins
 :tags: cloud-native, saas, config, stateless, deployment, heroku
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/unix-philosophy.adoc
+++ b/docs/anchors/unix-philosophy.adoc
@@ -1,0 +1,63 @@
+= Unix Philosophy
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: separation-of-concerns, dry, kiss-principle, code-smells
+:proponents: Doug McIlroy, Eric S. Raymond
+:tags: modularity, composability, simplicity, pipes, kiss
+:tier: 2
+
+[%collapsible]
+====
+Also known as:: Software Tools philosophy, Unix design philosophy
+
+[discrete]
+== *Core Concepts*:
+
+Do one thing well:: "Make each program do one thing well. To do a new job, build afresh rather than complicate old programs by adding new features." (Doug McIlroy, Bell System Technical Journal, 1978)
+
+Compose small tools:: Expect the output of every program to become the input to another, as yet unknown, program; small sharp tools combine into larger workflows via pipes
+
+Text streams as universal interface:: "Write programs to handle text streams, because that is a universal interface" — plain text is the lingua franca that lets independent tools interoperate
+
+Build prototypes early:: Don't hesitate to throw away the clumsy parts and rebuild them; favour fast prototyping over over-design
+
+Worse is better:: Richard P. Gabriel's observation that simple, available implementations spread faster than elegant, complete ones — a descriptive lens on why the Unix style won
+
+Rule of Modularity:: Build a program out of simple parts connected by clean, well-defined interfaces (Eric S. Raymond)
+
+Rule of Composition:: Design programs to be connected to other programs; keep formats parseable so tools chain together (Eric S. Raymond)
+
+Rule of Silence:: "When a program has nothing surprising to say, it should say nothing" — quiet success keeps output usable as another program's input (Eric S. Raymond)
+
+Key Proponents:: Doug McIlroy (Bell System Technical Journal, 1978), Eric S. Raymond ("The Art of Unix Programming", 2003, with 17 design rules)
+
+[discrete]
+== *When to Use*:
+
+* Designing CLI tools, scripts, and pipelines meant to compose with others
+* Deciding whether to extend an existing program or build a separate, focused one
+* Arguing for plain-text, line-oriented data formats over opaque binary blobs
+* Reviewing a tool that is accumulating flags and feature creep
+* Prompting an LLM to produce small, single-purpose, composable Unix-style programs
+
+[discrete]
+== *Related Anchors*:
+
+* <<separation-of-concerns,Separation of Concerns>>
+* <<dry,DRY (Don't Repeat Yourself)>>
+* <<kiss-principle,KISS Principle>>
+* <<code-smells,Code Smells>>
+
+[discrete]
+== *Criticism*:
+
+* Rob Pike and Brian Kernighan, "Program Design in the UNIX Environment" / "cat -v Considered Harmful" (1984) — argue that Unix itself drifted from the philosophy, with utilities like `cat` accreting flags (`-n`, `-s`, `-b`, `-v`) that violate "do one thing well"; summarized at https://en.wikipedia.org/wiki/Unix_philosophy[Unix philosophy (Wikipedia)]
+* Simson Garfinkel, Daniel Weise, Steven Strassmann (eds.), https://en.wikipedia.org/wiki/The_UNIX-HATERS_Handbook[The UNIX-HATERS Handbook] (1994) — a compilation of the UNIX-HATERS mailing list attacking the "worse is better" design culture as a source of obscure flags, cryptic errors, and lost work
+* Richard P. Gabriel, https://en.wikipedia.org/wiki/Worse_is_better["The Rise of Worse is Better"] (1989, published 1991) — frames the philosophy descriptively rather than as a virtue: simple-but-incomplete designs (C, Unix) outcompeted more correct, elegant ones (Lisp machines), implying the style spreads for market reasons, not because it is right
+
+[discrete]
+== *Current Status*:
+
+* The philosophy remains the conceptual core of CLI tooling, shells, and pipelines, but sits in tension with modern monolithic GUI/IDE and all-in-one platform tooling, where integration and discoverability are valued over composition of small text-stream tools
+* Eric S. Raymond's https://en.wikipedia.org/wiki/Unix_philosophy[17 rules] (2003) are the most cited modern codification; training-data priors most plausibly serve the McIlroy summary and Raymond's rules, while the Pike/Kernighan critique of Unix's own drift is the documented counter-current
+====

--- a/docs/anchors/unix-philosophy.de.adoc
+++ b/docs/anchors/unix-philosophy.de.adoc
@@ -4,6 +4,7 @@
 :related: separation-of-concerns, dry, kiss-principle, code-smells
 :proponents: Doug McIlroy, Eric S. Raymond
 :tags: modularity, composability, simplicity, pipes, kiss
+:tier: 2
 
 [%collapsible]
 ====

--- a/docs/anchors/unix-philosophy.de.adoc
+++ b/docs/anchors/unix-philosophy.de.adoc
@@ -1,0 +1,62 @@
+= Unix Philosophy
+:categories: design-principles
+:roles: software-developer, software-architect
+:related: separation-of-concerns, dry, kiss-principle, code-smells
+:proponents: Doug McIlroy, Eric S. Raymond
+:tags: modularity, composability, simplicity, pipes, kiss
+
+[%collapsible]
+====
+Auch bekannt als:: Software-Tools-Philosophie, Unix-Designphilosophie
+
+[discrete]
+== *Kernkonzepte*:
+
+Eine Sache gut machen:: "Make each program do one thing well. To do a new job, build afresh rather than complicate old programs by adding new features." (Doug McIlroy, Bell System Technical Journal, 1978)
+
+Kleine Tools komponieren:: Erwarte, dass die Ausgabe jedes Programms zur Eingabe eines weiteren, noch unbekannten Programms wird; kleine, scharfe Werkzeuge fügen sich über Pipes zu größeren Abläufen zusammen
+
+Text-Streams als universelle Schnittstelle:: "Write programs to handle text streams, because that is a universal interface" — Klartext ist die gemeinsame Sprache, die unabhängige Tools zusammenarbeiten lässt
+
+Prototypen früh bauen:: Zögere nicht, die unbeholfenen Teile zu verwerfen und neu zu bauen; bevorzuge schnelles Prototyping gegenüber Über-Design
+
+Worse is better:: Richard P. Gabriels Beobachtung, dass einfache, verfügbare Implementierungen sich schneller verbreiten als elegante, vollständige — eine beschreibende Sicht darauf, warum sich der Unix-Stil durchsetzte
+
+Rule of Modularity:: Baue ein Programm aus einfachen Teilen, die durch klare, wohldefinierte Schnittstellen verbunden sind (Eric S. Raymond)
+
+Rule of Composition:: Entwirf Programme so, dass sie mit anderen Programmen verbunden werden können; halte Formate parsebar, damit Tools sich verketten lassen (Eric S. Raymond)
+
+Rule of Silence:: "When a program has nothing surprising to say, it should say nothing" — stiller Erfolg hält die Ausgabe als Eingabe eines anderen Programms nutzbar (Eric S. Raymond)
+
+Schlüsselvertreter:: Doug McIlroy (Bell System Technical Journal, 1978), Eric S. Raymond ("The Art of Unix Programming", 2003, mit 17 Designregeln)
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Entwurf von CLI-Tools, Skripten und Pipelines, die mit anderen komponieren sollen
+* Entscheidung, ob ein bestehendes Programm erweitert oder ein separates, fokussiertes gebaut wird
+* Argumentation für klartext- und zeilenorientierte Datenformate statt undurchsichtiger Binär-Blobs
+* Review eines Tools, das Flags und Feature Creep ansammelt
+* Prompting eines LLM, um kleine, einzweckige, komponierbare Programme im Unix-Stil zu erzeugen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<separation-of-concerns,Separation of Concerns>>
+* <<dry,DRY (Don't Repeat Yourself)>>
+* <<kiss-principle,KISS-Prinzip>>
+* <<code-smells,Code Smells>>
+
+[discrete]
+== *Kritik*:
+
+* Rob Pike und Brian Kernighan, "Program Design in the UNIX Environment" / "cat -v Considered Harmful" (1984) — argumentieren, dass Unix selbst von der Philosophie abdriftete, da Utilities wie `cat` Flags (`-n`, `-s`, `-b`, `-v`) ansammelten, die "eine Sache gut machen" verletzen; zusammengefasst unter https://en.wikipedia.org/wiki/Unix_philosophy[Unix philosophy (Wikipedia)]
+* Simson Garfinkel, Daniel Weise, Steven Strassmann (Hrsg.), https://en.wikipedia.org/wiki/The_UNIX-HATERS_Handbook[The UNIX-HATERS Handbook] (1994) — eine Sammlung der UNIX-HATERS-Mailingliste, die die "worse is better"-Designkultur als Quelle obskurer Flags, kryptischer Fehler und verlorener Arbeit angreift
+* Richard P. Gabriel, https://en.wikipedia.org/wiki/Worse_is_better["The Rise of Worse is Better"] (1989, veröffentlicht 1991) — beschreibt die Philosophie deskriptiv statt als Tugend: einfache, aber unvollständige Designs (C, Unix) setzten sich gegen korrektere, elegantere durch (Lisp-Maschinen), was nahelegt, dass sich der Stil aus Marktgründen verbreitet, nicht weil er richtig ist
+
+[discrete]
+== *Aktueller Stand*:
+
+* Die Philosophie bleibt der konzeptionelle Kern von CLI-Tooling, Shells und Pipelines, steht aber im Spannungsverhältnis zu modernem monolithischem GUI-/IDE- und All-in-One-Plattform-Tooling, das Integration und Auffindbarkeit über die Komposition kleiner Text-Stream-Tools stellt
+* Eric S. Raymonds https://en.wikipedia.org/wiki/Unix_philosophy[17 Regeln] (2003) sind die meistzitierte moderne Kodifizierung; Trainingsdaten-Prioren bedienen am ehesten die McIlroy-Zusammenfassung und Raymonds Regeln, während die Pike/Kernighan-Kritik an Unix' eigenem Abdriften die dokumentierte Gegenströmung ist
+====

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -186,6 +186,25 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Andy Hunt, David Thomas
 - **Core:** Lightweight end-to-end slice that validates architectural direction on real infrastructure; unlike a spike, tracer code is kept and refined into the final system; enables rapid directional correction via the "aim-fire-adjust" loop; primary goal is architecture validation, not feature delivery
 
+### Circuit Breaker
+- **Also known as:** Circuit Breaker stability pattern
+- **Proponents:** Michael Nygard, Martin Fowler
+- **Core:** Wraps remote calls in a closed/open/half-open state machine that trips on a failure threshold to fail-fast and trigger fallbacks, preventing cascading failure; pairs with timeout, retry, and bulkhead
+
+### Strangler Fig
+- **Also known as:** Strangler Fig Application
+- **Proponents:** Martin Fowler
+- **Core:** Incrementally retire a legacy system by placing a routing facade in front of it and migrating capabilities piece by piece into a new system that grows until it "strangles" and replaces the host, avoiding a big-bang rewrite
+
+### Team Topologies
+- **Proponents:** Matthew Skelton, Manuel Pais
+- **Core:** Org-design framework for fast flow: four team types (stream-aligned, enabling, complicated-subsystem, platform) and three interaction modes (collaboration, X-as-a-Service, facilitating) that limit team cognitive load and operationalize Conway's Law via the Inverse Conway Maneuver and explicit Team APIs
+
+### Twelve-Factor App
+- **Also known as:** 12-Factor App
+- **Proponents:** Adam Wiggins (Heroku)
+- **Core:** Twelve principles for portable, scalable cloud-native/SaaS apps — config in env, stateless disposable processes, backing services as attached resources, strict build-release-run separation, port binding, horizontal concurrency, dev/prod parity, and logs as event streams
+
 ## Design Principles
 
 ### DRY (Don't Repeat Yourself)
@@ -386,6 +405,20 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Martin Fowler
 - **Core:** Repository, Unit of Work, Data Mapper, Active Record, etc.
 
+### Separation of Concerns
+- **Also known as:** SoC
+- **Proponents:** Edsger W. Dijkstra
+- **Core:** Isolate each distinct aspect or responsibility (correctness vs. efficiency, logic vs. presentation, domain vs. persistence) so it can be reasoned about and changed independently — the structural basis for modularity, high cohesion, and low coupling
+
+### Unix Philosophy
+- **Proponents:** Doug McIlroy, Eric S. Raymond
+- **Core:** Make each program do one thing well, compose small sharp tools through pipes, and treat plain text streams as the universal interface
+
+### Design by Contract
+- **Also known as:** DbC, Programming by Contract
+- **Proponents:** Bertrand Meyer
+- **Core:** Specifies software correctness as enforceable preconditions (caller's obligation), postconditions (supplier's guarantee), and class invariants — assigning blame on violation, formalizing behavioural subtyping (LSP), and coined for Eiffel by Bertrand Meyer
+
 ## Problem-Solving
 
 ### First Principles Thinking
@@ -454,6 +487,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Fritz B. Simon, Helm Stierlin, Gunthard Weber, Paul Watzlawick
 - **Core:** Heidelberg School of systemic consulting — all-partiality, neutrality, circular questions, context clarification, problems as emergent relational patterns; the consultant cannot instruct a closed system, only offer irritations it may integrate
 
+### Fermi Estimation
+- **Also known as:** Order-of-Magnitude Estimation, Back-of-the-Envelope Calculation
+- **Proponents:** Enrico Fermi
+- **Core:** Estimate an unknown by decomposing it into bracketed sub-quantities, reasoning in powers of ten and taking geometric means, so independent errors cancel and the product lands within a factor of 2-3 — enough to sanity-check or size a problem
+
 ## Requirements Engineering
 
 ### Cockburn Use Cases
@@ -494,6 +532,15 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 
 ### Problem Space NVC
 - **Core:** Needs-Value-Constraints framework for problem definition
+
+### Laddering (Interview Technique)
+- **Also known as:** Means-End Laddering, Laddering Interview
+- **Proponents:** George Kelly, Dennis Hinkle, Thomas Reynolds, Jonathan Gutman
+- **Core:** Bidirectional interview technique that maps attribute→consequence→value chains by laddering up ("why is that important to you?") toward values and down ("how / for example?") toward specifics; surfaces a hierarchy of user motivations rather than a single root cause like Five Whys
+
+### req42
+- **Proponents:** Peter Hruschka, Markus Meuten
+- **Core:** Free, open-source AsciiDoc template for pragmatic agile requirements documentation — the requirements companion to arc42, covering goals, stakeholders, scope, backlog, quality requirements, constraints, and risks
 
 ## Communication & Presentation
 
@@ -547,6 +594,15 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Also known as:** MBTI, Myers-Briggs, 16 Personality Types
 - **Proponents:** Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 - **Core:** Four dichotomies (E/I, S/N, T/F, J/P) produce 16 personality types describing communication preferences, decision-making styles, and team dynamics
+
+### Curse of Knowledge
+- **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
+- **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience
+
+### Four-Sides Model (Schulz von Thun)
+- **Also known as:** Communication Square, Four-Ears Model, Vier-Seiten-Modell
+- **Proponents:** Friedemann Schulz von Thun
+- **Core:** Every message carries four facets at once — factual information (Sachinhalt), self-revelation (Selbstoffenbarung), relationship (Beziehung), and appeal (Appell); the sender speaks with "four beaks" and the receiver listens with "four ears", and mismatched ears cause misunderstanding
 
 ## Documentation
 
@@ -634,6 +690,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
 - **Core:** Apply software engineering to operations; SLI/SLO/SLA; error budgets balance reliability vs. feature velocity (100% is the wrong target); eliminate toil with ~50% ops cap; blameless postmortems; four golden signals (latency, traffic, errors, saturation); release & capacity engineering
 
+### Effective Java
+- **Proponents:** Joshua Bloch
+- **Core:** Catalog of ~90 "Items" of idiomatic Java best practice — static factories & the Builder pattern, the equals/hashCode contracts, minimize mutability, composition over inheritance, generics with PECS, enums over int constants, and try-with-resources
+
 ## Statistical Methods
 
 ### SPC (Statistical Process Control)
@@ -699,6 +759,30 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Also known as:** MHC, Meaningful Human Control over Individual Attacks
 - **Proponents:** Article 36 (coined the term, 2013), Noel Sharkey (five-level framework, 2014), ICRC, UN CCW GGE, IEEE Global Initiative
 - **Core:** Requirement that humans retain genuine, substantive control over autonomous systems making high-stakes decisions — not merely formulaic "human-in-the-loop" oversight; demands situational awareness, an identifiable accountability chain (never transferable to machines), positive human authorization of critical actions, and timely intervention/override; Sharkey's five levels (L1 human deliberates → L5 fully autonomous) classify the degree of autonomy; originates in the autonomous-weapons / international humanitarian law debate but applies to medical AI, autonomous driving, and critical infrastructure; underlies the EU AI Act's human-oversight requirements
+
+### OKR (Objectives and Key Results)
+- **Proponents:** Andy Grove, John Doerr
+- **Core:** A qualitative Objective paired with 3-5 measurable Key Results, set on a quarterly cadence as ambitious stretch goals (~0.7 = success), kept transparent for alignment and decoupled from compensation
+
+### Eisenhower Matrix
+- **Also known as:** Urgent-Important Matrix, Eisenhower Box, Time Management Matrix
+- **Proponents:** Dwight D. Eisenhower (attrib.), Stephen Covey
+- **Core:** Plots tasks on two axes — urgency × importance — into four quadrants (Do, Schedule, Delegate, Delete) to separate genuine importance from manufactured urgency; admitted with a Criticism section (mere-urgency effect) since its framing is contested
+
+### Consent vs. Consensus
+- **Proponents:** Gerard Endenburg (Sociocracy), Brian Robertson (Holacracy)
+- **Core:** Consensus requires everyone's active "yes"; consent requires only the absence of a paramount, reasoned objection ("good enough for now, safe enough to try"), so objections are argued and integrated rather than vetoed — speeding decisions and avoiding lowest-common-denominator outcomes and groupthink
+
+## Knowledge Management
+
+### Dreyfus Model of Skill Acquisition
+- **Proponents:** Stuart Dreyfus, Hubert Dreyfus
+- **Core:** Five stages from Novice to Expert (Novice, Advanced Beginner, Competent, Proficient, Expert) tracing a shift from rigid rule-following to intuitive pattern recognition, so teaching and explanation depth should match the learner's stage
+
+### ADDIE Model
+- **Also known as:** ADDIE, Instructional Systems Design (ISD)
+- **Proponents:** Florida State University; Robert Maribe Branch
+- **Core:** Five-phase instructional-design process — Analysis, Design, Development, Implementation, Evaluation (formative + summative, often paired with Kirkpatrick) — modern usage iterative rather than strict waterfall
 
 ## Creative Writing & Storytelling
 

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -186,6 +186,25 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Andy Hunt, David Thomas
 - **Core:** Lightweight end-to-end slice that validates architectural direction on real infrastructure; unlike a spike, tracer code is kept and refined into the final system; enables rapid directional correction via the "aim-fire-adjust" loop; primary goal is architecture validation, not feature delivery
 
+### Circuit Breaker
+- **Also known as:** Circuit Breaker stability pattern
+- **Proponents:** Michael Nygard, Martin Fowler
+- **Core:** Wraps remote calls in a closed/open/half-open state machine that trips on a failure threshold to fail-fast and trigger fallbacks, preventing cascading failure; pairs with timeout, retry, and bulkhead
+
+### Strangler Fig
+- **Also known as:** Strangler Fig Application
+- **Proponents:** Martin Fowler
+- **Core:** Incrementally retire a legacy system by placing a routing facade in front of it and migrating capabilities piece by piece into a new system that grows until it "strangles" and replaces the host, avoiding a big-bang rewrite
+
+### Team Topologies
+- **Proponents:** Matthew Skelton, Manuel Pais
+- **Core:** Org-design framework for fast flow: four team types (stream-aligned, enabling, complicated-subsystem, platform) and three interaction modes (collaboration, X-as-a-Service, facilitating) that limit team cognitive load and operationalize Conway's Law via the Inverse Conway Maneuver and explicit Team APIs
+
+### Twelve-Factor App
+- **Also known as:** 12-Factor App
+- **Proponents:** Adam Wiggins (Heroku)
+- **Core:** Twelve principles for portable, scalable cloud-native/SaaS apps — config in env, stateless disposable processes, backing services as attached resources, strict build-release-run separation, port binding, horizontal concurrency, dev/prod parity, and logs as event streams
+
 ## Design Principles
 
 ### DRY (Don't Repeat Yourself)
@@ -386,6 +405,20 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Martin Fowler
 - **Core:** Repository, Unit of Work, Data Mapper, Active Record, etc.
 
+### Separation of Concerns
+- **Also known as:** SoC
+- **Proponents:** Edsger W. Dijkstra
+- **Core:** Isolate each distinct aspect or responsibility (correctness vs. efficiency, logic vs. presentation, domain vs. persistence) so it can be reasoned about and changed independently — the structural basis for modularity, high cohesion, and low coupling
+
+### Unix Philosophy
+- **Proponents:** Doug McIlroy, Eric S. Raymond
+- **Core:** Make each program do one thing well, compose small sharp tools through pipes, and treat plain text streams as the universal interface
+
+### Design by Contract
+- **Also known as:** DbC, Programming by Contract
+- **Proponents:** Bertrand Meyer
+- **Core:** Specifies software correctness as enforceable preconditions (caller's obligation), postconditions (supplier's guarantee), and class invariants — assigning blame on violation, formalizing behavioural subtyping (LSP), and coined for Eiffel by Bertrand Meyer
+
 ## Problem-Solving
 
 ### First Principles Thinking
@@ -454,6 +487,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Fritz B. Simon, Helm Stierlin, Gunthard Weber, Paul Watzlawick
 - **Core:** Heidelberg School of systemic consulting — all-partiality, neutrality, circular questions, context clarification, problems as emergent relational patterns; the consultant cannot instruct a closed system, only offer irritations it may integrate
 
+### Fermi Estimation
+- **Also known as:** Order-of-Magnitude Estimation, Back-of-the-Envelope Calculation
+- **Proponents:** Enrico Fermi
+- **Core:** Estimate an unknown by decomposing it into bracketed sub-quantities, reasoning in powers of ten and taking geometric means, so independent errors cancel and the product lands within a factor of 2-3 — enough to sanity-check or size a problem
+
 ## Requirements Engineering
 
 ### Cockburn Use Cases
@@ -494,6 +532,15 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 
 ### Problem Space NVC
 - **Core:** Needs-Value-Constraints framework for problem definition
+
+### Laddering (Interview Technique)
+- **Also known as:** Means-End Laddering, Laddering Interview
+- **Proponents:** George Kelly, Dennis Hinkle, Thomas Reynolds, Jonathan Gutman
+- **Core:** Bidirectional interview technique that maps attribute→consequence→value chains by laddering up ("why is that important to you?") toward values and down ("how / for example?") toward specifics; surfaces a hierarchy of user motivations rather than a single root cause like Five Whys
+
+### req42
+- **Proponents:** Peter Hruschka, Markus Meuten
+- **Core:** Free, open-source AsciiDoc template for pragmatic agile requirements documentation — the requirements companion to arc42, covering goals, stakeholders, scope, backlog, quality requirements, constraints, and risks
 
 ## Communication & Presentation
 
@@ -547,6 +594,15 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Also known as:** MBTI, Myers-Briggs, 16 Personality Types
 - **Proponents:** Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 - **Core:** Four dichotomies (E/I, S/N, T/F, J/P) produce 16 personality types describing communication preferences, decision-making styles, and team dynamics
+
+### Curse of Knowledge
+- **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
+- **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience
+
+### Four-Sides Model (Schulz von Thun)
+- **Also known as:** Communication Square, Four-Ears Model, Vier-Seiten-Modell
+- **Proponents:** Friedemann Schulz von Thun
+- **Core:** Every message carries four facets at once — factual information (Sachinhalt), self-revelation (Selbstoffenbarung), relationship (Beziehung), and appeal (Appell); the sender speaks with "four beaks" and the receiver listens with "four ears", and mismatched ears cause misunderstanding
 
 ## Documentation
 
@@ -634,6 +690,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
 - **Core:** Apply software engineering to operations; SLI/SLO/SLA; error budgets balance reliability vs. feature velocity (100% is the wrong target); eliminate toil with ~50% ops cap; blameless postmortems; four golden signals (latency, traffic, errors, saturation); release & capacity engineering
 
+### Effective Java
+- **Proponents:** Joshua Bloch
+- **Core:** Catalog of ~90 "Items" of idiomatic Java best practice — static factories & the Builder pattern, the equals/hashCode contracts, minimize mutability, composition over inheritance, generics with PECS, enums over int constants, and try-with-resources
+
 ## Statistical Methods
 
 ### SPC (Statistical Process Control)
@@ -699,6 +759,30 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Also known as:** MHC, Meaningful Human Control over Individual Attacks
 - **Proponents:** Article 36 (coined the term, 2013), Noel Sharkey (five-level framework, 2014), ICRC, UN CCW GGE, IEEE Global Initiative
 - **Core:** Requirement that humans retain genuine, substantive control over autonomous systems making high-stakes decisions — not merely formulaic "human-in-the-loop" oversight; demands situational awareness, an identifiable accountability chain (never transferable to machines), positive human authorization of critical actions, and timely intervention/override; Sharkey's five levels (L1 human deliberates → L5 fully autonomous) classify the degree of autonomy; originates in the autonomous-weapons / international humanitarian law debate but applies to medical AI, autonomous driving, and critical infrastructure; underlies the EU AI Act's human-oversight requirements
+
+### OKR (Objectives and Key Results)
+- **Proponents:** Andy Grove, John Doerr
+- **Core:** A qualitative Objective paired with 3-5 measurable Key Results, set on a quarterly cadence as ambitious stretch goals (~0.7 = success), kept transparent for alignment and decoupled from compensation
+
+### Eisenhower Matrix
+- **Also known as:** Urgent-Important Matrix, Eisenhower Box, Time Management Matrix
+- **Proponents:** Dwight D. Eisenhower (attrib.), Stephen Covey
+- **Core:** Plots tasks on two axes — urgency × importance — into four quadrants (Do, Schedule, Delegate, Delete) to separate genuine importance from manufactured urgency; admitted with a Criticism section (mere-urgency effect) since its framing is contested
+
+### Consent vs. Consensus
+- **Proponents:** Gerard Endenburg (Sociocracy), Brian Robertson (Holacracy)
+- **Core:** Consensus requires everyone's active "yes"; consent requires only the absence of a paramount, reasoned objection ("good enough for now, safe enough to try"), so objections are argued and integrated rather than vetoed — speeding decisions and avoiding lowest-common-denominator outcomes and groupthink
+
+## Knowledge Management
+
+### Dreyfus Model of Skill Acquisition
+- **Proponents:** Stuart Dreyfus, Hubert Dreyfus
+- **Core:** Five stages from Novice to Expert (Novice, Advanced Beginner, Competent, Proficient, Expert) tracing a shift from rigid rule-following to intuitive pattern recognition, so teaching and explanation depth should match the learner's stage
+
+### ADDIE Model
+- **Also known as:** ADDIE, Instructional Systems Design (ISD)
+- **Proponents:** Florida State University; Robert Maribe Branch
+- **Core:** Five-phase instructional-design process — Analysis, Design, Development, Implementation, Evaluation (formative + summative, often paired with Kirkpatrick) — modern usage iterative rather than strict waterfall
 
 ## Creative Writing & Storytelling
 


### PR DESCRIPTION
## Summary

Adds **18 new semantic anchors** (English + German each, 36 files) plus the AgentSkill catalog updates (both copies), from a triage of the open `[Anchor Proposal]` issues. Each anchor follows the house format, links only to existing anchors, and carries a fetch-verified `== Criticism` / `== Current Status` section **only where a named, citable source was found** (per the #603 convention).

Generated artifacts (`docs/all-anchors.adoc`, `website/public/data/*.json`, `llms.txt`, `sitemap.xml`) are intentionally **not** included — CI/deploy regenerates them from these sources.

## Anchors by theme

**Architecture & Design** — Circuit Breaker (#630), Strangler Fig (#631), Team Topologies (#632), Twelve-Factor App (#622), Separation of Concerns (#627), Unix Philosophy (#628), Design by Contract (#633)

**Strategy, Problem-Solving & Requirements** — OKR (#635), Fermi Estimation (#608), Eisenhower Matrix (#623, with mandatory Criticism), Laddering (#634), Consent vs. Consensus (#626), req42 (#625)

**Communication & Learning** — Curse of Knowledge (#638), Four-Sides Model (#636), Dreyfus Model of Skill Acquisition (#637), Effective Java (#618), ADDIE Model (#621)

Adds a new **Knowledge Management** section to the catalog for Dreyfus & ADDIE.

## Notes for review
- Slugs disambiguated where the bare term is polysemous: `four-sides-model`, `dreyfus-skill-acquisition`, `laddering` (title "Laddering (Interview Technique)").
- **Eisenhower Matrix** is admitted deliberately *with* a fetch-verified Criticism section (mere-urgency effect; Covey's own caution) — a worked example of the "Rung 0" handling discussed in #624. The heavier `:advisory:` metadata question stays open on #624.
- A second reviewer pass over all 18 found no major issues; minor fixes (DE cross-links for SoC↔Unix, OKR list syntax) are already folded in.

Closes #630, #631, #632, #622, #627, #628, #633, #635, #608, #623, #634, #626, #625, #638, #636, #637, #618, #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwHxWa3srvd79sQo5FBhQk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Zahlreiche neue Wissensseiten zu Architektur-, Design-, Kommunikations-, Planungs- und Lernkonzepten wurden ergänzt.
* **Dokumentation**
  * Inhalte zu Themen wie Circuit Breaker, Strangler Fig, Team Topologies, Twelve-Factor App, OKR, ADDIE, Design by Contract, Unix Philosophy und weiteren Begriffen wurden erweitert.
  * Der semantische Anker-Katalog wurde um passende Einträge und Verlinkungen ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->