### PR TITLE
docs: link anchor names in the changelog to their anchor pages

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -51,30 +51,30 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 _Architecture & Design_
 
-* *Circuit Breaker* — wraps a protected call in a state machine (Closed/Open/Half-Open) that trips to fail-fast once failures cross a threshold, preventing resource exhaustion and cascading failure (Michael Nygard, _Release It!_, 2007; Martin Fowler; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/630[#630])
-* *Strangler Fig* — incrementally replaces a legacy system by routing functionality to new code around its edges until the old system can be retired, avoiding a big-bang rewrite (Martin Fowler, 2004; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/631[#631])
-* *Team Topologies* — organises delivery around four team types (Stream-aligned, Enabling, Complicated-Subsystem, Platform) and three interaction modes for fast flow (Matthew Skelton & Manuel Pais, 2019; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/632[#632])
-* *Twelve-Factor App* — twelve practices for portable, scalable SaaS (explicit dependencies, config in the environment, stateless processes, disposability) (Adam Wiggins, Heroku, 2011; proposed by https://github.com/mc2259[@mc2259] in https://github.com/LLM-Coding/Semantic-Anchors/issues/622[#622])
-* *Separation of Concerns* — study and change each distinct aspect of a system in isolation, so one can be reasoned about without interference from the others (Edsger W. Dijkstra, 1974; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/627[#627])
-* *Unix Philosophy* — make each program do one thing well and compose small sharp tools via pipes (Doug McIlroy, 1978; Eric S. Raymond, _The Art of Unix Programming_, 2003; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/628[#628])
-* *Design by Contract* — specify routines with preconditions (caller's obligation), postconditions (supplier's guarantee) and invariants, assigning blame precisely when a contract is violated (Bertrand Meyer, Eiffel, 1986; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/633[#633])
+* *link:#/anchor/circuit-breaker[Circuit Breaker]* — wraps a protected call in a state machine (Closed/Open/Half-Open) that trips to fail-fast once failures cross a threshold, preventing resource exhaustion and cascading failure (Michael Nygard, _Release It!_, 2007; Martin Fowler; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/630[#630])
+* *link:#/anchor/strangler-fig[Strangler Fig]* — incrementally replaces a legacy system by routing functionality to new code around its edges until the old system can be retired, avoiding a big-bang rewrite (Martin Fowler, 2004; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/631[#631])
+* *link:#/anchor/team-topologies[Team Topologies]* — organises delivery around four team types (Stream-aligned, Enabling, Complicated-Subsystem, Platform) and three interaction modes for fast flow (Matthew Skelton & Manuel Pais, 2019; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/632[#632])
+* *link:#/anchor/twelve-factor-app[Twelve-Factor App]* — twelve practices for portable, scalable SaaS (explicit dependencies, config in the environment, stateless processes, disposability) (Adam Wiggins, Heroku, 2011; proposed by https://github.com/mc2259[@mc2259] in https://github.com/LLM-Coding/Semantic-Anchors/issues/622[#622])
+* *link:#/anchor/separation-of-concerns[Separation of Concerns]* — study and change each distinct aspect of a system in isolation, so one can be reasoned about without interference from the others (Edsger W. Dijkstra, 1974; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/627[#627])
+* *link:#/anchor/unix-philosophy[Unix Philosophy]* — make each program do one thing well and compose small sharp tools via pipes (Doug McIlroy, 1978; Eric S. Raymond, _The Art of Unix Programming_, 2003; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/628[#628])
+* *link:#/anchor/design-by-contract[Design by Contract]* — specify routines with preconditions (caller's obligation), postconditions (supplier's guarantee) and invariants, assigning blame precisely when a contract is violated (Bertrand Meyer, Eiffel, 1986; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/633[#633])
 
 _Strategy, Problem-Solving & Requirements_
 
-* *OKR (Objectives and Key Results)* — couples a qualitative Objective with a few measurable Key Results to focus and align goals (Andy Grove at Intel; popularised by John Doerr, _Measure What Matters_, 2018; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/635[#635])
-* *Fermi Estimation* — decompose an unknown quantity into estimable sub-quantities and reason in powers of ten to land the right order of magnitude (Enrico Fermi; proposed by Ralf D. Müller in https://github.com/LLM-Coding/Semantic-Anchors/issues/608[#608])
-* *Eisenhower Matrix* — plots tasks on urgency × importance to separate the two and prioritise accordingly; admitted deliberately _with_ a fetch-verified Criticism section (mere-urgency effect; Covey's own caution) (Dwight D. Eisenhower; popularised by Stephen Covey; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/623[#623])
-* *Laddering (Interview Technique)* — reconstructs the means-end chain attribute -> consequence -> value through repeated "why is that important to you?" probing (George Kelly; Hinkle; Reynolds & Gutman; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/634[#634])
-* *Consent vs. Consensus* — distinguishes decision by absence of a reasoned objection ("good enough for now, safe enough to try") from decision by everyone's active agreement (Gerard Endenburg, Sociocracy; Brian Robertson, Holacracy; proposed by https://github.com/fdesoye[@fdesoye] in https://github.com/LLM-Coding/Semantic-Anchors/issues/626[#626])
-* *req42* — the pragmatic, agile requirements framework structured as twelve "drawers" mirroring arc42; the requirements companion to arc42 (Peter Hruschka & Markus Meuten; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/625[#625])
+* *link:#/anchor/okr[OKR (Objectives and Key Results)]* — couples a qualitative Objective with a few measurable Key Results to focus and align goals (Andy Grove at Intel; popularised by John Doerr, _Measure What Matters_, 2018; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/635[#635])
+* *link:#/anchor/fermi-estimation[Fermi Estimation]* — decompose an unknown quantity into estimable sub-quantities and reason in powers of ten to land the right order of magnitude (Enrico Fermi; proposed by Ralf D. Müller in https://github.com/LLM-Coding/Semantic-Anchors/issues/608[#608])
+* *link:#/anchor/eisenhower-matrix[Eisenhower Matrix]* — plots tasks on urgency × importance to separate the two and prioritise accordingly; admitted deliberately _with_ a fetch-verified Criticism section (mere-urgency effect; Covey's own caution) (Dwight D. Eisenhower; popularised by Stephen Covey; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/623[#623])
+* *link:#/anchor/laddering[Laddering (Interview Technique)]* — reconstructs the means-end chain attribute -> consequence -> value through repeated "why is that important to you?" probing (George Kelly; Hinkle; Reynolds & Gutman; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/634[#634])
+* *link:#/anchor/consent-vs-consensus[Consent vs. Consensus]* — distinguishes decision by absence of a reasoned objection ("good enough for now, safe enough to try") from decision by everyone's active agreement (Gerard Endenburg, Sociocracy; Brian Robertson, Holacracy; proposed by https://github.com/fdesoye[@fdesoye] in https://github.com/LLM-Coding/Semantic-Anchors/issues/626[#626])
+* *link:#/anchor/req42[req42]* — the pragmatic, agile requirements framework structured as twelve "drawers" mirroring arc42; the requirements companion to arc42 (Peter Hruschka & Markus Meuten; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/625[#625])
 
 _Communication & Learning_
 
-* *Curse of Knowledge* — once you know something you cannot reconstruct not knowing it, so experts overestimate shared context (Camerer, Loewenstein & Weber, 1989; popularised by Chip & Dan Heath; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/638[#638])
-* *Four-Sides Model (Schulz von Thun)* — every message carries four sides at once — fact, self-revelation, relationship, appeal — and is heard with four matching "ears" (Friedemann Schulz von Thun, 1981; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/636[#636])
-* *Dreyfus Model of Skill Acquisition* — five stages from Novice to Expert describing how rule-following gives way to intuitive, context-driven mastery (Stuart & Hubert Dreyfus, 1980; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/637[#637])
-* *Effective Java* — Joshua Bloch's catalogue of ~90 concrete best-practice "Items" for idiomatic, robust Java (Joshua Bloch, 3rd ed. 2018; proposed by https://github.com/schtiefl[@schtiefl] in https://github.com/LLM-Coding/Semantic-Anchors/issues/618[#618])
-* *ADDIE Model* — the instructional-design process of Analysis, Design, Development, Implementation, Evaluation (Florida State University origin; codified by Robert Maribe Branch, 2009; proposed by https://github.com/davidlohner[@davidlohner] in https://github.com/LLM-Coding/Semantic-Anchors/issues/621[#621])
+* *link:#/anchor/curse-of-knowledge[Curse of Knowledge]* — once you know something you cannot reconstruct not knowing it, so experts overestimate shared context (Camerer, Loewenstein & Weber, 1989; popularised by Chip & Dan Heath; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/638[#638])
+* *link:#/anchor/four-sides-model[Four-Sides Model (Schulz von Thun)]* — every message carries four sides at once — fact, self-revelation, relationship, appeal — and is heard with four matching "ears" (Friedemann Schulz von Thun, 1981; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/636[#636])
+* *link:#/anchor/dreyfus-skill-acquisition[Dreyfus Model of Skill Acquisition]* — five stages from Novice to Expert describing how rule-following gives way to intuitive, context-driven mastery (Stuart & Hubert Dreyfus, 1980; proposed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/issues/637[#637])
+* *link:#/anchor/effective-java[Effective Java]* — Joshua Bloch's catalogue of ~90 concrete best-practice "Items" for idiomatic, robust Java (Joshua Bloch, 3rd ed. 2018; proposed by https://github.com/schtiefl[@schtiefl] in https://github.com/LLM-Coding/Semantic-Anchors/issues/618[#618])
+* *link:#/anchor/addie-model[ADDIE Model]* — the instructional-design process of Analysis, Design, Development, Implementation, Evaluation (Florida State University origin; codified by Robert Maribe Branch, 2009; proposed by https://github.com/davidlohner[@davidlohner] in https://github.com/LLM-Coding/Semantic-Anchors/issues/621[#621])
 
 A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
@@ -175,8 +175,8 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *IOSP (Integration Operation Segregation Principle)* — a function shall either contain logic (Operation) or call other functions (Integration), but never both; the formal refinement of SRP at function level; separates integration (coordination/sequencing) from operation (business logic/computation); eliminates mock-heavy tests by avoiding new'ing in functions that contain logic; formally checkable via IospAnalyzer (Roslyn); reduces the need for Dependency Injection (DIP) at the function level (Ralf Westphal, 2022; Stefan Lieser, 2025; proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/556[#556])
-* *AIDA Model* — the classic copywriting/advertising funnel: Attention → Interest → Desire → Action; a sequential hierarchy-of-effects model that makes persuasive copy do each job in turn (hook, relevance, wanting, call to action) instead of jumping to the ask; pins the canonical four-stage form and notes variants (AIDAS, AIDCA, AIDA-R); fills the persuasion/copywriting gap in the communication cluster (commonly attributed to E. St. Elmo Lewis, 1898)
+* *link:#/anchor/iosp[IOSP (Integration Operation Segregation Principle)]* — a function shall either contain logic (Operation) or call other functions (Integration), but never both; the formal refinement of SRP at function level; separates integration (coordination/sequencing) from operation (business logic/computation); eliminates mock-heavy tests by avoiding new'ing in functions that contain logic; formally checkable via IospAnalyzer (Roslyn); reduces the need for Dependency Injection (DIP) at the function level (Ralf Westphal, 2022; Stefan Lieser, 2025; proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/issues/556[#556])
+* *link:#/anchor/aida-model[AIDA Model]* — the classic copywriting/advertising funnel: Attention → Interest → Desire → Action; a sequential hierarchy-of-effects model that makes persuasive copy do each job in turn (hook, relevance, wanting, call to action) instead of jumping to the ask; pins the canonical four-stage form and notes variants (AIDAS, AIDCA, AIDA-R); fills the persuasion/copywriting gap in the communication cluster (commonly attributed to E. St. Elmo Lewis, 1898)
 
 *New contracts:*
 
@@ -186,9 +186,9 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *DRY (Don't Repeat Yourself)* — "every piece of knowledge must have a single, unambiguous, authoritative representation within a system"; targets duplicated knowledge/intent rather than coincidental textual similarity, with the Rule of Three (Fowler) and the wrong-abstraction caution ("duplication is far cheaper than the wrong abstraction", Sandi Metz) as guardrails; antonym WET (Andy Hunt & Dave Thomas, *The Pragmatic Programmer*, 1999; proposed by https://github.com/GaboCapo[@GaboCapo] in https://github.com/LLM-Coding/Semantic-Anchors/issues/560[#560])
-* *Event Storming according to Alberto Brandolini* — a collaborative workshop that models a domain as past-tense domain events on a timeline using a fixed colour notation (orange Event, blue Command, yellow Aggregate, lilac Policy, green Read Model, pink External System, red Hotspot) across three levels (Big Picture, Process Modeling, Design Level); surfaces bounded-context seams via pivotal events and makes assumptions explicit as hotspots; Reverse Event Storming reconstructs legacy systems (Alberto Brandolini, 2012/2013; proposed by https://github.com/SidekickJohn[@SidekickJohn] in https://github.com/LLM-Coding/Semantic-Anchors/issues/558[#558])
-* *Bloom's Taxonomy* — the six-level hierarchy of cognitive learning objectives (Remember, Understand, Apply, Analyze, Evaluate, Create) with measurable action verbs per level; pins the Revised 2001 version and its knowledge dimension; complements the teaching cluster (4MAT, Feynman, Socratic) by grading the cognitive *level* a step targets — so "demonstrated understanding" can be set at Apply/Analyze rather than recall (Benjamin Bloom, 1956; Anderson & Krathwohl revision, 2001)
+* *link:#/anchor/dry[DRY (Don't Repeat Yourself)]* — "every piece of knowledge must have a single, unambiguous, authoritative representation within a system"; targets duplicated knowledge/intent rather than coincidental textual similarity, with the Rule of Three (Fowler) and the wrong-abstraction caution ("duplication is far cheaper than the wrong abstraction", Sandi Metz) as guardrails; antonym WET (Andy Hunt & Dave Thomas, *The Pragmatic Programmer*, 1999; proposed by https://github.com/GaboCapo[@GaboCapo] in https://github.com/LLM-Coding/Semantic-Anchors/issues/560[#560])
+* *link:#/anchor/event-storming[Event Storming according to Alberto Brandolini]* — a collaborative workshop that models a domain as past-tense domain events on a timeline using a fixed colour notation (orange Event, blue Command, yellow Aggregate, lilac Policy, green Read Model, pink External System, red Hotspot) across three levels (Big Picture, Process Modeling, Design Level); surfaces bounded-context seams via pivotal events and makes assumptions explicit as hotspots; Reverse Event Storming reconstructs legacy systems (Alberto Brandolini, 2012/2013; proposed by https://github.com/SidekickJohn[@SidekickJohn] in https://github.com/LLM-Coding/Semantic-Anchors/issues/558[#558])
+* *link:#/anchor/blooms-taxonomy[Bloom's Taxonomy]* — the six-level hierarchy of cognitive learning objectives (Remember, Understand, Apply, Analyze, Evaluate, Create) with measurable action verbs per level; pins the Revised 2001 version and its knowledge dimension; complements the teaching cluster (4MAT, Feynman, Socratic) by grading the cognitive *level* a step targets — so "demonstrated understanding" can be set at Apply/Analyze rather than recall (Benjamin Bloom, 1956; Anderson & Krathwohl revision, 2001)
 
 *New contracts:*
 
@@ -198,24 +198,24 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *Meaningful Human Control (MHC)* — the requirement that humans keep genuine, substantive control over autonomous systems making high-stakes decisions, rather than formulaic "human-in-the-loop" oversight; demands situational awareness, an identifiable accountability chain that cannot pass to machines, positive human authorization of critical actions, and timely intervention; Sharkey's five levels (L1 human deliberates → L5 fully autonomous) grade the autonomy; rooted in the autonomous-weapons / international humanitarian law debate (Article 36, 2013) and now underpinning the EU AI Act's human-oversight rules (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/543[#543], issue https://github.com/LLM-Coding/Semantic-Anchors/issues/540[#540])
-* *Conway's Law* — organizations produce designs whose structure mirrors their communication structure; underlies team-topology and module-boundary reasoning and the Inverse Conway Maneuver (Melvin Conway, 1968; https://github.com/LLM-Coding/Semantic-Anchors/issues/506[#506])
-* *CAP Theorem* — a partitioned distributed system must trade Consistency against Availability; reframed by PACELC for the no-partition case (Brewer 2000; Gilbert & Lynch 2002; https://github.com/LLM-Coding/Semantic-Anchors/issues/508[#508])
-* *Fallacies of Distributed Computing* — the eight false network assumptions (reliable, zero latency, infinite bandwidth, secure, fixed topology, one admin, zero transport cost, homogeneous) as an audit checklist for distributed designs (L. P. Deutsch & J. Gosling, Sun; https://github.com/LLM-Coding/Semantic-Anchors/issues/507[#507])
-* *Law of Demeter* — "only talk to your immediate friends"; the Principle of Least Knowledge against train-wreck call chains (Ian Holland & Karl Lieberherr, Northeastern, 1987; https://github.com/LLM-Coding/Semantic-Anchors/issues/509[#509])
-* *First Principles Thinking* — decompose a problem to irreducible truths and reason up, instead of reasoning by analogy (roots in Aristotle/Descartes; https://github.com/LLM-Coding/Semantic-Anchors/issues/510[#510])
-* *Postel's Law* — the Robustness Principle: "be conservative in what you send, be liberal in what you accept", with the modern strictness/versioning caveat (Jon Postel, RFC 761, 1980; https://github.com/LLM-Coding/Semantic-Anchors/issues/512[#512])
-* *Goodhart's Law* — "when a measure becomes a target, it ceases to be a good measure"; a critique lens for KPIs and LLM-evaluation criteria (Charles Goodhart 1975; Strathern's formulation; https://github.com/LLM-Coding/Semantic-Anchors/issues/513[#513])
-* *Inverted Pyramid Style* — the journalistic news structure: most important information first, with a long prunable tail; distinct from BLUF (short) and the Pyramid Principle (complete argument) (proposed by https://github.com/mhchem[@mhchem] in https://github.com/LLM-Coding/Semantic-Anchors/issues/538[#538])
+* *link:#/anchor/meaningful-human-control[Meaningful Human Control (MHC)]* — the requirement that humans keep genuine, substantive control over autonomous systems making high-stakes decisions, rather than formulaic "human-in-the-loop" oversight; demands situational awareness, an identifiable accountability chain that cannot pass to machines, positive human authorization of critical actions, and timely intervention; Sharkey's five levels (L1 human deliberates → L5 fully autonomous) grade the autonomy; rooted in the autonomous-weapons / international humanitarian law debate (Article 36, 2013) and now underpinning the EU AI Act's human-oversight rules (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/543[#543], issue https://github.com/LLM-Coding/Semantic-Anchors/issues/540[#540])
+* *link:#/anchor/conways-law[Conway's Law]* — organizations produce designs whose structure mirrors their communication structure; underlies team-topology and module-boundary reasoning and the Inverse Conway Maneuver (Melvin Conway, 1968; https://github.com/LLM-Coding/Semantic-Anchors/issues/506[#506])
+* *link:#/anchor/cap-theorem[CAP Theorem]* — a partitioned distributed system must trade Consistency against Availability; reframed by PACELC for the no-partition case (Brewer 2000; Gilbert & Lynch 2002; https://github.com/LLM-Coding/Semantic-Anchors/issues/508[#508])
+* *link:#/anchor/fallacies-of-distributed-computing[Fallacies of Distributed Computing]* — the eight false network assumptions (reliable, zero latency, infinite bandwidth, secure, fixed topology, one admin, zero transport cost, homogeneous) as an audit checklist for distributed designs (L. P. Deutsch & J. Gosling, Sun; https://github.com/LLM-Coding/Semantic-Anchors/issues/507[#507])
+* *link:#/anchor/law-of-demeter[Law of Demeter]* — "only talk to your immediate friends"; the Principle of Least Knowledge against train-wreck call chains (Ian Holland & Karl Lieberherr, Northeastern, 1987; https://github.com/LLM-Coding/Semantic-Anchors/issues/509[#509])
+* *link:#/anchor/first-principles-thinking[First Principles Thinking]* — decompose a problem to irreducible truths and reason up, instead of reasoning by analogy (roots in Aristotle/Descartes; https://github.com/LLM-Coding/Semantic-Anchors/issues/510[#510])
+* *link:#/anchor/postels-law[Postel's Law]* — the Robustness Principle: "be conservative in what you send, be liberal in what you accept", with the modern strictness/versioning caveat (Jon Postel, RFC 761, 1980; https://github.com/LLM-Coding/Semantic-Anchors/issues/512[#512])
+* *link:#/anchor/goodharts-law[Goodhart's Law]* — "when a measure becomes a target, it ceases to be a good measure"; a critique lens for KPIs and LLM-evaluation criteria (Charles Goodhart 1975; Strathern's formulation; https://github.com/LLM-Coding/Semantic-Anchors/issues/513[#513])
+* *link:#/anchor/inverted-pyramid-style[Inverted Pyramid Style]* — the journalistic news structure: most important information first, with a long prunable tail; distinct from BLUF (short) and the Pyramid Principle (complete argument) (proposed by https://github.com/mhchem[@mhchem] in https://github.com/LLM-Coding/Semantic-Anchors/issues/538[#538])
 
 == 2026-05-22
 
 *New anchors:*
 
-* *Quality Attribute Scenario* — Bass, Clements & Kazman's six-part scenario format (SEI, *Software Architecture in Practice*) that turns a vague quality goal into a testable statement: Source, Stimulus, Artifact, Environment, Response, Response Measure; the Response Measure is what makes it verifiable. The format underlies arc42 Chapter 10 quality requirements and the leaves of an ATAM utility tree.
-* *Luhmann's System Theory* — Niklas Luhmann's sociological systems theory; autopoiesis, operational closure, structural coupling, double contingency, communication as the operation of social systems; a theory for analysing complex socio-technical systems where boundaries are contested (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
-* *Simon's Constructivism* — Fritz B. Simon's introduction to systems theory and constructivism; viability vs. truth, trivial vs. non-trivial machines, second-order cybernetics, perturbation instead of instruction (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
-* *Systemic Consulting (Heidelberg School)* — the Heidelberg School of systemic consulting after Fritz B. Simon; all-partiality, neutrality, circular questions, context clarification, intervention as irritation rather than instruction (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
+* *link:#/anchor/quality-attribute-scenario[Quality Attribute Scenario]* — Bass, Clements & Kazman's six-part scenario format (SEI, *Software Architecture in Practice*) that turns a vague quality goal into a testable statement: Source, Stimulus, Artifact, Environment, Response, Response Measure; the Response Measure is what makes it verifiable. The format underlies arc42 Chapter 10 quality requirements and the leaves of an ATAM utility tree.
+* *link:#/anchor/luhmann-system-theory[Luhmann's System Theory]* — Niklas Luhmann's sociological systems theory; autopoiesis, operational closure, structural coupling, double contingency, communication as the operation of social systems; a theory for analysing complex socio-technical systems where boundaries are contested (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
+* *link:#/anchor/simon-constructivism[Simon's Constructivism]* — Fritz B. Simon's introduction to systems theory and constructivism; viability vs. truth, trivial vs. non-trivial machines, second-order cybernetics, perturbation instead of instruction (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
+* *link:#/anchor/systemic-consulting[Systemic Consulting (Heidelberg School)]* — the Heidelberg School of systemic consulting after Fritz B. Simon; all-partiality, neutrality, circular questions, context clarification, intervention as irritation rather than instruction (proposed by https://github.com/JensGrote[@JensGrote] in https://github.com/LLM-Coding/Semantic-Anchors/pull/517[#517])
 
 *Contract updates:*
 
@@ -236,22 +236,22 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *Hoshin Kanri* — Yoji Akao's Lean strategy-deployment discipline; 3-5 year True North objectives cascade into annual hoshin via the X-Matrix, with two-way *catchball* negotiation and monthly Bowling-Chart reviews; deliberately restricted to the few vital goals (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/468[#468])
-* *Double Diamond* — UK Design Council's design-process model (2005, expanded 2019); two divergent-convergent cycles — Discover/Define (problem space) and Develop/Deliver (solution space); "design the right thing, then design the thing right" (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/467[#467])
-* *Decisional Balance Sheet* — Janis & Mann's four-cell decision matrix (1977) extending Franklin's "moral algebra"; surfaces utilitarian and social trade-offs, used in decision coaching and Motivational Interviewing to resolve ambivalence (proposed by https://github.com/Mabla70[@Mabla70] in https://github.com/LLM-Coding/Semantic-Anchors/issues/448[#448])
+* *link:#/anchor/hoshin-kanri[Hoshin Kanri]* — Yoji Akao's Lean strategy-deployment discipline; 3-5 year True North objectives cascade into annual hoshin via the X-Matrix, with two-way *catchball* negotiation and monthly Bowling-Chart reviews; deliberately restricted to the few vital goals (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/468[#468])
+* *link:#/anchor/double-diamond[Double Diamond]* — UK Design Council's design-process model (2005, expanded 2019); two divergent-convergent cycles — Discover/Define (problem space) and Develop/Deliver (solution space); "design the right thing, then design the thing right" (proposed by https://github.com/jaoltr[@jaoltr] in https://github.com/LLM-Coding/Semantic-Anchors/issues/467[#467])
+* *link:#/anchor/decisional-balance-sheet[Decisional Balance Sheet]* — Janis & Mann's four-cell decision matrix (1977) extending Franklin's "moral algebra"; surfaces utilitarian and social trade-offs, used in decision coaching and Motivational Interviewing to resolve ambivalence (proposed by https://github.com/Mabla70[@Mabla70] in https://github.com/LLM-Coding/Semantic-Anchors/issues/448[#448])
 
 == 2026-05-08
 
 *New anchors:*
 
-* *Kano Model* — Noriaki Kano's two-dimensional quality model classifying features as Must-be, Performance, Attractive, Indifferent or Reverse, surveyed via paired functional/dysfunctional questions; pairs naturally with MoSCoW for backlog prioritisation (proposed in https://github.com/LLM-Coding/Semantic-Anchors/issues/459[#459])
-* *Kotter's 8-Step Change Model* — John P. Kotter's classic transformation framework from *Leading Change* (HBR 1995, book 1996): urgency, guiding coalition, vision, communication, empowerment, short-term wins, consolidation, anchor in culture; the model is the inversion of the eight common errors that kill transformations (proposed in https://github.com/LLM-Coding/Semantic-Anchors/issues/460[#460])
+* *link:#/anchor/kano-model[Kano Model]* — Noriaki Kano's two-dimensional quality model classifying features as Must-be, Performance, Attractive, Indifferent or Reverse, surveyed via paired functional/dysfunctional questions; pairs naturally with MoSCoW for backlog prioritisation (proposed in https://github.com/LLM-Coding/Semantic-Anchors/issues/459[#459])
+* *link:#/anchor/kotter-8-step-change-model[Kotter's 8-Step Change Model]* — John P. Kotter's classic transformation framework from *Leading Change* (HBR 1995, book 1996): urgency, guiding coalition, vision, communication, empowerment, short-term wins, consolidation, anchor in culture; the model is the inversion of the eight common errors that kill transformations (proposed in https://github.com/LLM-Coding/Semantic-Anchors/issues/460[#460])
 
 == 2026-05-07
 
 *New anchors:*
 
-* *XY Problem* — Communication anti-pattern from technical-support culture, coined by Mark Jason Dominus (2001) and popularised by Eric S. Raymond ("How To Ask Questions The Smart Way"); the asker requests Y when the real goal is X (proposed by https://github.com/dernerl[@dernerl] in https://github.com/LLM-Coding/Semantic-Anchors/issues/457[#457])
+* *link:#/anchor/xy-problem[XY Problem]* — Communication anti-pattern from technical-support culture, coined by Mark Jason Dominus (2001) and popularised by Eric S. Raymond ("How To Ask Questions The Smart Way"); the asker requests Y when the real goal is X (proposed by https://github.com/dernerl[@dernerl] in https://github.com/LLM-Coding/Semantic-Anchors/issues/457[#457])
 
 == 2026-05-03
 
@@ -263,7 +263,7 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *Cockburn Use Cases* — Alistair Cockburn's structured textual use case format with Goal Levels (Summary, User Goal, Subfunction) and Actor-Goal List discovery technique
+* *link:#/anchor/cockburn-use-cases[Cockburn Use Cases]* — Alistair Cockburn's structured textual use case format with Goal Levels (Summary, User Goal, Subfunction) and Actor-Goal List discovery technique
 
 *New contracts:*
 
@@ -273,40 +273,40 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors:*
 
-* *Single Level of Abstraction Principle (SLAP)* — Kent Beck's Composed Method, codified as a Clean Code function-design rule by Robert C. Martin (proposed by https://github.com/eirikbell[@eirikbell] in https://github.com/LLM-Coding/Semantic-Anchors/issues/440[#440])
-* *Occam's Razor* — William of Ockham's parsimony principle applied to explanations, debugging and architecture rationale (proposed by https://github.com/danielschmeiss[@danielschmeiss] in https://github.com/LLM-Coding/Semantic-Anchors/issues/439[#439])
-* *Code Smells* — Kent Beck / Martin Fowler / Robert C. Martin catalogue of surface indications pointing to deeper design problems (proposed by https://github.com/ma7tz[@ma7tz] in https://github.com/LLM-Coding/Semantic-Anchors/issues/435[#435])
-* *What Would Chuck Norris Do? (WWCND)* — Tier 3 disposition-activator for direct commitment under uncertainty; originally rejected in https://github.com/LLM-Coding/Semantic-Anchors/issues/426[#426], re-proposed by https://github.com/cornelius[@cornelius] in https://github.com/LLM-Coding/Semantic-Anchors/issues/438[#438] with a 16-page empirical validation (3 models × 19 prompts × N=2 = 114 manually scored responses) that passed all four catalog criteria
+* *link:#/anchor/single-level-of-abstraction-principle[Single Level of Abstraction Principle (SLAP)]* — Kent Beck's Composed Method, codified as a Clean Code function-design rule by Robert C. Martin (proposed by https://github.com/eirikbell[@eirikbell] in https://github.com/LLM-Coding/Semantic-Anchors/issues/440[#440])
+* *link:#/anchor/occams-razor[Occam's Razor]* — William of Ockham's parsimony principle applied to explanations, debugging and architecture rationale (proposed by https://github.com/danielschmeiss[@danielschmeiss] in https://github.com/LLM-Coding/Semantic-Anchors/issues/439[#439])
+* *link:#/anchor/code-smells[Code Smells]* — Kent Beck / Martin Fowler / Robert C. Martin catalogue of surface indications pointing to deeper design problems (proposed by https://github.com/ma7tz[@ma7tz] in https://github.com/LLM-Coding/Semantic-Anchors/issues/435[#435])
+* *link:#/anchor/what-would-chuck-norris-do[What Would Chuck Norris Do? (WWCND)]* — Tier 3 disposition-activator for direct commitment under uncertainty; originally rejected in https://github.com/LLM-Coding/Semantic-Anchors/issues/426[#426], re-proposed by https://github.com/cornelius[@cornelius] in https://github.com/LLM-Coding/Semantic-Anchors/issues/438[#438] with a 16-page empirical validation (3 models × 19 prompts × N=2 = 114 manually scored responses) that passed all four catalog criteria
 
 == 2026-04-15
 
 *New anchors* (proposed by Ralf D. Müller in https://github.com/LLM-Coding/Semantic-Anchors/issues/436[#436]):
 
-* *Lehman's Software Classification* — Meir M. Lehman's S-/P-/E-type taxonomy and Laws of Software Evolution
+* *link:#/anchor/lehmans-classification[Lehman's Software Classification]* — Meir M. Lehman's S-/P-/E-type taxonomy and Laws of Software Evolution
 
 == 2026-04-12
 
 *New anchors:*
 
-* *Red/Green TDD* — Kent Beck's classical TDD cycle (proposed by https://github.com/petehodgson-tribe[@petehodgson-tribe] in https://github.com/LLM-Coding/Semantic-Anchors/issues/412[#412])
-* *4MAT* — Bernice McCarthy's learning cycle: why → what → how → what if (proposed by https://github.com/rweisleder[@rweisleder] in https://github.com/LLM-Coding/Semantic-Anchors/issues/413[#413])
-* *Walking Skeleton* — Alistair Cockburn's end-to-end production-capable skeleton (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/420[#420])
-* *Tracer Bullet* — Hunt & Thomas's exploratory end-to-end slice (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/421[#421])
-* *Thin Vertical Slice* — Cockburn & Cohn's end-to-end delivery technique (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/422[#422])
-* *Spike Solution* — Kent Beck's time-boxed XP research technique (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/423[#423])
-* *Minimum Viable Product (MVP)* — Eric Ries's lean-startup hypothesis validation (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/424[#424])
+* *link:#/anchor/red-green-tdd[Red/Green TDD]* — Kent Beck's classical TDD cycle (proposed by https://github.com/petehodgson-tribe[@petehodgson-tribe] in https://github.com/LLM-Coding/Semantic-Anchors/issues/412[#412])
+* *link:#/anchor/4mat[4MAT]* — Bernice McCarthy's learning cycle: why → what → how → what if (proposed by https://github.com/rweisleder[@rweisleder] in https://github.com/LLM-Coding/Semantic-Anchors/issues/413[#413])
+* *link:#/anchor/walking-skeleton[Walking Skeleton]* — Alistair Cockburn's end-to-end production-capable skeleton (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/420[#420])
+* *link:#/anchor/tracer-bullet[Tracer Bullet]* — Hunt & Thomas's exploratory end-to-end slice (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/421[#421])
+* *link:#/anchor/thin-vertical-slice[Thin Vertical Slice]* — Cockburn & Cohn's end-to-end delivery technique (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/422[#422])
+* *link:#/anchor/spike-solution[Spike Solution]* — Kent Beck's time-boxed XP research technique (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/423[#423])
+* *link:#/anchor/mvp[Minimum Viable Product (MVP)]* — Eric Ries's lean-startup hypothesis validation (proposed by https://github.com/cpoepke[@cpoepke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/424[#424])
 
 == 2026-04-07
 
 *New anchors* (proposed by Gernot Starke):
 
-* *Cohesion Criteria (Constantine & Yourdon)* — Seven levels of module cohesion from coincidental to functional
+* *link:#/anchor/cohesion-criteria[Cohesion Criteria (Constantine & Yourdon)]* — Seven levels of module cohesion from coincidental to functional
 
 == 2026-04-01
 
 *New anchors:*
 
-* *Effective Go* — The Go Authors' canonical guide to idiomatic Go
+* *link:#/anchor/effective-go[Effective Go]* — The Go Authors' canonical guide to idiomatic Go
 
 == 2026-03-29
 
@@ -314,26 +314,26 @@ A new *Knowledge Management* catalog section was added to house Dreyfus & ADDIE.
 
 *New anchors* (proposed by https://github.com/deehtodd[@deehtodd] in https://github.com/LLM-Coding/Semantic-Anchors/issues/387[#387]):
 
-* *Three-Act Structure* — Aristotle / Syd Field / McKee
-* *Hero's Journey (Monomyth)* — Joseph Campbell / Christopher Vogler
-* *Save the Cat! 15-Beat Sheet* — Blake Snyder
-* *Fichtean Curve* — John Gardner / Janet Burroway
-* *Freytag's Pyramid (Five-Act)* — Gustav Freytag / John Yorke
-* *Story Circle* — Dan Harmon
-* *Kishōtenketsu* — Classical Chinese/Japanese tradition
-* *Hemingway Bridge* — Tiago Forte's session re-entry technique (proposed by https://github.com/arampp[@arampp] in https://github.com/LLM-Coding/Semantic-Anchors/issues/389[#389])
-* *CRC-Cards* — Ward Cunningham & Kent Beck's collaborative OO design technique (proposed by https://github.com/arampp[@arampp] in https://github.com/LLM-Coding/Semantic-Anchors/issues/386[#386])
+* *link:#/anchor/three-act-structure[Three-Act Structure]* — Aristotle / Syd Field / McKee
+* *link:#/anchor/heros-journey[Hero's Journey (Monomyth)]* — Joseph Campbell / Christopher Vogler
+* *link:#/anchor/save-the-cat[Save the Cat! 15-Beat Sheet]* — Blake Snyder
+* *link:#/anchor/fichtean-curve[Fichtean Curve]* — John Gardner / Janet Burroway
+* *link:#/anchor/freytags-pyramid[Freytag's Pyramid (Five-Act)]* — Gustav Freytag / John Yorke
+* *link:#/anchor/story-circle-dan-harmon[Story Circle]* — Dan Harmon
+* *link:#/anchor/kishotenketsu[Kishōtenketsu]* — Classical Chinese/Japanese tradition
+* *link:#/anchor/hemingway-bridge[Hemingway Bridge]* — Tiago Forte's session re-entry technique (proposed by https://github.com/arampp[@arampp] in https://github.com/LLM-Coding/Semantic-Anchors/issues/389[#389])
+* *link:#/anchor/crc-cards[CRC-Cards]* — Ward Cunningham & Kent Beck's collaborative OO design technique (proposed by https://github.com/arampp[@arampp] in https://github.com/LLM-Coding/Semantic-Anchors/issues/386[#386])
 
 == 2026-03-26
 
 *New anchors:*
 
-* *GRASP* — Craig Larman's 9 OO responsibility-assignment patterns
-* *Vertical Slice Architecture* — Jimmy Bogard's feature-first architecture
-* *KISS Principle* — Keep It Simple (Tier 1)
-* *P.A.R.A. Method* — Tiago Forte's knowledge organization framework
-* *PERT* — Program Evaluation and Review Technique (Tier 2)
-* *ISO 25010* — Software product quality model
+* *link:#/anchor/grasp[GRASP]* — Craig Larman's 9 OO responsibility-assignment patterns
+* *link:#/anchor/vertical-slice-architecture[Vertical Slice Architecture]* — Jimmy Bogard's feature-first architecture
+* *link:#/anchor/kiss-principle[KISS Principle]* — Keep It Simple (Tier 1)
+* *link:#/anchor/para-method[P.A.R.A. Method]* — Tiago Forte's knowledge organization framework
+* *link:#/anchor/pert[PERT]* — Program Evaluation and Review Technique (Tier 2)
+* *link:#/anchor/iso-25010[ISO 25010]* — Software product quality model
 
 *New features:*
 
@@ -347,17 +347,17 @@ Quality review of all anchors: introduced a three-tier rating system (★★★ 
 *Removed:*
 
 * *Rubber Duck Debugging* — concept is fully covered by <<socratic-method,Socratic Method>>; no actionable LLM instruction on its own
-* *DRY (Don't Repeat Yourself)* — design principle, but "make it DRY" is too vague as an LLM instruction
+* *link:#/anchor/dry[DRY (Don't Repeat Yourself)]* — design principle, but "make it DRY" is too vague as an LLM instruction
 * *SPOT (Single Point of Truth)* — too similar to SSOT; consolidated into <<ssot-principle,SSOT>>
 * *Chatham House Rule* — well-defined rule, but no practical LLM application
 
 *Renamed & upgraded:*
 
-* *Mental Model (Naur)* → *Programming as Theory Building (Naur)* — sharpened focus on documenting the "why" behind code (★☆☆ → ★★☆)
-* *Problem Space NVC* → *Nonviolent Communication (Rosenberg)* — stronger trigger, clear 4-step process (★★☆ → ★★★)
-* *Test Double (Meszaros)* → ★★★ umbrella anchor with 5 new sub-anchors: *Dummy*, *Stub*, *Spy*, *Mock*, *Fake* — each a precise, actionable LLM instruction (★☆☆ → ★★★)
-* *Jobs To Be Done* — upgraded to ★★★, strong for landing pages and customer analysis
-* *SOTA* — upgraded to ★★★, "Recherchiere SOTA zu [Thema]" reliably activates research mode
+* *link:#/anchor/mental-model-according-to-naur[Mental Model (Naur)]* → *Programming as Theory Building (Naur)* — sharpened focus on documenting the "why" behind code (★☆☆ → ★★☆)
+* *link:#/anchor/problem-space-nvc[Problem Space NVC]* → *Nonviolent Communication (Rosenberg)* — stronger trigger, clear 4-step process (★★☆ → ★★★)
+* *link:#/anchor/test-double-meszaros[Test Double (Meszaros)]* → ★★★ umbrella anchor with 5 new sub-anchors: *Dummy*, *Stub*, *Spy*, *Mock*, *Fake* — each a precise, actionable LLM instruction (★☆☆ → ★★★)
+* *link:#/anchor/jobs-to-be-done[Jobs To Be Done]* — upgraded to ★★★, strong for landing pages and customer analysis
+* *link:#/anchor/sota[SOTA]* — upgraded to ★★★, "Recherchiere SOTA zu [Thema]" reliably activates research mode
 
 *New quality criteria for proposals:*
 
@@ -366,46 +366,46 @@ Quality review of all anchors: introduced a three-tier rating system (★★★ 
 
 == 2026-03-12
 
-* *Plain English (Strunk & White)* in https://github.com/LLM-Coding/Semantic-Anchors/pull/177[#177]
-* *Gutes Deutsch (Wolf Schneider)* in https://github.com/LLM-Coding/Semantic-Anchors/pull/175[#175]
+* *link:#/anchor/plain-english-strunk-white[Plain English (Strunk & White)]* in https://github.com/LLM-Coding/Semantic-Anchors/pull/177[#177]
+* *link:#/anchor/gutes-deutsch-wolf-schneider[Gutes Deutsch (Wolf Schneider)]* in https://github.com/LLM-Coding/Semantic-Anchors/pull/175[#175]
 
 == 2026-03-11
 
-* *Gherkin* in https://github.com/LLM-Coding/Semantic-Anchors/pull/171[#171]
-* *SWOT* in https://github.com/LLM-Coding/Semantic-Anchors/pull/169[#169]
+* *link:#/anchor/gherkin[Gherkin]* in https://github.com/LLM-Coding/Semantic-Anchors/pull/171[#171]
+* *link:#/anchor/swot[SWOT]* in https://github.com/LLM-Coding/Semantic-Anchors/pull/169[#169]
 
 == 2026-03-09
 
-* *GoF Design Patterns Umbrella* — 23 GoF patterns as sub-anchors with tier system (12 Tier-1, 7 Tier-2, 4 Tier-3) in https://github.com/LLM-Coding/Semantic-Anchors/pull/159[#159]
-* *SOLID Principles Umbrella* — 5 SOLID principles as sub-anchors (SRP, OCP, LSP, ISP, DIP, all Tier-1) in https://github.com/LLM-Coding/Semantic-Anchors/pull/161[#161]
-* *Myers-Briggs Type Indicator (MBTI)* — proposed by https://github.com/gernotstarke[@gernotstarke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/158[#158]. Thank you!
-* *CQRS* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/137[#137]. Thank you!
-* *GoF Design Patterns* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/140[#140]. Thank you!
-* *Test Double (Meszaros)* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/142[#142]. Thank you!
-* *Event-Driven Architecture* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/143[#143]. Thank you!
-* *BDD (Given-When-Then)* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/138[#138], merged via https://github.com/LLM-Coding/Semantic-Anchors/pull/152[#152]. Thank you!
-* *YAGNI* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/139[#139], merged via https://github.com/LLM-Coding/Semantic-Anchors/pull/152[#152]. Thank you!
+* *link:#/anchor/gof-design-patterns[GoF Design Patterns Umbrella]* — 23 GoF patterns as sub-anchors with tier system (12 Tier-1, 7 Tier-2, 4 Tier-3) in https://github.com/LLM-Coding/Semantic-Anchors/pull/159[#159]
+* *link:#/anchor/solid-principles[SOLID Principles Umbrella]* — 5 SOLID principles as sub-anchors (SRP, OCP, LSP, ISP, DIP, all Tier-1) in https://github.com/LLM-Coding/Semantic-Anchors/pull/161[#161]
+* *link:#/anchor/myers-briggs-type-indicator[Myers-Briggs Type Indicator (MBTI)]* — proposed by https://github.com/gernotstarke[@gernotstarke] in https://github.com/LLM-Coding/Semantic-Anchors/issues/158[#158]. Thank you!
+* *link:#/anchor/cqrs[CQRS]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/137[#137]. Thank you!
+* *link:#/anchor/gof-design-patterns[GoF Design Patterns]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/140[#140]. Thank you!
+* *link:#/anchor/test-double-meszaros[Test Double (Meszaros)]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/142[#142]. Thank you!
+* *link:#/anchor/event-driven-architecture[Event-Driven Architecture]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/143[#143]. Thank you!
+* *link:#/anchor/bdd-given-when-then[BDD (Given-When-Then)]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/138[#138], merged via https://github.com/LLM-Coding/Semantic-Anchors/pull/152[#152]. Thank you!
+* *link:#/anchor/yagni[YAGNI]* — contributed by https://github.com/Nantero1[@Nantero1] in https://github.com/LLM-Coding/Semantic-Anchors/pull/139[#139], merged via https://github.com/LLM-Coding/Semantic-Anchors/pull/152[#152]. Thank you!
 
 == 2026-03-06
 
-* *ATAM* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/133[#133]
-* *LASR* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/135[#135]
+* *link:#/anchor/atam[ATAM]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/133[#133]
+* *link:#/anchor/lasr[LASR]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/135[#135]
 
 == 2026-03-04
 
-* *OWASP Top 10* — proposed by https://github.com/Advisior[@Advisior] in https://github.com/LLM-Coding/Semantic-Anchors/issues/130[#130]. Thank you!
+* *link:#/anchor/owasp-top-10[OWASP Top 10]* — proposed by https://github.com/Advisior[@Advisior] in https://github.com/LLM-Coding/Semantic-Anchors/issues/130[#130]. Thank you!
 
 == 2026-03-01
 
-* *GoM (Grundsätze ordnungsmäßiger Modellierung)* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/126[#126]
+* *link:#/anchor/gom[GoM (Grundsätze ordnungsmäßiger Modellierung)]* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/126[#126]
 
 == 2026-02-23
 
-* *Regulated Environment* — proposed by https://github.com/bit-jkraushaar[@bit-jkraushaar] in https://github.com/LLM-Coding/Semantic-Anchors/issues/120[#120]. Thank you!
+* *link:#/anchor/regulated-environment[Regulated Environment]* — proposed by https://github.com/bit-jkraushaar[@bit-jkraushaar] in https://github.com/LLM-Coding/Semantic-Anchors/issues/120[#120]. Thank you!
 
 == 2026-02-22
 
-* *MoSCoW* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/115[#115]
+* *link:#/anchor/moscow[MoSCoW]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/115[#115]
 
 == 2026-02-17
 
@@ -413,91 +413,91 @@ Quality review of all anchors: introduced a three-tier rating system (★★★ 
 
 == 2026-02-16
 
-* *Fowler Patterns (PEAA)* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/99[#99]
+* *link:#/anchor/fowler-patterns[Fowler Patterns (PEAA)]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/99[#99]
 
 == 2026-02-13
 
-* *Morphological Box* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/67[#67]
-* *IEC 61508 SIL Levels* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/67[#67]
+* *link:#/anchor/morphological-box[Morphological Box]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/67[#67]
+* *link:#/anchor/iec-61508-sil-levels[IEC 61508 SIL Levels]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/67[#67]
 * Split from monolithic README.adoc into individual anchor files (https://github.com/LLM-Coding/Semantic-Anchors/pull/38[#38])
 
 == 2026-02-12
 
-* *Socratic Method* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *BLUF* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/socratic-method[Socratic Method]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/bluf[BLUF]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
 * *Rubber Duck Debugging* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *Chain of Thought* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *Devil's Advocate* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *Five Whys* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *Feynman Technique* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
-* *MADR* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/29[#29]
+* *link:#/anchor/chain-of-thought[Chain of Thought]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/devils-advocate[Devil's Advocate]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/five-whys[Five Whys]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/feynman-technique[Feynman Technique]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/31[#31]
+* *link:#/anchor/madr[MADR]* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/29[#29]
 
 == 2026-02-11
 
-* *TIMTOWTDI* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/28[#28]. Thank you!
+* *link:#/anchor/timtowtdi[TIMTOWTDI]* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/28[#28]. Thank you!
 
 == 2026-02-07
 
-* *MECE Principle* — proposed by https://github.com/ingo-eichhorst[@ingo-eichhorst] in https://github.com/LLM-Coding/Semantic-Anchors/issues/26[#26]. Thank you!
+* *link:#/anchor/mece[MECE Principle]* — proposed by https://github.com/ingo-eichhorst[@ingo-eichhorst] in https://github.com/LLM-Coding/Semantic-Anchors/issues/26[#26]. Thank you!
 
 == 2026-02-05
 
-* *Nelson Rules* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/20[#20]
-* *Control Chart (Shewhart)* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/21[#21]
-* *SPC* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/22[#22]
+* *link:#/anchor/nelson-rules[Nelson Rules]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/20[#20]
+* *link:#/anchor/control-chart-shewhart[Control Chart (Shewhart)]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/21[#21]
+* *link:#/anchor/spc[SPC]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/22[#22]
 
 == 2026-02-03
 
-* *DRY Principle* — added in https://github.com/LLM-Coding/Semantic-Anchors/pull/19[#19]
+* *link:#/anchor/dry[DRY Principle]* — added in https://github.com/LLM-Coding/Semantic-Anchors/pull/19[#19]
 * *SPOT Principle* — added in https://github.com/LLM-Coding/Semantic-Anchors/pull/19[#19]
-* *SSOT Principle* — added in https://github.com/LLM-Coding/Semantic-Anchors/pull/19[#19]
-* *SOTA* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/16[#16]
-* *todo.txt-flavoured Markdown* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/14[#14]
+* *link:#/anchor/ssot-principle[SSOT Principle]* — added in https://github.com/LLM-Coding/Semantic-Anchors/pull/19[#19]
+* *link:#/anchor/sota[SOTA]* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/16[#16]
+* *link:#/anchor/todotxt-flavoured-markdown[todo.txt-flavoured Markdown]* — proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/14[#14]
 
 == 2026-01-21
 
-* *Pyramid Principle* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/12[#12]
+* *link:#/anchor/pyramid-principle[Pyramid Principle]* — proposed by https://github.com/rdmueller[@rdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/12[#12]
 
 == 2025-11-18
 
-* *Mutation Testing* — contributed by ThomasPeuss. Thank you!
+* *link:#/anchor/mutation-testing[Mutation Testing]* — contributed by ThomasPeuss. Thank you!
 
 == 2025-11-13
 
-* *BEM Methodology* — contributed by Robert Nimax. Thank you!
+* *link:#/anchor/bem-methodology[BEM Methodology]* — contributed by Robert Nimax. Thank you!
 
 == 2025-11-11
 
-* *Conventional Commits* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/4[#4]. Thank you!
-* *Semantic Versioning* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/4[#4]. Thank you!
-* *SOLID Principles* — contributed by https://github.com/bit-jkraushaar[@bit-jkraushaar]. Thank you!
+* *link:#/anchor/conventional-commits[Conventional Commits]* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/4[#4]. Thank you!
+* *link:#/anchor/semantic-versioning[Semantic Versioning]* — contributed by https://github.com/rehsack[@rehsack] in https://github.com/LLM-Coding/Semantic-Anchors/pull/4[#4]. Thank you!
+* *link:#/anchor/solid-principles[SOLID Principles]* — contributed by https://github.com/bit-jkraushaar[@bit-jkraushaar]. Thank you!
 
 == 2025-11-10 — Initial Catalog
 
 First commit by https://github.com/rdmueller[@rdmueller] with 23 founding anchors:
 
-* *TDD, London School*
-* *TDD, Chicago School*
-* *Problem Space NVC*
-* *Mental Model (Naur)*
-* *EARS Requirements*
-* *arc42*
-* *ADR (Nygard)*
-* *Pugh Matrix*
-* *C4 Diagrams*
-* *Docs-as-Code*
-* *Domain-Driven Design*
-* *Hexagonal Architecture*
-* *Clean Architecture*
-* *User Story Mapping*
-* *Impact Mapping*
-* *Jobs To Be Done*
-* *Cynefin Framework*
-* *Wardley Mapping*
-* *Property-Based Testing*
-* *Testing Pyramid*
-* *Diátaxis Framework*
-* *What Qualifies as a Semantic Anchor*
+* *link:#/anchor/tdd-london-school[TDD, London School]*
+* *link:#/anchor/tdd-chicago-school[TDD, Chicago School]*
+* *link:#/anchor/problem-space-nvc[Problem Space NVC]*
+* *link:#/anchor/mental-model-according-to-naur[Mental Model (Naur)]*
+* *link:#/anchor/ears-requirements[EARS Requirements]*
+* *link:#/anchor/arc42[arc42]*
+* *link:#/anchor/adr-according-to-nygard[ADR (Nygard)]*
+* *link:#/anchor/pugh-matrix[Pugh Matrix]*
+* *link:#/anchor/c4-diagrams[C4 Diagrams]*
+* *link:#/anchor/docs-as-code[Docs-as-Code]*
+* *link:#/anchor/domain-driven-design[Domain-Driven Design]*
+* *link:#/anchor/hexagonal-architecture[Hexagonal Architecture]*
+* *link:#/anchor/clean-architecture[Clean Architecture]*
+* *link:#/anchor/user-story-mapping[User Story Mapping]*
+* *link:#/anchor/impact-mapping[Impact Mapping]*
+* *link:#/anchor/jobs-to-be-done[Jobs To Be Done]*
+* *link:#/anchor/cynefin-framework[Cynefin Framework]*
+* *link:#/anchor/wardley-mapping[Wardley Mapping]*
+* *link:#/anchor/property-based-testing[Property-Based Testing]*
+* *link:#/anchor/testing-pyramid[Testing Pyramid]*
+* *link:#/anchor/diataxis-framework[Diátaxis Framework]*
+* *link:#/anchor/what-qualifies-as-a-semantic-anchor[What Qualifies as a Semantic Anchor]*
 
 == Community Contributors
 


### PR DESCRIPTION
Suggested by @raifdmueller: anchor names in the changelog were bold but not clickable, so a reader can't jump from an entry to the anchor.

## What changed
- Every bold lead-in (`* *Name* — …`) that **resolves to a real anchor** is now a bold link `*link:#/anchor/<id>[Name]*` → renders as `<strong><a href="#/anchor/<id>">…</a></strong>`, the same in-app link pattern the live `/rejected-proposals` page already uses. **144 links** across the file.
- Resolution is safe: exact title match (case-insensitive), kebab-of-name → id, a "(…)"-prefix fallback, and a small curated alias map for naming drift (possessives, "Umbrella"/"Principle" suffixes, paren expansions). A name is linked **only** when it maps to an existing anchor id.
- Left untouched (correctly): feature/fix sub-headings, contracts ("Architecture Documentation", "Semantic Contracts", "TDD, Hamburg Style"…), articles, the skill page, and rejected terms ("Rubber Duck Debugging"). 37 such bold leads remain plain.

## Notes
- Links use `#/anchor/<id>` — identical href to the proven rejected-proposals links; the `<strong>` wrapper doesn't affect router click-handling.
- A short tail of older entries naming non-anchors stays unlinked by design.
- Going forward, new changelog anchor entries should use the same `link:#/anchor/<id>[Name]` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)