### PR TITLE
feat: counter-consensus advisory flag + rejection category (#624)

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-anchor.yml
+++ b/.github/ISSUE_TEMPLATE/propose-anchor.yml
@@ -71,6 +71,24 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: viability-test
+    attributes:
+      label: Viability Test (Optional but encouraged)
+      description: |
+        Recognition is not activation. Does naming this anchor actually change the
+        LLM's output structure? Compare: (A) the task without the anchor term vs.
+        (B) the same task with it. See the training-data-vs-practice article for the
+        methodology.
+      placeholder: |
+        Task: "..."
+        Without anchor: [brief description of output structure]
+        With anchor: [brief description of output structure]
+        Structural difference: [what changed]
+        Weak model tested: [model name, result]
+    validations:
+      required: false
+
   - type: checkboxes
     id: checklist
     attributes:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -217,6 +217,7 @@ Each anchor is stored as an AsciiDoc file with metadata attributes:
 * `:proponents:` - Key people, publications, or standards
 * `:tags:` - Keywords for search (optional but recommended)
 * `:related:` - Related anchor IDs (optional)
+* `:advisory:` - Short caution label (optional). Use only for *counter-consensus framing*: the anchor activates reliably but its framing conflicts with its own field's documented consensus. Renders as a visible badge in the card/modal; keep the detail and the cited source in the `== Criticism` / `== Current Status` section (single source of truth). See `eisenhower-matrix.adoc`.
 
 *Criticism and Current Status (research required, include when found):*
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -90,6 +90,16 @@ Evaluate the response:
 * *Depth:* Does it cover multiple related concepts?
 * *Specificity:* Is the scope well-defined?
 
+== Viability Test (Does the anchor deliver?)
+
+Recognition is not activation. A model can talk fluently *about* a term while naming it changes nothing in the output — or worse, silently substitutes an older concept or confabulates a plausible-but-fictitious one. The link:https://llm-coding.github.io/Semantic-Anchors/training-data-vs-practice[training-data-vs-practice] article documents these failure modes across model families. The activation test above catches recognition; the viability test below catches delivery.
+
+. *Before/After test.* Give a model a task *without* the anchor term, then the same task *with* it. Does the output structure change? If not, the term is decorative, not functional.
+. *Substitution check.* Ask "What is [term]?" on a weaker model (Haiku-class). If it hedges, silently substitutes, or confabulates, the prior is too thin for an anchor — it belongs in a *Contract* (which supplies its own meaning), per the thin-prior rule in _Artifact Types_ above.
+. *Cross-model check.* Does the before/after difference hold on at least one weak *and* one strong model? If it only fires on frontier models, note it as ★★ (needs qualification).
+
+A term that passes the four Quality Criteria but fails the viability test is a *Contract*, not an Anchor.
+
 == Developer Setup
 
 === Prerequisites

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -88,6 +88,16 @@ Bewerten Sie die Antwort:
 * *Tiefe:* Deckt es mehrere verwandte Konzepte ab?
 * *Spezifität:* Ist der Umfang gut definiert?
 
+== Viability-Test (Liefert der Anker?)
+
+Erkennung ist nicht Aktivierung. Ein Modell kann flüssig *über* einen Begriff reden, während sein Benennen an der Ausgabe nichts ändert — oder schlimmer: still ein älteres Konzept substituiert oder ein plausibel klingendes, aber erfundenes konfabuliert. Der link:https://llm-coding.github.io/Semantic-Anchors/training-data-vs-practice[training-data-vs-practice]-Artikel dokumentiert diese Failure-Modes über Modellfamilien hinweg. Der Aktivierungstest oben fängt die Erkennung; der Viability-Test unten fängt die Lieferung.
+
+. *Before/After-Test.* Dem Modell eine Aufgabe *ohne* den Anker-Term geben, dann dieselbe Aufgabe *mit* ihm. Ändert sich die Ausgabestruktur? Wenn nicht, ist der Term dekorativ, nicht funktional.
+. *Substitutions-Check.* "Was ist [Term]?" auf einem schwächeren Modell (Haiku-Klasse) fragen. Hedgt es, substituiert still oder konfabuliert es, ist der Prior zu dünn für einen Anchor — er gehört in einen *Contract* (der seine eigene Bedeutung mitliefert), gemäß der Thin-Prior-Regel unter _Artefakttypen_.
+. *Cross-Model-Check.* Hält der Before/After-Unterschied auf mindestens einem schwachen *und* einem starken Modell? Wenn nur auf Frontier-Modellen, als ★★ (needs qualification) notieren.
+
+Ein Term, der die vier Qualitätskriterien besteht, aber den Viability-Test nicht, ist ein *Contract*, kein Anchor.
+
 == Wie man einen neuen Anker vorschlägt
 
 Wir verwenden einen *automatisierten Workflow mit GitHub Copilot* zur Validierung und Anreicherung von Vorschlägen:

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -174,6 +174,7 @@ Jeder Anker wird als AsciiDoc-Datei mit Metadaten-Attributen gespeichert:
 * `:proponents:` - Schlüsselpersonen, Publikationen oder Standards
 * `:tags:` - Schlüsselwörter für die Suche (optional, aber empfohlen)
 * `:related:` - Verwandte Anker-IDs (optional)
+* `:advisory:` - Kurzes Hinweis-Label (optional). Nur für *Counter-Consensus-Framing*: Der Anker aktiviert zuverlässig, aber sein Framing widerspricht dem dokumentierten Konsens seines eigenen Fachgebiets. Wird als sichtbares Badge in Karte/Modal gerendert; Detail und zitierte Quelle bleiben im `== Criticism` / `== Current Status`-Abschnitt (Single Source of Truth). Siehe `eisenhower-matrix.adoc`.
 
 == Gegenbeispiele
 

--- a/docs/anchors/eisenhower-matrix.adoc
+++ b/docs/anchors/eisenhower-matrix.adoc
@@ -5,6 +5,7 @@
 :proponents: Dwight D. Eisenhower, Stephen Covey
 :tags: prioritization, time-management, urgency, importance, productivity
 :tier: 2
+:advisory: Activates an urgency-first framing its own field cautions against (see Criticism)
 
 [%collapsible]
 ====
@@ -47,4 +48,9 @@ Key Proponents:: Dwight D. Eisenhower (attrib.) — popularized the urgent/impor
 * General critique that a 2x2 grid oversimplifies prioritization — it treats "importance" and "urgency" as binary and independent, ignoring dependencies, effort/cost, value magnitude, and time-decay, dimensions that richer methods (e.g. weighted scoring, cost-of-delay) make explicit.
 
 The Criticism section reports the discourse; it does not adjudicate it.
+
+[discrete]
+== *Current Status*:
+
+Actively used and widely taught. The point of caution is not obsolescence but framing: the matrix activates a "sort by urgency × importance" logic that its own field documents as vulnerable to the *mere-urgency effect* (Zhu, Yang & Hsee 2018; see Criticism). Use it to *separate* importance from urgency — not as licence to act on whatever is merely urgent. This is why the anchor carries an `:advisory:` flag.
 ====

--- a/docs/anchors/eisenhower-matrix.de.adoc
+++ b/docs/anchors/eisenhower-matrix.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Dwight D. Eisenhower, Stephen Covey
 :tags: prioritization, time-management, urgency, importance, productivity
 :tier: 2
+:advisory: Aktiviert ein Dringlichkeits-Framing, vor dem das eigene Fachgebiet warnt (siehe Kritik)
 
 [%collapsible]
 ====
@@ -47,4 +48,9 @@ Schlüsselvertreter:: Dwight D. Eisenhower (zugeschrieben) — popularisierte di
 * Allgemeine Kritik, dass ein 2x2-Raster Priorisierung übervereinfacht — es behandelt "Wichtigkeit" und "Dringlichkeit" als binär und unabhängig und ignoriert Abhängigkeiten, Aufwand/Kosten, Wertgröße und Zeit-Verfall, also Dimensionen, die reichere Methoden (z. B. gewichtete Bewertung, Cost of Delay) explizit machen.
 
 Der Kritik-Abschnitt gibt den Diskurs wieder; er entscheidet ihn nicht.
+
+[discrete]
+== *Aktueller Stand*:
+
+Aktiv genutzt und weit verbreitet gelehrt. Der Vorbehalt betrifft nicht Veraltung, sondern das Framing: Die Matrix aktiviert eine "nach Dringlichkeit × Wichtigkeit sortieren"-Logik, die ihr eigenes Fachgebiet als anfällig für den *Mere-Urgency-Effekt* dokumentiert (Zhu, Yang & Hsee 2018; siehe Kritik). Nutze sie, um Wichtigkeit *von* Dringlichkeit zu trennen — nicht als Freibrief, das bloß Dringliche zu tun. Deshalb trägt der Anchor ein `:advisory:`-Flag.
 ====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-27
 
+*Counter-consensus framing — advisory flag + rejection category (#624):*
+
+* Some terms activate reliably yet prime a framing their own field cautions against (e.g. the Eisenhower Matrix and the "mere-urgency effect"). Two new handling paths: a hard rejection category *Counter-consensus framing* in `rejected-proposals.adoc` (which requires a cited consensus source from the framework's own field), and — for terms worth keeping — an optional `:advisory:` anchor attribute that renders as a visible amber badge on the card and a banner in the modal, with the detail and source staying in the anchor's Criticism / Current Status section (single source of truth). The Eisenhower Matrix is the seed: it gains an `:advisory:` flag and a `== Current Status` section. Proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/624[#624].
+
 *Viability test for anchor proposals — recognition ≠ activation (#640):*
 
 * Contribution guidance now tests not just whether a model *recognizes* a term but whether naming it *changes the output*. A new "Viability Test" section in `CONTRIBUTING.adoc` / `CONTRIBUTING.de.adoc` adds a before/after test, a substitution check (silent substitution / confabulation on weaker models), and a cross-model check; `propose-anchor.yml` gains an optional viability-test field. A term that passes the four quality criteria but fails viability belongs in a *Contract*, not an anchor — the destination the taxonomy (#585) defines. Proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/640[#640].

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,11 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-27
 
+*Viability test for anchor proposals — recognition ≠ activation (#640):*
+
+* Contribution guidance now tests not just whether a model *recognizes* a term but whether naming it *changes the output*. A new "Viability Test" section in `CONTRIBUTING.adoc` / `CONTRIBUTING.de.adoc` adds a before/after test, a substitution check (silent substitution / confabulation on weaker models), and a cross-model check; `propose-anchor.yml` gains an optional viability-test field. A term that passes the four quality criteria but fails viability belongs in a *Contract*, not an anchor — the destination the taxonomy (#585) defines. Proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/640[#640].
+* The "Not in training data" rejection category was sharpened and renamed *Insufficient training-data density*, distinguishing recognition from activation and pointing thin-prior terms at a Semantic Contract.
+
 *Artifact taxonomy formalised — Anchor vs. Contract vs. Skill (#585):*
 
 * The three artifact types the catalog ships now have an explicit, written definition instead of an implicitly-reconstructed one. New `ADR-007` (Nygard + Pugh, +63 vs. keeping it implicit) defines each type by function, linguistic shape and loading behaviour, plus a discrimination test; the working definitions are mirrored into `CONTRIBUTING.adoc` and `CONTRIBUTING.de.adoc` so contributors meet them where they look. ADR drafted by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/585[#585].

--- a/docs/rejected-proposals.adoc
+++ b/docs/rejected-proposals.adoc
@@ -15,6 +15,9 @@ A legitimate concept or framework that is *recognized* (models can talk about it
 Too niche::
 A real methodology but too specialized for reliable activation across different LLMs and contexts. Fails the link:#/about[Consistent] and/or link:#/about[Rich] criteria.
 
+Counter-consensus framing::
+The term reliably activates coherent knowledge (it passes all four criteria), but the activated framing contradicts the documented consensus of the framework's *own source field* — admitting it would prime an LLM toward an approach its own canonical literature marks as misleading or superseded. This category requires *citing that consensus source*; it must not rest on a contributor's personal disagreement. Where the term is still worth keeping, the alternative to outright rejection is to admit it with an `:advisory:` flag (a visible caution in the card/modal, detail in the anchor's Criticism / Current Status section) — see the Eisenhower Matrix.
+
 == Rejected Proposals
 
 [cols="2,2,3", options="header"]

--- a/docs/rejected-proposals.adoc
+++ b/docs/rejected-proposals.adoc
@@ -9,8 +9,8 @@ Understanding why proposals are rejected helps contributors submit better propos
 Structurally unsuitable::
 The term is too vague, has no defined methodology, or is a pure instruction rather than a concept. Fails the link:#/about[Precise] and/or link:#/about[Rich] criteria.
 
-Not in training data::
-A legitimate concept or framework, but not established enough in LLM training data to reliably activate the right knowledge. Fails the link:#/about[Consistent] criterion.
+Insufficient training-data density::
+A legitimate concept or framework that is *recognized* (models can talk about it) but does not reliably *activate* in outputs: naming it does not structurally change the result compared to a generic prompt, or it triggers silent substitution / confabulation on weaker models. Fails the link:#/about[Consistent] criterion. Terms here may become viable anchors as training data grows — until then, a link:#/contracts[Semantic Contract] (which supplies its own meaning) is the right home. (Formerly "Not in training data".)
 
 Too niche::
 A real methodology but too specialized for reliable activation across different LLMs and contexts. Fails the link:#/about[Consistent] and/or link:#/about[Rich] criteria.
@@ -42,7 +42,7 @@ A real methodology but too specialized for reliable activation across different 
 *Now available as link:#/contracts[Semantic Contract]*: "Layer Boundaries".
 
 | *MIRRR UX Framework* (https://github.com/LLM-Coding/Semantic-Anchors/issues/150[#150])
-| Not in training data
+| Insufficient training-data density
 | A real UX framework with defined methodology, but not widely enough documented for LLMs to reliably recognize it and activate the correct concepts.
 
 | *YOLO* (https://github.com/LLM-Coding/Semantic-Anchors/issues/443[#443])

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -89,6 +89,12 @@ function parseAnchorFile(filePath) {
   const tierAttr = attributes.tier
   if (tierAttr) anchor.tier = parseInt(tierAttr, 10)
 
+  // Optional advisory: a short caution label for anchors whose activated framing
+  // conflicts with their field's own consensus (#624). The detail/source lives in
+  // the anchor's Criticism / Current Status section (SSOT); this is only the flag.
+  const advisoryAttr = attributes.advisory
+  if (advisoryAttr) anchor.advisory = decodeHtmlEntities(advisoryAttr.trim())
+
   // Validation
   const errors = []
   const warnings = []

--- a/scripts/extract-metadata.test.js
+++ b/scripts/extract-metadata.test.js
@@ -29,6 +29,31 @@ describe('extract-metadata', () => {
     const strategy = anchors.find((a) => a.id === 'gof-strategy-pattern')
     expect(strategy).toBeDefined()
     expect(strategy.umbrella).toBe('gof-design-patterns')
-    expect(strategy.tier).toBe(1)
+    expect(strategy.tier).toBe(3)
+  })
+
+  it('should extract the optional :advisory: attribute', () => {
+    execFileSync('node', ['scripts/extract-metadata.js'], {
+      cwd: path.join(__dirname, '..'),
+      stdio: 'pipe',
+    })
+
+    const anchors = JSON.parse(
+      fs.readFileSync(
+        path.join(__dirname, '..', 'website', 'public', 'data', 'anchors.json'),
+        'utf-8'
+      )
+    )
+
+    // Eisenhower Matrix carries an advisory (counter-consensus framing, #624).
+    const eisenhower = anchors.find((a) => a.id === 'eisenhower-matrix')
+    expect(eisenhower).toBeDefined()
+    expect(typeof eisenhower.advisory).toBe('string')
+    expect(eisenhower.advisory.length).toBeGreaterThan(0)
+
+    // Anchors without the attribute must not carry an empty advisory field.
+    const withoutAdvisory = anchors.find((a) => a.id === 'gof-design-patterns')
+    expect(withoutAdvisory).toBeDefined()
+    expect(withoutAdvisory.advisory).toBeUndefined()
   })
 })

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -269,6 +269,21 @@ export async function loadAnchorContent(anchorId) {
     const allAnchors = await fetchAnchorsData()
     const currentAnchor = allAnchors.find((a) => a.id === anchorId)
 
+    // Advisory banner (#624): a counter-consensus-framing caution. The detail and
+    // source live in the anchor's Criticism / Current Status section below (SSOT);
+    // this banner is only the flag and points the reader there. Built via DOM APIs
+    // with textContent (not innerHTML) so the label can never be an HTML sink.
+    if (currentAnchor?.advisory) {
+      const banner = document.createElement('div')
+      banner.className = 'anchor-advisory-banner'
+      banner.setAttribute('role', 'note')
+      const icon = document.createElement('span')
+      icon.setAttribute('aria-hidden', 'true')
+      icon.textContent = '⚠'
+      banner.append(icon, ` ${currentAnchor.advisory}`)
+      contentEl.insertBefore(banner, contentEl.firstChild)
+    }
+
     if (currentAnchor?.subAnchors) {
       // Safe: renderSubAnchorList uses escapeHtml for all dynamic values
       contentEl.innerHTML += renderSubAnchorList(currentAnchor.subAnchors, allAnchors)

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -232,6 +232,14 @@ function renderAnchorCard(anchor, categoryColor, categoryId) {
       </div>
 
       ${
+        anchor.advisory
+          ? `
+        <div class="anchor-advisory-badge" role="note" aria-label="${escapeHtml(i18n.t('card.advisory'))}: ${escapeHtml(anchor.advisory)}"><span aria-hidden="true">⚠</span> ${escapeHtml(anchor.advisory)}</div>
+      `
+          : ''
+      }
+
+      ${
         anchor.proponents && anchor.proponents.length > 0
           ? `
         <p class="anchor-card-proponents">${escapeHtml(anchor.proponents.slice(0, 2).join(', '))}</p>

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -61,6 +61,38 @@ describe('umbrella anchors', () => {
   })
 })
 
+describe('advisory badge', () => {
+  const categories = [{ id: 'strategic-planning', name: 'Strategy' }]
+  const make = (advisory) => [
+    {
+      id: 'eisenhower-matrix',
+      title: 'Eisenhower Matrix',
+      categories: ['strategic-planning'],
+      roles: ['team-lead'],
+      tags: [],
+      proponents: [],
+      ...(advisory ? { advisory } : {}),
+    },
+  ]
+
+  it('renders an advisory badge with the label when anchor.advisory is set', () => {
+    const html = renderCardGrid(categories, make('Use with caution: primes urgency'))
+    expect(html).toContain('anchor-advisory-badge')
+    expect(html).toContain('Use with caution: primes urgency')
+  })
+
+  it('does not render an advisory badge when anchor.advisory is absent', () => {
+    const html = renderCardGrid(categories, make(null))
+    expect(html).not.toContain('anchor-advisory-badge')
+  })
+
+  it('escapes the advisory label', () => {
+    const html = renderCardGrid(categories, make('<script>x</script>'))
+    expect(html).not.toContain('<script>x</script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})
+
 describe('category quick-nav', () => {
   const categories = [
     { id: 'testing-quality', name: 'Testing' },

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -252,6 +252,20 @@ html {
   @apply italic;
 }
 
+/* Advisory flag (#624): counter-consensus-framing caution. Amber palette chosen
+   for AA contrast in both themes; detail/source live in the Criticism section. */
+.anchor-advisory-badge {
+  @apply inline-flex items-start gap-1 mb-2 px-2 py-1 rounded text-xs font-medium;
+  @apply bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200;
+  @apply border border-amber-300 dark:border-amber-800;
+}
+
+.anchor-advisory-banner {
+  @apply flex items-start gap-2 mb-4 px-4 py-3 rounded-lg text-sm font-medium;
+  @apply bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200;
+  @apply border border-amber-300 dark:border-amber-800;
+}
+
 .anchor-card-meta {
   @apply flex flex-wrap items-center gap-2 text-xs;
   @apply text-gray-500 dark:text-gray-400;

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -112,6 +112,7 @@
   "card.edit": "Auf GitHub bearbeiten",
   "card.copyKeyword": "Schlüsselwort in Zwischenablage kopieren",
   "card.keywordCopied": "Schlüsselwort kopiert!",
+  "card.advisory": "Hinweis",
   "card.copyLink": "Link zu diesem Anker kopieren",
   "card.linkCopied": "Link kopiert!",
   "card.roles": "Rolle",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -112,6 +112,7 @@
   "card.edit": "Edit on GitHub",
   "card.copyKeyword": "Copy keyword to clipboard",
   "card.keywordCopied": "Keyword copied!",
+  "card.advisory": "Advisory",
   "card.copyLink": "Copy link to this anchor",
   "card.linkCopied": "Link copied!",
   "card.roles": "role",


### PR DESCRIPTION
Closes #624. Completes Phase 2 of the meta/taxonomy chain.

> ⚠️ **Stacked on #646** (the #640 viability test). Merge #646 first; until then this PR's diff also shows #640's commits. After #646 merges I'll rebase so only the #624 delta remains.

Some terms activate reliably yet prime a framing their own field cautions against — e.g. the Eisenhower Matrix and the documented *mere-urgency effect*. The issue deliberately left the mechanism to maintainers; you chose **both** paths:

## Option A — hard rejection category
`docs/rejected-proposals.adoc` gains *Counter-consensus framing*: the term passes all four criteria but its activated framing contradicts its own field's consensus. Requires a **cited consensus source** from that field — not a contributor's personal disagreement.

## Option B — keep with an advisory flag
- New optional **`:advisory:`** anchor attribute. `extract-metadata.js` parses it into `anchors.json`.
- The **card** shows an amber badge; the **modal** an amber banner. Both built via DOM + `textContent` (no `innerHTML` sink — flagged by the security hook and avoided).
- Detail and source stay in the anchor's `== Criticism` / `== Current Status` section (single source of truth); the flag only points there.
- **Eisenhower Matrix** is the seed: it gains `:advisory:` + a `== Current Status` section (EN+DE). I did **not** mark it "Deprecated" (the issue's example wording) because that's factually wrong — it's contested, not obsolete; the Current Status says exactly that.

Documented in `CONTRIBUTING.adoc` / `.de.adoc`.

## Tests & verification
- TDD: unit tests for the parser (`:advisory:` present/absent) and the card badge (presence/absence/HTML-escaping). Full suite green (root + 118 website).
- Visually verified with Playwright: one amber badge on the Eisenhower card, amber banner in the modal, `role="note"`, correct text. (Lint + format + build all pass.)
- Fixes a **pre-existing stale unit test** (`gof-strategy-pattern` tier is 3, not 1) — CI doesn't run unit tests, so it had drifted to red on main.

Generated `website/public/data/*.json` intentionally not committed — CI/deploy regenerates them (incl. the new `advisory` field).

Advisory mechanism proposed by @rehsack in #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)