### PR TITLE
feat: "New" badge on recently-added anchor cards (#652)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history so extract-metadata can read each anchor's first-commit
+          # date for the "new" badge (#652); the default shallow clone has none.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-06-27
 
+*"New" badge on recently-added anchors (#652):*
+
+* Anchors added in the last 30 days now show a green *New* badge on their card, so returning visitors can spot fresh entries at a glance. The "added" date is derived from each anchor file's first git commit at build time (no manual upkeep) and stored as `addedAt`; the badge is computed at render time against the current date, so it expires on its own. Bilingual ("New" / "Neu"). The deploy workflow now checks out full history (`fetch-depth: 0`) so the dates are available in CI.
+
 *Direct-answer blocks for AI/LLM citability (#580):*
 
 * A GEO audit found the site ranks #1-3 in traditional search yet gets *zero* citations from ChatGPT, Perplexity, Gemini and Copilot for "What is Semantic Anchors?". The fix: every anchor's pre-rendered page now carries a concise, standalone *direct-answer block* that AI crawlers (which mostly do not run JS) can quote verbatim, and the home page gains a crawlable "What is Semantic Anchors?" answer section (EN + DE). A shared resolver prefers a curated `:definition:` attribute and otherwise derives one from the first Core Concept, so the answer block, the modal lead-in, and the DefinedTerm JSON-LD description all agree. Curated definitions seeded for 11 high-value anchors (MECE, BLUF, arc42, Clean Architecture, TDD London School, Gherkin, SOLID, Cynefin, Socratic Method, Chain of Thought, DDD); the rest use the derived fallback until curated. Proposed by https://github.com/raifdmueller[@raifdmueller] in https://github.com/LLM-Coding/Semantic-Anchors/issues/580[#580].

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -10,12 +10,54 @@
 
 const fs = require('fs')
 const path = require('path')
+const { execFileSync } = require('child_process')
 const asciidoctor = require('@asciidoctor/core')()
 const { getAnchorDefinition } = require('./lib/anchor-definition')
 
 // Paths
+const REPO_ROOT = path.join(__dirname, '..')
 const ANCHORS_DIR = path.join(__dirname, '..', 'docs', 'anchors')
 const OUTPUT_DIR = path.join(__dirname, '..', 'website', 'public', 'data')
+
+/**
+ * Map each anchor id to the ISO date its .adoc was first added to git (#652),
+ * so the website can flag recently-added anchors. One `git log` call over the
+ * anchors dir, oldest-first, recording the first add event per file. Returns an
+ * empty map when git history is unavailable (no repo, or a shallow CI checkout)
+ * — callers then simply omit `addedAt` and render no "new" badge.
+ */
+function buildAddedAtMap() {
+  const map = {}
+  let out
+  try {
+    out = execFileSync(
+      'git',
+      [
+        'log',
+        '--diff-filter=A',
+        '--reverse',
+        '--format=%x00%aI',
+        '--name-only',
+        '--',
+        'docs/anchors',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 }
+    )
+  } catch {
+    return map // not a git repo, git missing, etc.
+  }
+  let currentDate = null
+  for (const line of out.split('\n')) {
+    if (line.startsWith('\0')) {
+      currentDate = line.slice(1).trim()
+    } else if (line.startsWith('docs/anchors/') && line.endsWith('.adoc')) {
+      const base = path.basename(line, '.adoc')
+      if (base.match(/\.\w{2}$/)) continue // skip language variants (e.g. x.de)
+      if (!map[base] && currentDate) map[base] = currentDate // first (oldest) add wins
+    }
+  }
+  return map
+}
 
 // Ensure output directory exists
 if (!fs.existsSync(OUTPUT_DIR)) {
@@ -263,6 +305,9 @@ function main() {
 
   console.log(`📂 Found ${files.length} anchor files\n`)
 
+  // First-added dates from git, for the "recently added" badge (#652).
+  const addedAt = buildAddedAtMap()
+
   // Parse all files
   const anchors = []
   const errors = []
@@ -277,6 +322,7 @@ function main() {
         errors.push({ file, issues: result.errors })
         console.log(`   ✗ ${file}: ${result.errors.join(', ')}`)
       } else {
+        if (addedAt[result.anchor.id]) result.anchor.addedAt = addedAt[result.anchor.id]
         anchors.push(result.anchor)
         if (result.warnings) {
           warnings.push({ file, issues: result.warnings })

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -10,6 +10,17 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;')
 }
 
+// An anchor is flagged "new" for 30 days after its first commit (#652). Computed
+// at render time against the current date, so the badge expires on its own.
+const NEW_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+
+function isRecentlyAdded(anchor) {
+  if (!anchor.addedAt) return false
+  const added = new Date(anchor.addedAt).getTime()
+  if (Number.isNaN(added)) return false
+  return Date.now() - added < NEW_WINDOW_MS
+}
+
 /**
  * Category color palette (matching previous categories)
  */
@@ -192,7 +203,11 @@ function renderAnchorCard(anchor, categoryColor, categoryId) {
       aria-labelledby="${cardTitleId}"
     >
       <div class="anchor-card-header">
-        <h3 id="${cardTitleId}" class="anchor-card-title">${escapeHtml(anchor.title)}</h3>
+        <h3 id="${cardTitleId}" class="anchor-card-title">${escapeHtml(anchor.title)}${
+          isRecentlyAdded(anchor)
+            ? ` <span class="anchor-new-badge" title="${escapeHtml(i18n.t('card.new'))}">${escapeHtml(i18n.t('card.new'))}</span>`
+            : ''
+        }</h3>
         <div class="flex gap-1">
           <button
             class="anchor-copy-keyword-btn"

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -93,6 +93,34 @@ describe('advisory badge', () => {
   })
 })
 
+describe('new badge', () => {
+  const categories = [{ id: 'strategic-planning', name: 'Strategy' }]
+  const make = (addedAt) => [
+    {
+      id: 'eisenhower-matrix',
+      title: 'Eisenhower Matrix',
+      categories: ['strategic-planning'],
+      roles: ['team-lead'],
+      tags: [],
+      proponents: [],
+      ...(addedAt ? { addedAt } : {}),
+    },
+  ]
+  const daysAgo = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
+
+  it('renders a new badge for anchors added within 30 days', () => {
+    expect(renderCardGrid(categories, make(daysAgo(5)))).toContain('anchor-new-badge')
+  })
+
+  it('does not render a new badge for anchors older than 30 days', () => {
+    expect(renderCardGrid(categories, make(daysAgo(45)))).not.toContain('anchor-new-badge')
+  })
+
+  it('does not render a new badge when addedAt is absent', () => {
+    expect(renderCardGrid(categories, make(null))).not.toContain('anchor-new-badge')
+  })
+})
+
 describe('category quick-nav', () => {
   const categories = [
     { id: 'testing-quality', name: 'Testing' },

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -280,6 +280,13 @@ html {
   @apply m-0;
 }
 
+/* "New" badge (#652): flags anchors added within the last 30 days so they're
+   easy to spot. Green pill next to the card title; expires on its own. */
+.anchor-new-badge {
+  @apply inline-block align-middle ml-1 px-1.5 py-0.5 rounded text-xs font-semibold uppercase tracking-wide;
+  @apply bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200;
+}
+
 .anchor-card-meta {
   @apply flex flex-wrap items-center gap-2 text-xs;
   @apply text-gray-500 dark:text-gray-400;

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -115,6 +115,7 @@
   "card.copyKeyword": "Schlüsselwort in Zwischenablage kopieren",
   "card.keywordCopied": "Schlüsselwort kopiert!",
   "card.advisory": "Hinweis",
+  "card.new": "Neu",
   "card.copyLink": "Link zu diesem Anker kopieren",
   "card.linkCopied": "Link kopiert!",
   "card.roles": "Rolle",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -115,6 +115,7 @@
   "card.copyKeyword": "Copy keyword to clipboard",
   "card.keywordCopied": "Keyword copied!",
   "card.advisory": "Advisory",
+  "card.new": "New",
   "card.copyLink": "Copy link to this anchor",
   "card.linkCopied": "Link copied!",
   "card.roles": "role",


### PR DESCRIPTION
Closes #652.

Returning visitors had no quick way to spot freshly-added anchors. Anchors added in the **last 30 days** now show a green **New** badge next to the card title.

## What changed
- **`extract-metadata.js`** — derives each anchor's first-commit date from git (one `git log --diff-filter=A --reverse` over `docs/anchors`, oldest-add-wins) into `anchors.json` as `addedAt`. If git history is unavailable (no repo / shallow checkout) the map is empty → `addedAt` omitted → no badge (graceful).
- **`card-grid.js`** — renders the badge when `addedAt` is within 30 days, computed **at render time** against the current date, so it **expires on its own** with no code change. Bilingual via `card.new` (New / Neu).
- **`deploy.yml`** — `fetch-depth: 0` so the deployed build has the history the dates need (the default shallow clone has none).
- **Tests** — badge shows for <30 d, hidden for >30 d, hidden when `addedAt` is absent.

## Verification
- Build green (doc + Vite). `anchors.json` gets `addedAt` for all 179 anchors; 33–34 are <30 days (the recent batches).
- Playwright: 34 "New" badges render on the home grid; screenshot confirms a clean green pill next to the title (AIDA Model card).
- Unit suites green (website 121, scripts 9); lint + format clean.

## Decisions (per the issue)
Git-derived date (recommended option, zero upkeep); 30-day window; client-side expiry. Badge is on the card (SPA-rendered); crawlers don't need a "new" marker so it's not added to the static catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Karten mit kürzlich hinzugefügten Anchors zeigen jetzt ein automatisch auslaufendes „Neu/New“-Badge an.
  * Die Kennzeichnung wird in Deutsch und Englisch unterstützt.

* **Bug Fixes**
  * Datumsinformationen für neue Einträge werden nun zuverlässiger aus der Git-Historie ermittelt, sodass die Badge korrekt angezeigt wird.

* **Style**
  * Das neue Badge erhält eigene visuelle Hervorhebung für Light- und Dark-Mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->