### PR TITLE
fix(security): remove file-system race in JSON-LD injection (CodeQL #8)

### DIFF
--- a/scripts/generate-jsonld.js
+++ b/scripts/generate-jsonld.js
@@ -106,10 +106,22 @@ function buildScriptTag() {
   return `<script type="application/ld+json">\n${json}\n</script>`
 }
 
-/** Insert the script tag before </head>, unless the set is already present. */
+/**
+ * Insert the script tag before </head>, unless the set is already present.
+ *
+ * Reads directly and treats a missing file as "nothing to do" via the read's
+ * own error, rather than an `fs.existsSync` pre-check: a check-then-write pair
+ * is a file-system race (TOCTOU), since the path could change between the two
+ * calls (CodeQL js/file-system-race).
+ */
 function injectInto(file, scriptTag) {
-  if (!fs.existsSync(file)) return false
-  let html = fs.readFileSync(file, 'utf-8')
+  let html
+  try {
+    html = fs.readFileSync(file, 'utf-8')
+  } catch (err) {
+    if (err.code === 'ENOENT') return false
+    throw err
+  }
   if (html.includes(SET_ID)) return false // idempotent
   if (!html.includes('</head>')) return false
   html = html.replace('</head>', `  ${scriptTag}\n  </head>`)
@@ -147,4 +159,4 @@ function main() {
 
 if (require.main === module) main()
 
-module.exports = { buildDefinedTermSet, buildScriptTag, extractDescription }
+module.exports = { buildDefinedTermSet, buildScriptTag, extractDescription, injectInto }

--- a/scripts/generate-jsonld.test.js
+++ b/scripts/generate-jsonld.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { injectInto } from './generate-jsonld.js'
+
+// The tag must carry SET_ID (the catalog @id) for the idempotency check to fire.
+const TAG =
+  '<script type="application/ld+json">{"@id":"https://llm-coding.github.io/Semantic-Anchors/#catalog"}</script>'
+
+describe('injectInto', () => {
+  let dir
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonld-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns false for a missing file (no existsSync TOCTOU)', () => {
+    expect(injectInto(path.join(dir, 'nope.html'), TAG)).toBe(false)
+  })
+
+  it('injects the tag before </head> and returns true', () => {
+    const f = path.join(dir, 'index.html')
+    fs.writeFileSync(f, '<html><head><title>x</title></head><body></body></html>')
+    expect(injectInto(f, TAG)).toBe(true)
+    const out = fs.readFileSync(f, 'utf-8')
+    expect(out).toContain('application/ld+json')
+    expect(out.indexOf(TAG)).toBeLessThan(out.indexOf('</head>'))
+  })
+
+  it('is idempotent — a second call does not inject again', () => {
+    const f = path.join(dir, 'index.html')
+    fs.writeFileSync(f, '<html><head></head></html>')
+    expect(injectInto(f, TAG)).toBe(true)
+    expect(injectInto(f, TAG)).toBe(false)
+    const out = fs.readFileSync(f, 'utf-8')
+    expect(out.match(/application\/ld\+json/g)).toHaveLength(1)
+  })
+
+  it('returns false when there is no </head>', () => {
+    const f = path.join(dir, 'frag.html')
+    fs.writeFileSync(f, '<div>no head here</div>')
+    expect(injectInto(f, TAG)).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes CodeQL code-scanning alert **#8** — `js/file-system-race` (Potential file system race condition) at `scripts/generate-jsonld.js:116`.

## Cause
`injectInto()` did:
```js
if (!fs.existsSync(file)) return false   // check
let html = fs.readFileSync(file, 'utf-8') // use
...
fs.writeFileSync(file, html, 'utf-8')     // use  ← flagged
```
The `existsSync` check followed by read/write on the same path is a check-then-use TOCTOU: the path could change between the check and the write.

## Fix
Drop the `existsSync` pre-check and treat a missing file via the read's own `ENOENT` error:
```js
try { html = fs.readFileSync(file, 'utf-8') }
catch (err) { if (err.code === 'ENOENT') return false; throw err }
```
No window between checking and writing. **Behaviour unchanged:** a missing file still returns `false`, injection stays idempotent, and the script runs (`node scripts/generate-jsonld.js` → exit 0).

Adds a unit test for `injectInto` (missing file → false, inject-before-`</head>`, idempotency, no-`</head>` → false). scripts suite: 9 tests green; lint/format clean.

The alert predates current work (first detected ~3 weeks ago, from the JSON-LD feature in #592). The CodeQL run on this PR should clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * JSON-LD wird jetzt zuverlässig in vorgerenderte Seiten eingefügt, ohne doppelte Einträge zu erzeugen.
  * Eine zusätzliche Hilfsfunktion wurde für die Wiederverwendung verfügbar gemacht.

* **Tests**
  * Neue Tests prüfen das Verhalten bei fehlenden Dateien, korrekter Einfügung vor `</head>` und mehrfachen Aufrufen.
  * Es wird auch abgedeckt, dass Seiten ohne schließenden `</head>` unverändert bleiben.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->