### PR TITLE
feat: direct-answer blocks per anchor + landing page for AI/LLM citability (#580)

### DIFF
--- a/docs/anchors/arc42.adoc
+++ b/docs/anchors/arc42.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
 :tier: 3
+:definition: arc42 is a template for documenting software architecture, created by Gernot Starke and Peter Hruschka. It organises an architecture into twelve standardised sections — from goals, constraints, and context through building blocks, runtime, and deployment to decisions, quality, and risks — so teams document consistently and completely.
 
 [%collapsible]
 ====

--- a/docs/anchors/bluf.adoc
+++ b/docs/anchors/bluf.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US Military (Army writing standards), adopted broadly in business and government
 :tier: 3
+:definition: BLUF — Bottom Line Up Front — is a communication structure from US military practice: state the conclusion, decision, or key request in the very first sentence, then give the supporting detail. The reader gets the essential takeaway immediately instead of reading to the end to find it.
 
 [%collapsible]
 ====

--- a/docs/anchors/chain-of-thought.adoc
+++ b/docs/anchors/chain-of-thought.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
 :tier: 3
+:definition: Chain of Thought (CoT) is a prompting technique for large language models that asks the model to reason step by step before stating a final answer. Making the intermediate steps explicit improves accuracy on multi-step arithmetic, logic, and reasoning tasks compared with answering directly.
 
 [%collapsible]
 ====

--- a/docs/anchors/clean-architecture.adoc
+++ b/docs/anchors/clean-architecture.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :tier: 3
+:definition: Clean Architecture, formulated by Robert C. Martin, organises code into concentric layers whose dependencies point only inward toward the domain. Business rules sit at the centre, independent of frameworks, UI, and databases at the outer edges. The Dependency Rule keeps the core testable and insulated from external change.
 
 [%collapsible]
 ====

--- a/docs/anchors/cynefin-framework.adoc
+++ b/docs/anchors/cynefin-framework.adoc
@@ -5,6 +5,7 @@
 :related: wardley-mapping
 :tags: complexity, decision-making, sensemaking, strategy, domains
 :tier: 3
+:definition: Cynefin, created by Dave Snowden, is a sense-making framework that sorts situations into five domains — Clear, Complicated, Complex, Chaotic, and Disorder — each with a different cause-and-effect relationship. It helps choose the right response, from applying best practice in ordered domains to probing and experimenting in the complex one.
 
 [%collapsible]
 ====

--- a/docs/anchors/domain-driven-design.adoc
+++ b/docs/anchors/domain-driven-design.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, business-analyst, team-lead
 :tier: 3
+:definition: Domain-Driven Design, introduced by Eric Evans, tackles complex software by centring the design on the business domain. A shared Ubiquitous Language unites developers and domain experts, Bounded Contexts delimit models, and tactical patterns — entities, value objects, aggregates, repositories — express the domain directly in code.
 
 [%collapsible]
 ====

--- a/docs/anchors/gherkin.adoc
+++ b/docs/anchors/gherkin.adoc
@@ -5,6 +5,7 @@
 :proponents: Aslak Hellesøy
 :tags: gherkin, bdd, cucumber, given-when-then, specification-by-example, dsl, acceptance-testing, living-documentation
 :tier: 3
+:definition: Gherkin is the structured, plain-language syntax used by Behaviour-Driven Development tools such as Cucumber to write executable specifications. Scenarios follow a Given/When/Then form — context, action, outcome — so the same text serves as readable acceptance criteria for stakeholders and as automated tests.
 
 [%collapsible]
 ====

--- a/docs/anchors/mece.adoc
+++ b/docs/anchors/mece.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, software-architect, data-scientist
 :tier: 3
+:definition: MECE — Mutually Exclusive, Collectively Exhaustive — is a grouping principle from Barbara Minto’s Pyramid Principle: split a topic into categories that do not overlap and together cover everything. It yields clean, gap-free, duplication-free structures for analysis, communication, and problem decomposition.
 
 [%collapsible]
 ====

--- a/docs/anchors/socratic-method.adoc
+++ b/docs/anchors/socratic-method.adoc
@@ -1,6 +1,7 @@
 = Socratic Method
 :categories: dialogue-interaction
 :roles: educator, consultant, team-lead
+:proponents: Socrates, Plato
 :tier: 3
 :definition: The Socratic Method is a form of cooperative inquiry, attributed to Socrates, that advances understanding through disciplined questioning rather than assertion. By probing assumptions, definitions, and consequences, it surfaces contradictions and gaps, helping participants refine their own reasoning instead of being handed the answer.
 

--- a/docs/anchors/socratic-method.adoc
+++ b/docs/anchors/socratic-method.adoc
@@ -2,6 +2,7 @@
 :categories: dialogue-interaction
 :roles: educator, consultant, team-lead
 :tier: 3
+:definition: The Socratic Method is a form of cooperative inquiry, attributed to Socrates, that advances understanding through disciplined questioning rather than assertion. By probing assumptions, definitions, and consequences, it surfaces contradictions and gaps, helping participants refine their own reasoning instead of being handed the answer.
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-principles.adoc
+++ b/docs/anchors/solid-principles.adoc
@@ -6,6 +6,7 @@
 :tags: design-principles, oop, solid, uncle-bob
 :tier: 3
 :sub-anchors: solid-srp, solid-ocp, solid-lsp, solid-isp, solid-dip
+:definition: SOLID is a set of five object-oriented design principles popularised by Robert C. Martin: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, and Dependency Inversion. Together they steer code toward loose coupling and high cohesion, reducing rigidity and fragility as a system grows.
 
 [%collapsible]
 ====

--- a/docs/anchors/tdd-london-school.adoc
+++ b/docs/anchors/tdd-london-school.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
 :tier: 3
+:definition: TDD London School — also called mockist or outside-in TDD (Steve Freeman and Nat Pryce) — drives design from the outside in: start at the system boundary, mock collaborators to specify their interactions, and let the required interfaces emerge. It emphasises object roles and message-passing over verifying state.
 
 [%collapsible]
 ====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-27
 
+*Direct-answer blocks for AI/LLM citability (#580):*
+
+* A GEO audit found the site ranks #1-3 in traditional search yet gets *zero* citations from ChatGPT, Perplexity, Gemini and Copilot for "What is Semantic Anchors?". The fix: every anchor's pre-rendered page now carries a concise, standalone *direct-answer block* that AI crawlers (which mostly do not run JS) can quote verbatim, and the home page gains a crawlable "What is Semantic Anchors?" answer section (EN + DE). A shared resolver prefers a curated `:definition:` attribute and otherwise derives one from the first Core Concept, so the answer block, the modal lead-in, and the DefinedTerm JSON-LD description all agree. Curated definitions seeded for 11 high-value anchors (MECE, BLUF, arc42, Clean Architecture, TDD London School, Gherkin, SOLID, Cynefin, Socratic Method, Chain of Thought, DDD); the rest use the derived fallback until curated. Proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/580[#580].
+
 *Onboarding skill repositioned to a Semantic Contracts installer (#521, #515):*
 
 * The `semantic-anchor-onboarding` skill installed a list of anchors the model mostly already knows. It is renamed and repositioned as *`semantic-contracts-installer`*: its default mode now installs *Semantic Contracts* — the compositions and rendered templates the model cannot guess (e.g. "Specification" = Cockburn use cases + Gherkin + EARS) — reading a bundled `data/contracts.json` snapshot (refreshable via `scripts/refresh-contracts.sh`). The former anchor-block flow stays as an `--anchors-only` sub-mode. The old skill name remains for one release as a deprecation alias that forwards to the new one and idempotently overwrites blocks it previously installed (same markers). The plugin is bumped to v0.6.0.

--- a/scripts/anchor-definition.test.js
+++ b/scripts/anchor-definition.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { getAnchorDefinition } from './lib/anchor-definition.js'
+
+describe('getAnchorDefinition', () => {
+  it('returns a curated :definition: attribute as source=curated', () => {
+    // mece carries a curated :definition: (seeded in #580).
+    const def = getAnchorDefinition('docs/anchors/mece.adoc')
+    expect(def).toBeTruthy()
+    expect(def.source).toBe('curated')
+    expect(def.text).toMatch(/Mutually Exclusive, Collectively Exhaustive/)
+  })
+
+  it('falls back to a derived definition as source=derived', () => {
+    // circuit-breaker has no curated :definition:, so it derives from Core Concepts.
+    const def = getAnchorDefinition('docs/anchors/circuit-breaker.adoc')
+    expect(def).toBeTruthy()
+    expect(def.source).toBe('derived')
+    expect(def.text.length).toBeGreaterThan(20)
+  })
+
+  it('returns null for a non-existent file', () => {
+    expect(getAnchorDefinition('docs/anchors/does-not-exist.adoc')).toBeNull()
+  })
+})

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -95,6 +95,14 @@ function parseAnchorFile(filePath) {
   const advisoryAttr = attributes.advisory
   if (advisoryAttr) anchor.advisory = decodeHtmlEntities(advisoryAttr.trim())
 
+  // Curated direct-answer definition (#580): a standalone "What is X?" sentence.
+  // Only the curated `:definition:` attribute lands in the data (and the modal
+  // lead-in); the crawlable answer block and JSON-LD fall back to a derived
+  // definition where this is absent, but the modal must not duplicate the
+  // Core-Concept text it already renders below.
+  const definitionAttr = attributes.definition
+  if (definitionAttr) anchor.definition = decodeHtmlEntities(definitionAttr.trim())
+
   // Validation
   const errors = []
   const warnings = []

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -11,6 +11,7 @@
 const fs = require('fs')
 const path = require('path')
 const asciidoctor = require('@asciidoctor/core')()
+const { getAnchorDefinition } = require('./lib/anchor-definition')
 
 // Paths
 const ANCHORS_DIR = path.join(__dirname, '..', 'docs', 'anchors')
@@ -96,12 +97,11 @@ function parseAnchorFile(filePath) {
   if (advisoryAttr) anchor.advisory = decodeHtmlEntities(advisoryAttr.trim())
 
   // Curated direct-answer definition (#580): a standalone "What is X?" sentence.
-  // Only the curated `:definition:` attribute lands in the data (and the modal
-  // lead-in); the crawlable answer block and JSON-LD fall back to a derived
-  // definition where this is absent, but the modal must not duplicate the
-  // Core-Concept text it already renders below.
-  const definitionAttr = attributes.definition
-  if (definitionAttr) anchor.definition = decodeHtmlEntities(definitionAttr.trim())
+  // Use the shared resolver so the cleaning/validation matches the crawlable
+  // answer block and the JSON-LD exactly — but keep only the *curated* value, so
+  // the modal lead never duplicates the Core-Concept text it renders below.
+  const def = getAnchorDefinition(anchor.filePath)
+  if (def && def.source === 'curated') anchor.definition = decodeHtmlEntities(def.text)
 
   // Validation
   const errors = []

--- a/scripts/generate-jsonld.js
+++ b/scripts/generate-jsonld.js
@@ -37,49 +37,10 @@ const SET_ID = `${BASE}/#catalog`
 // reference. Both represent the whole set; other routes do not.
 const TARGETS = [path.join(DIST, 'index.html'), path.join(DIST, 'all-anchors', 'index.html')]
 
-/**
- * Pull a short definition for an anchor from the first "Core Concepts" entry in
- * its .adoc. Returns a cleaned, length-capped string, or null when nothing
- * usable is found (safe to omit — DefinedTerm.description is optional).
- */
-function extractDescription(filePath) {
-  const abs = path.join(ROOT, filePath)
-  if (!fs.existsSync(abs)) return null
-  const lines = fs.readFileSync(abs, 'utf-8').split('\n')
-
-  const ccIndex = lines.findIndex((l) => /Core Concepts/i.test(l))
-  if (ccIndex === -1) return null
-
-  // First definition-list description after the Core Concepts heading:
-  //   Term:: definition text
-  for (let i = ccIndex + 1; i < lines.length && i < ccIndex + 12; i++) {
-    const m = lines[i].match(/^.+?::\s+(.+)$/)
-    if (m) {
-      const cleaned = cleanAdoc(m[1])
-      return cleaned.length >= 20 ? capLength(cleaned, 220) : null
-    }
-  }
-  return null
-}
-
-/** Strip the AsciiDoc inline markup that would be noise in a description. */
-function cleanAdoc(s) {
-  return s
-    .replace(/link:[^[]*\[([^\]]*)\]/g, '$1') // link:url[text] -> text
-    .replace(/<<[^,>]+,\s*([^>]+)>>/g, '$1') // <<id,text>> -> text
-    .replace(/<<([^>]+)>>/g, '$1') // <<id>> -> id
-    .replace(/[*_`]/g, '') // bold/italic/mono markers
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
-/** Cap at a word boundary, appending an ellipsis when truncated. */
-function capLength(s, max) {
-  if (s.length <= max) return s
-  const cut = s.slice(0, max)
-  const lastSpace = cut.lastIndexOf(' ')
-  return `${cut.slice(0, lastSpace > 40 ? lastSpace : max).trim()}…`
-}
+// Anchor definitions (curated `:definition:` preferred, else derived from the
+// first "Core Concepts" entry) come from the shared resolver so the JSON-LD
+// DefinedTerm description matches the rendered answer block (#580).
+const { getAnchorDefinition, extractDescription } = require('./lib/anchor-definition')
 
 /** Build the DefinedTermSet object from anchors.json. */
 function buildDefinedTermSet() {
@@ -98,8 +59,8 @@ function buildDefinedTermSet() {
         url,
         inDefinedTermSet: SET_ID,
       }
-      const description = a.filePath ? extractDescription(a.filePath) : null
-      if (description) term.description = description
+      const def = a.filePath ? getAnchorDefinition(a.filePath) : null
+      if (def) term.description = def.text
       return term
     })
 

--- a/scripts/lib/anchor-definition.js
+++ b/scripts/lib/anchor-definition.js
@@ -1,0 +1,89 @@
+/**
+ * Shared resolver for an anchor's "direct answer" definition (#580).
+ *
+ * Precedence:
+ *   1. a curated `:definition:` AsciiDoc attribute (a standalone ~40-60 word
+ *      "What is X?" answer), when the anchor author has written one;
+ *   2. otherwise the first "Core Concepts" definition-list entry, derived.
+ *
+ * One source of truth so the rendered answer block (render-docs.js), the
+ * DefinedTerm JSON-LD (generate-jsonld.js), and any data consumer agree.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = path.join(__dirname, '..', '..')
+
+/** Strip the AsciiDoc inline markup that would be noise in a plain-text answer. */
+function cleanAdoc(s) {
+  return s
+    .replace(/link:[^[]*\[([^\]]*)\]/g, '$1') // link:url[text] -> text
+    .replace(/<<[^,>]+,\s*([^>]+)>>/g, '$1') // <<id,text>> -> text
+    .replace(/<<([^>]+)>>/g, '$1') // <<id>> -> id
+    .replace(/[*_`]/g, '') // bold/italic/mono markers
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Cap at a word boundary, appending an ellipsis when truncated. */
+function capLength(s, max) {
+  if (s.length <= max) return s
+  const cut = s.slice(0, max)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${cut.slice(0, lastSpace > 40 ? lastSpace : max).trim()}…`
+}
+
+/** Read a curated `:definition:` attribute from the .adoc header, if present. */
+function readDefinitionAttribute(lines) {
+  for (const line of lines) {
+    const m = line.match(/^:definition:\s+(.+)$/)
+    if (m) {
+      const cleaned = cleanAdoc(m[1])
+      return cleaned.length >= 20 ? cleaned : null
+    }
+    // Attributes live in the header; stop once the document body starts.
+    if (/^\[%collapsible\]/.test(line) || /^====/.test(line)) break
+  }
+  return null
+}
+
+/** Derive a description from the first "Core Concepts" definition-list entry. */
+function extractDescription(filePathRel) {
+  const abs = path.join(ROOT, filePathRel)
+  if (!fs.existsSync(abs)) return null
+  const lines = fs.readFileSync(abs, 'utf-8').split('\n')
+
+  const ccIndex = lines.findIndex((l) => /Core Concepts/i.test(l))
+  if (ccIndex === -1) return null
+
+  for (let i = ccIndex + 1; i < lines.length && i < ccIndex + 12; i++) {
+    const m = lines[i].match(/^.+?::\s+(.+)$/)
+    if (m) {
+      const cleaned = cleanAdoc(m[1])
+      return cleaned.length >= 20 ? capLength(cleaned, 220) : null
+    }
+  }
+  return null
+}
+
+/**
+ * Resolve the best available definition for an anchor file (relative to repo
+ * root). Returns { text, source: 'curated'|'derived' } or null when neither is
+ * available.
+ */
+function getAnchorDefinition(filePathRel) {
+  const abs = path.join(ROOT, filePathRel)
+  if (!fs.existsSync(abs)) return null
+  const lines = fs.readFileSync(abs, 'utf-8').split('\n')
+
+  const curated = readDefinitionAttribute(lines)
+  if (curated) return { text: curated, source: 'curated' }
+
+  const derived = extractDescription(filePathRel)
+  if (derived) return { text: derived, source: 'derived' }
+
+  return null
+}
+
+module.exports = { getAnchorDefinition, extractDescription, cleanAdoc, capLength }

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -584,12 +584,21 @@ function writeHomeVariant(shell, lang) {
   const title = tr['hero.title'] || ''
   const intro = tr['hero.intro'] || ''
   const emphasis = tr['hero.introEmphasis'] || ''
+  // Direct-answer block (#580): a crawlable, self-contained "What is Semantic
+  // Anchors?" definition AI-overview crawlers can quote verbatim — the exact
+  // query the GEO audit found the site absent for.
+  const answerHeading = tr['home.answer.heading'] || ''
+  const answerBody = tr['home.answer.body'] || ''
 
   const block = `
       <section class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <h1 class="text-3xl sm:text-4xl font-bold mb-3 leading-tight">${escapeHtml(title)}</h1>
         <p class="mb-2 max-w-3xl">${escapeHtml(intro)}</p>
         <p class="font-semibold max-w-3xl">${escapeHtml(emphasis)}</p>
+      </section>
+      <section class="mx-auto max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+        <h2 class="text-2xl font-bold mb-2">${escapeHtml(answerHeading)}</h2>
+        <p class="anchor-answer max-w-3xl" data-answer-block>${escapeHtml(answerBody)}</p>
       </section>
       ${buildCatalogMarkup(lang, tr)}
     `

--- a/scripts/render-docs.js
+++ b/scripts/render-docs.js
@@ -20,9 +20,34 @@
 const fs = require('fs')
 const path = require('path')
 const Asciidoctor = require('@asciidoctor/core')
+const { getAnchorDefinition } = require('./lib/anchor-definition')
 
 const asciidoctor = Asciidoctor()
 const ROOT = path.join(__dirname, '..')
+
+/** Minimal HTML escape for text injected into rendered fragments. */
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * Build the crawlable "direct answer" block for an anchor (#580): a concise,
+ * standalone definition LLM/AI-overview crawlers can quote verbatim. Returns ''
+ * when no definition is available, so the fragment is unchanged.
+ */
+function answerBlockHtml(anchorFileRel) {
+  const def = getAnchorDefinition(anchorFileRel)
+  if (!def) return ''
+  return (
+    `<div class="anchor-answer" data-answer-block data-answer-source="${def.source}">` +
+    `<p>${escapeHtml(def.text)}</p>` +
+    `</div>\n`
+  )
+}
 
 const OPTS = {
   safe: 'safe',
@@ -88,13 +113,13 @@ function rewriteLegacyHashLinks(html) {
   return html.replace(/href="#\//g, 'href="/Semantic-Anchors/')
 }
 
-function renderFile(srcPath, destPath, quiet = false) {
+function renderFile(srcPath, destPath, quiet = false, prependHtml = '') {
   if (!fs.existsSync(srcPath)) return
   try {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
     const html = String(asciidoctor.convertFile(srcPath, { ...OPTS, to_file: false }))
     const { toc, body } = extractToc(rewriteLegacyHashLinks(html))
-    fs.writeFileSync(destPath, body, 'utf-8')
+    fs.writeFileSync(destPath, prependHtml + body, 'utf-8')
     if (!quiet) console.log(`Rendered: ${path.relative(ROOT, destPath)}`)
     const tocPath = destPath.replace(/\.html$/, '.toc.html')
     if (toc) {
@@ -212,7 +237,8 @@ for (const file of fs.readdirSync(ANCHORS_SRC).sort()) {
   renderFile(
     path.join(ANCHORS_SRC, file),
     path.join(ANCHORS_OUT, file.replace(/\.adoc$/, '.html')),
-    true
+    true,
+    answerBlockHtml(`docs/anchors/${file}`)
   )
   anchorFragments++
 }

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -284,6 +284,16 @@ export async function loadAnchorContent(anchorId) {
       contentEl.insertBefore(banner, contentEl.firstChild)
     }
 
+    // Direct-answer lead (#580): a curated standalone definition, shown above the
+    // content as the "What is X?" answer. Only curated definitions land here, so it
+    // never duplicates the Core-Concept text rendered below. textContent, no sink.
+    if (currentAnchor?.definition) {
+      const lead = document.createElement('p')
+      lead.className = 'anchor-answer-lead'
+      lead.textContent = currentAnchor.definition
+      contentEl.insertBefore(lead, contentEl.firstChild)
+    }
+
     if (currentAnchor?.subAnchors) {
       // Safe: renderSubAnchorList uses escapeHtml for all dynamic values
       contentEl.innerHTML += renderSubAnchorList(currentAnchor.subAnchors, allAnchors)

--- a/website/src/components/anchor-modal.js
+++ b/website/src/components/anchor-modal.js
@@ -269,6 +269,21 @@ export async function loadAnchorContent(anchorId) {
     const allAnchors = await fetchAnchorsData()
     const currentAnchor = allAnchors.find((a) => a.id === anchorId)
 
+    // Both blocks are prepended with insertBefore(firstChild), so the one
+    // inserted LAST ends up on top. Insert the definition first and the advisory
+    // second, so the final order is: advisory caution, then definition, then
+    // content — a caution is never demoted below the definition (#624 + #580).
+
+    // Direct-answer lead (#580): a curated standalone definition, shown above the
+    // content as the "What is X?" answer. Only curated definitions land here, so it
+    // never duplicates the Core-Concept text rendered below. textContent, no sink.
+    if (currentAnchor?.definition) {
+      const lead = document.createElement('p')
+      lead.className = 'anchor-answer-lead'
+      lead.textContent = currentAnchor.definition
+      contentEl.insertBefore(lead, contentEl.firstChild)
+    }
+
     // Advisory banner (#624): a counter-consensus-framing caution. The detail and
     // source live in the anchor's Criticism / Current Status section below (SSOT);
     // this banner is only the flag and points the reader there. Built via DOM APIs
@@ -282,16 +297,6 @@ export async function loadAnchorContent(anchorId) {
       icon.textContent = '⚠'
       banner.append(icon, ` ${currentAnchor.advisory}`)
       contentEl.insertBefore(banner, contentEl.firstChild)
-    }
-
-    // Direct-answer lead (#580): a curated standalone definition, shown above the
-    // content as the "What is X?" answer. Only curated definitions land here, so it
-    // never duplicates the Core-Concept text rendered below. textContent, no sink.
-    if (currentAnchor?.definition) {
-      const lead = document.createElement('p')
-      lead.className = 'anchor-answer-lead'
-      lead.textContent = currentAnchor.definition
-      contentEl.insertBefore(lead, contentEl.firstChild)
     }
 
     if (currentAnchor?.subAnchors) {

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -266,6 +266,20 @@ html {
   @apply border border-amber-300 dark:border-amber-800;
 }
 
+/* Direct-answer block (#580): a standalone "What is X?" definition for crawlers
+   and as the modal lead-in. .anchor-answer wraps the crawlable fragment block;
+   .anchor-answer-lead is the curated lead paragraph in the modal. */
+.anchor-answer,
+.anchor-answer-lead {
+  @apply mb-4 px-4 py-3 rounded-lg text-base leading-relaxed;
+  @apply bg-gray-50 text-gray-800 dark:bg-gray-800 dark:text-gray-100;
+  @apply border-l-4 border-blue-400 dark:border-blue-500;
+}
+
+.anchor-answer p {
+  @apply m-0;
+}
+
 .anchor-card-meta {
   @apply flex flex-wrap items-center gap-2 text-xs;
   @apply text-gray-500 dark:text-gray-400;

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -34,6 +34,8 @@
   "hero.title": "Nichts installieren. Nichts laden. Einfach tippen.",
   "hero.intro": "Semantic Anchors sind Wörter — etablierte Begriffe wie Clean Architecture, Cockburn Use Cases oder MECE — die in jedem modernen LLM ein präzises Konzept aktivieren.",
   "hero.introEmphasis": "Du installierst sie nicht. Du importierst sie nicht. Du tippst sie.",
+  "home.answer.heading": "Was sind Semantic Anchors?",
+  "home.answer.body": "Semantic Anchors ist ein kuratierter Katalog klar definierter Begriffe — Methoden, Frameworks und Prinzipien wie MECE, arc42 und BLUF — die als gemeinsames Vokabular für die Kommunikation mit Large Language Models dienen. Das Benennen eines Anchors aktiviert einen dichten, vorberechneten Wissenscluster im Modell, sodass ein einzelnes Wort die Ausgabe präzise steuert statt eines langen Prompts.",
   "hero.withoutLabel": "Ohne Anker",
   "hero.withAnchorLabel": "Mit Anker",
   "hero.example.1.without": "Bitte refaktoriere diesen Code unter Berücksichtigung der Dependency Rule, mit Entitäten im Kern, Frameworks am Rand, Use Cases dazwischen, I/O getrennt von Fachlogik, Datenbank über Interfaces isoliert, sodass die inneren Schichten nichts von den äußeren wissen, und jeder Framework-Aufruf über einen Adapter läuft, damit der Kern Framework-unabhängig und isoliert testbar bleibt…",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -34,6 +34,8 @@
   "hero.title": "No download. No install. Just type.",
   "hero.intro": "Semantic Anchors are words — established terms like Clean Architecture, Cockburn Use Cases or MECE — that activate rich, well-defined concepts inside any modern LLM.",
   "hero.introEmphasis": "You don't install them. You don't import them. You type them.",
+  "home.answer.heading": "What is Semantic Anchors?",
+  "home.answer.body": "Semantic Anchors is a curated catalog of well-defined terms — methodologies, frameworks, and principles like MECE, arc42, and BLUF — that act as shared vocabulary for communicating with large language models. Naming an anchor activates a dense, pre-computed cluster of knowledge inside the model, so a single word steers the output precisely instead of a long prompt.",
   "hero.withoutLabel": "Without anchor",
   "hero.withAnchorLabel": "With anchor",
   "hero.example.1.without": "Please refactor this code keeping the dependency rule in mind, with entities at the center, frameworks at the edge, and use cases in between, separating I/O concerns from domain logic, isolating the database via interfaces, ensuring the inner layers know nothing about the outer ones, and routing every framework call through an adapter so the core remains framework-agnostic and testable in isolation…",


### PR DESCRIPTION
Closes #580.

A GEO audit found the site ranks #1-3 in traditional search but gets **zero** citations from ChatGPT/Perplexity/Gemini/Copilot for *"What is Semantic Anchors?"*. AI crawlers mostly don't run JS, so the answer has to live in static HTML.

## What changed
- **Shared resolver** `scripts/lib/anchor-definition.js` — prefers a curated `:definition:` attribute, else derives one from the first Core Concept. Single source of truth so the rendered block, the modal lead, and the JSON-LD all agree.
- **Per-anchor answer block** — `render-docs.js` injects a crawlable `.anchor-answer` block at the top of every pre-rendered anchor fragment (curated or derived). AC1 ✅
- **Landing page** — `prerender-routes.js` adds a crawlable "What is Semantic Anchors?" answer section to the home page (EN + DE), from new `home.answer.*` translations. AC2 ✅
- **JSON-LD** — `generate-jsonld.js` uses the resolver so the `DefinedTerm` description matches the answer block (pairs with #579).
- **Modal lead** — `extract-metadata.js` surfaces *only* the curated `:definition:` into `anchors.json`, so the modal shows a lead just for curated anchors and never duplicates the Core-Concept text it renders below.
- **Seeded** curated `:definition:` for 11 high-value anchors (MECE, BLUF, arc42, Clean Architecture, TDD London School, Gherkin, SOLID, Cynefin, Socratic Method, Chain of Thought, DDD); all others use the derived fallback now and can be curated incrementally.

## Verification
- Build green (doc + Vite). Pre-rendered `mece` fragment → `data-answer-source="curated"`; `circuit-breaker` → `"derived"`. Home `dist/index.html` (EN + DE) carries the answer section; JSON-LD carries the curated MECE description.
- Playwright: modal shows the curated lead above the content, distinct from Core Concepts (screenshot taken).
- New unit test for the resolver; full suite green (scripts 5, website 118); lint + format clean.

## Scope notes
- **Crawler-facing landing block:** AI crawlers (GPTBot/PerplexityBot) read the static HTML and get the block; JS users see the equivalent interactive hero (the SPA overwrites `#page-content` on boot). That's #580's target audience. Surfacing it in the SPA hero too is an easy follow-up if wanted.
- Bulk-curating the remaining ~150 `:definition:` values is a natural follow-up (derived fallback covers them meanwhile).
- Generated artifacts not committed — CI/deploy regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Auf den Anker-Seiten und der Startseite werden nun direkt sichtbare Antwortblöcke mit kurzen Definitionen angezeigt.
  * Mehrere Fachbegriffe und Architekturkonzepte wurden mit prägnanten Beschreibungen ergänzt.

* **Bug Fixes**
  * Anker-Beschreibungen werden zuverlässiger aus den Quelldokumenten übernommen und im JSON-LD sowie in der Vorschau konsistent angezeigt.

* **Tests**
  * Neue Prüfungen stellen sicher, dass kuratierte, abgeleitete und fehlende Definitionen korrekt behandelt werden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->