### PR TITLE
fix: req42 anchor title breaks deploy build

### DIFF
--- a/docs/anchors/req42.adoc
+++ b/docs/anchors/req42.adoc
@@ -1,4 +1,4 @@
-= req42
+= req42 Requirements Framework
 :categories: requirements-engineering
 :roles: business-analyst, software-architect, product-owner
 :related: arc42, ears-requirements, cockburn-use-cases, docs-as-code

--- a/docs/anchors/req42.de.adoc
+++ b/docs/anchors/req42.de.adoc
@@ -1,4 +1,4 @@
-= req42
+= req42 Requirements Framework
 :categories: requirements-engineering
 :roles: business-analyst, software-architect, product-owner
 :related: arc42, ears-requirements, cockburn-use-cases, docs-as-code


### PR DESCRIPTION
## Problem

The deploy build on `main` is failing at the **Extract metadata and generate sitemap** step:

```
req42.adoc:
   - Missing or invalid title
❌ Found 1 files with errors.
```

([failing run](https://github.com/LLM-Coding/Semantic-Anchors/actions/runs/28267223543/job/83756677634))

## Cause

`scripts/extract-metadata.js` treats a title as invalid when it equals the filename id:

```js
if (!anchor.title || anchor.title === id) {
  errors.push(`Missing or invalid title`)
}
```

This is a heuristic for "no real document title was set". The `req42` anchor's title was literally `= req42`, which equals its id `req42`, so it tripped the check — even though that is a legitimate title.

## Fix

Give `req42` a descriptive title in the same style as `arc42` ("arc42 Architecture Documentation"):

```
= req42 Requirements Framework
```

Applied to both `req42.adoc` and `req42.de.adoc` for consistency.

Verified locally: `npm run extract-metadata` now reports `✓ req42.adoc` and exits 0; `npm run generate-sitemap` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Die Dokumenttitel der Anforderungen wurden aktualisiert und sind nun aussagekräftiger, auf Englisch und Deutsch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->