### PR TITLE
docs: viability test for anchor proposals — recognition ≠ activation (#640)

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-anchor.yml
+++ b/.github/ISSUE_TEMPLATE/propose-anchor.yml
@@ -71,6 +71,24 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: viability-test
+    attributes:
+      label: Viability Test (Optional but encouraged)
+      description: |
+        Recognition is not activation. Does naming this anchor actually change the
+        LLM's output structure? Compare: (A) the task without the anchor term vs.
+        (B) the same task with it. See the training-data-vs-practice article for the
+        methodology.
+      placeholder: |
+        Task: "..."
+        Without anchor: [brief description of output structure]
+        With anchor: [brief description of output structure]
+        Structural difference: [what changed]
+        Weak model tested: [model name, result]
+    validations:
+      required: false
+
   - type: checkboxes
     id: checklist
     attributes:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -90,6 +90,16 @@ Evaluate the response:
 * *Depth:* Does it cover multiple related concepts?
 * *Specificity:* Is the scope well-defined?
 
+== Viability Test (Does the anchor deliver?)
+
+Recognition is not activation. A model can talk fluently *about* a term while naming it changes nothing in the output — or worse, silently substitutes an older concept or confabulates a plausible-but-fictitious one. The link:https://llm-coding.github.io/Semantic-Anchors/training-data-vs-practice[training-data-vs-practice] article documents these failure modes across model families. The activation test above catches recognition; the viability test below catches delivery.
+
+. *Before/After test.* Give a model a task *without* the anchor term, then the same task *with* it. Does the output structure change? If not, the term is decorative, not functional.
+. *Substitution check.* Ask "What is [term]?" on a weaker model (Haiku-class). If it hedges, silently substitutes, or confabulates, the prior is too thin for an anchor — it belongs in a *Contract* (which supplies its own meaning), per the thin-prior rule in _Artifact Types_ above.
+. *Cross-model check.* Does the before/after difference hold on at least one weak *and* one strong model? If it only fires on frontier models, note it as ★★ (needs qualification).
+
+A term that passes the four Quality Criteria but fails the viability test is a *Contract*, not an Anchor.
+
 == Developer Setup
 
 === Prerequisites

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -88,6 +88,16 @@ Bewerten Sie die Antwort:
 * *Tiefe:* Deckt es mehrere verwandte Konzepte ab?
 * *Spezifität:* Ist der Umfang gut definiert?
 
+== Viability-Test (Liefert der Anker?)
+
+Erkennung ist nicht Aktivierung. Ein Modell kann flüssig *über* einen Begriff reden, während sein Benennen an der Ausgabe nichts ändert — oder schlimmer: still ein älteres Konzept substituiert oder ein plausibel klingendes, aber erfundenes konfabuliert. Der link:https://llm-coding.github.io/Semantic-Anchors/training-data-vs-practice[training-data-vs-practice]-Artikel dokumentiert diese Failure-Modes über Modellfamilien hinweg. Der Aktivierungstest oben fängt die Erkennung; der Viability-Test unten fängt die Lieferung.
+
+. *Before/After-Test.* Dem Modell eine Aufgabe *ohne* den Anker-Term geben, dann dieselbe Aufgabe *mit* ihm. Ändert sich die Ausgabestruktur? Wenn nicht, ist der Term dekorativ, nicht funktional.
+. *Substitutions-Check.* "Was ist [Term]?" auf einem schwächeren Modell (Haiku-Klasse) fragen. Hedgt es, substituiert still oder konfabuliert es, ist der Prior zu dünn für einen Anchor — er gehört in einen *Contract* (der seine eigene Bedeutung mitliefert), gemäß der Thin-Prior-Regel unter _Artefakttypen_.
+. *Cross-Model-Check.* Hält der Before/After-Unterschied auf mindestens einem schwachen *und* einem starken Modell? Wenn nur auf Frontier-Modellen, als ★★ (needs qualification) notieren.
+
+Ein Term, der die vier Qualitätskriterien besteht, aber den Viability-Test nicht, ist ein *Contract*, kein Anchor.
+
 == Wie man einen neuen Anker vorschlägt
 
 Wir verwenden einen *automatisierten Workflow mit GitHub Copilot* zur Validierung und Anreicherung von Vorschlägen:

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,11 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-27
 
+*Viability test for anchor proposals — recognition ≠ activation (#640):*
+
+* Contribution guidance now tests not just whether a model *recognizes* a term but whether naming it *changes the output*. A new "Viability Test" section in `CONTRIBUTING.adoc` / `CONTRIBUTING.de.adoc` adds a before/after test, a substitution check (silent substitution / confabulation on weaker models), and a cross-model check; `propose-anchor.yml` gains an optional viability-test field. A term that passes the four quality criteria but fails viability belongs in a *Contract*, not an anchor — the destination the taxonomy (#585) defines. Proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/640[#640].
+* The "Not in training data" rejection category was sharpened and renamed *Insufficient training-data density*, distinguishing recognition from activation and pointing thin-prior terms at a Semantic Contract.
+
 *Artifact taxonomy formalised — Anchor vs. Contract vs. Skill (#585):*
 
 * The three artifact types the catalog ships now have an explicit, written definition instead of an implicitly-reconstructed one. New `ADR-007` (Nygard + Pugh, +63 vs. keeping it implicit) defines each type by function, linguistic shape and loading behaviour, plus a discrimination test; the working definitions are mirrored into `CONTRIBUTING.adoc` and `CONTRIBUTING.de.adoc` so contributors meet them where they look. ADR drafted by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/585[#585].

--- a/docs/rejected-proposals.adoc
+++ b/docs/rejected-proposals.adoc
@@ -9,8 +9,8 @@ Understanding why proposals are rejected helps contributors submit better propos
 Structurally unsuitable::
 The term is too vague, has no defined methodology, or is a pure instruction rather than a concept. Fails the link:#/about[Precise] and/or link:#/about[Rich] criteria.
 
-Not in training data::
-A legitimate concept or framework, but not established enough in LLM training data to reliably activate the right knowledge. Fails the link:#/about[Consistent] criterion.
+Insufficient training-data density::
+A legitimate concept or framework that is *recognized* (models can talk about it) but does not reliably *activate* in outputs: naming it does not structurally change the result compared to a generic prompt, or it triggers silent substitution / confabulation on weaker models. Fails the link:#/about[Consistent] criterion. Terms here may become viable anchors as training data grows — until then, a link:#/contracts[Semantic Contract] (which supplies its own meaning) is the right home. (Formerly "Not in training data".)
 
 Too niche::
 A real methodology but too specialized for reliable activation across different LLMs and contexts. Fails the link:#/about[Consistent] and/or link:#/about[Rich] criteria.
@@ -42,7 +42,7 @@ A real methodology but too specialized for reliable activation across different 
 *Now available as link:#/contracts[Semantic Contract]*: "Layer Boundaries".
 
 | *MIRRR UX Framework* (https://github.com/LLM-Coding/Semantic-Anchors/issues/150[#150])
-| Not in training data
+| Insufficient training-data density
 | A real UX framework with defined methodology, but not widely enough documented for LLMs to reliably recognize it and activate the correct concepts.
 
 | *YOLO* (https://github.com/LLM-Coding/Semantic-Anchors/issues/443[#443])


### PR DESCRIPTION
Closes #640. Phase 2 of the meta/taxonomy chain (follows #585).

Recognition is not activation — a model can talk fluently *about* a term while naming it changes nothing, or silently substitutes an older concept / confabulates on weaker models. The current activation test ("what do you associate with X?") only catches recognition.

## What's in

- **`CONTRIBUTING.adoc` + `docs/CONTRIBUTING.de.adoc`** — new *Viability Test* section: before/after test, substitution check, cross-model check. A term that passes the four quality criteria but fails viability is a *Contract*, not an Anchor — the destination #585's taxonomy defines.
- **`.github/ISSUE_TEMPLATE/propose-anchor.yml`** — optional `viability-test` field after the activation test (optional now, per #640; can become a gate once adopted).
- **`docs/rejected-proposals.adoc`** — sharpened + renamed the "Not in training data" category to *Insufficient training-data density* (distinguishes recognition from activation; points thin-prior terms at a Semantic Contract). Updated the one entry (MIRRR) that used the old label.
- **Changelog** entry.

Docs only, no code. Builds on the thin-prior rule landed in #585. Authorship credited to @JensGrote.

## Note
#624 (counter-consensus framing / `:advisory:`) is the other half of Phase 2 and carries a maintainer decision (Option A reject-category vs. Option B keep-with-advisory vs. both) — it follows as a separate PR once that's decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)