### PR TITLE
feat: show author byline on pre-rendered doc pages

### DIFF
--- a/scripts/byline.test.js
+++ b/scripts/byline.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { bylineHtml, injectByline } from './lib/byline.js'
+
+describe('bylineHtml', () => {
+  it('renders author and revision date', () => {
+    const html = bylineHtml('Ralf D. Müller', '2026-03-14')
+    expect(html).toContain('doc-byline')
+    expect(html).toContain('Ralf D. Müller')
+    expect(html).toContain('2026-03-14')
+  })
+
+  it('renders the author alone when no date is given', () => {
+    const html = bylineHtml('Ralf D. Müller', '')
+    expect(html).toContain('Ralf D. Müller')
+    expect(html).not.toContain('doc-byline-date')
+  })
+
+  it('returns an empty string when neither author nor date is present', () => {
+    expect(bylineHtml(undefined, undefined)).toBe('')
+    expect(bylineHtml('', '')).toBe('')
+  })
+
+  it('escapes HTML in the author name', () => {
+    const html = bylineHtml('<script>x</script>', '')
+    expect(html).not.toContain('<script>x</script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})
+
+describe('injectByline', () => {
+  it('inserts the byline directly after the leading h1', () => {
+    const out = injectByline('<h1>Title</h1>\n<div>body</div>', 'Ralf D. Müller', '2026-03-14')
+    expect(out.indexOf('doc-byline')).toBeGreaterThan(out.indexOf('</h1>'))
+    expect(out.indexOf('doc-byline')).toBeLessThan(out.indexOf('<div>body'))
+  })
+
+  it('prepends the byline when there is no h1', () => {
+    const out = injectByline('<div>body</div>', 'Ralf D. Müller', '')
+    expect(out.indexOf('doc-byline')).toBeLessThan(out.indexOf('<div>body'))
+  })
+
+  it('leaves the html unchanged when there is no author or date', () => {
+    const html = '<h1>Title</h1>\n<div>body</div>'
+    expect(injectByline(html, undefined, undefined)).toBe(html)
+  })
+})

--- a/scripts/lib/byline.js
+++ b/scripts/lib/byline.js
@@ -1,0 +1,50 @@
+/**
+ * Author/date byline for pre-rendered documentation pages.
+ *
+ * render-docs.js renders doc pages in embedded mode, which drops the document
+ * header (`#header`) that AsciiDoctor normally uses for the author + revision
+ * date. Authors are declared in the `.adoc` sources (e.g. `Ralf D. Müller` on
+ * line 2), so we re-create a minimal byline from the parsed metadata and inject
+ * it below the page title. Keeping it here as pure functions makes it testable
+ * without running the whole render script.
+ */
+
+/** Minimal HTML escape for text injected into rendered fragments. */
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * Build the byline HTML for an author and/or revision date. Returns '' when
+ * both are missing, so pages without an author stay unchanged.
+ */
+function bylineHtml(author, revdate) {
+  if (!author && !revdate) return ''
+  const parts = []
+  if (author) parts.push(`<span class="doc-byline-author">${escapeHtml(author)}</span>`)
+  if (revdate) parts.push(`<span class="doc-byline-date">${escapeHtml(revdate)}</span>`)
+  return `<div class="doc-byline">${parts.join('')}</div>\n`
+}
+
+/**
+ * Inject the byline directly after the leading `<h1>…</h1>` of a rendered
+ * fragment. If the fragment has no `<h1>` (rendered without showtitle), the
+ * byline is prepended. Unchanged when there is no author or date.
+ */
+function injectByline(html, author, revdate) {
+  const byline = bylineHtml(author, revdate)
+  if (!byline) return html
+  const close = '</h1>'
+  const idx = html.indexOf(close)
+  if (idx !== -1) {
+    const after = idx + close.length
+    return html.slice(0, after) + '\n' + byline + html.slice(after)
+  }
+  return byline + html
+}
+
+module.exports = { bylineHtml, injectByline }

--- a/scripts/render-docs.js
+++ b/scripts/render-docs.js
@@ -21,6 +21,7 @@ const fs = require('fs')
 const path = require('path')
 const Asciidoctor = require('@asciidoctor/core')
 const { getAnchorDefinition } = require('./lib/anchor-definition')
+const { injectByline } = require('./lib/byline')
 
 const asciidoctor = Asciidoctor()
 const ROOT = path.join(__dirname, '..')
@@ -117,7 +118,14 @@ function renderFile(srcPath, destPath, quiet = false, prependHtml = '') {
   if (!fs.existsSync(srcPath)) return
   try {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
-    const html = String(asciidoctor.convertFile(srcPath, { ...OPTS, to_file: false }))
+    // loadFile (not convertFile) so we can read the document header metadata
+    // (author, revision date) that embedded-mode rendering otherwise drops.
+    const doc = asciidoctor.loadFile(srcPath, OPTS)
+    // getAuthor()/getRevisionDate() return a truthy Opal object that stringifies
+    // to '' when the source has no author/date, so normalize to trimmed strings.
+    const author = String(doc.getAuthor() || '').trim()
+    const revdate = String(doc.getRevisionDate() || '').trim()
+    const html = injectByline(String(doc.convert()), author, revdate)
     const { toc, body } = extractToc(rewriteLegacyHashLinks(html))
     fs.writeFileSync(destPath, prependHtml + body, 'utf-8')
     if (!quiet) console.log(`Rendered: ${path.relative(ROOT, destPath)}`)

--- a/website/src/styles/asciidoctor-scoped.css
+++ b/website/src/styles/asciidoctor-scoped.css
@@ -62,6 +62,21 @@
     font-size: 1em;
   }
 
+  /*
+   * Author/date byline injected below the <h1> by render-docs.js. Embedded-mode
+   * rendering drops the AsciiDoctor #header, so the byline is styled here.
+   */
+  & .doc-byline {
+    margin: -0.25em 0 1.5em;
+    padding-bottom: 0.75em;
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+  }
+  & .doc-byline .doc-byline-date::before {
+    content: '\00a0\2022\00a0';
+  }
+
   & p {
     line-height: 1.6;
     margin-bottom: 1.25rem;


### PR DESCRIPTION
## What
Pre-rendered doc pages (spec-driven-workflow, brownfield-workflow, harness-inventory, anchor-evaluations, training-data-vs-practice, …) declare an author in their AsciiDoc header (`Ralf D. Müller`), but it never appeared on the site: `render-docs.js` renders in embedded mode, which drops the AsciiDoctor document header that carries author + revision date.

This reads the author/revdate from the parsed document and injects a styled byline below the `<h1>`, for all author-bearing doc pages.

## How
- New pure helper `scripts/lib/byline.js` (`bylineHtml`, `injectByline`) + unit tests (`scripts/byline.test.js`).
- `render-docs.js`: load the document (not just convert) to read `getAuthor()`/`getRevisionDate()`; normalize the truthy-empty Opal object to trimmed strings so author-less pages stay unchanged.
- Byline styling scoped under `.asciidoc-content` in `asciidoctor-scoped.css` (the bundled stylesheet — not the vendored `asciidoctor.css`).

## Verification
- `scripts` unit tests green (incl. new byline tests); ESLint + Prettier clean.
- Built + previewed: byline renders as "Ralf D. Müller • 2026-03-14" under the title (muted, divider), only on the 7 author-bearing pages; anchors/other pages unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Dokumentseiten zeigen jetzt automatisch eine Byline mit Autor und Revisionsdatum an, wenn diese Metadaten vorhanden sind.

* **Bug Fixes**
  * HTML in Autorennamen wird sicher dargestellt.
  * Fehlen Titel oder Byline-Metadaten, bleibt die Ausgabe sauber und unverändert.

* **Tests**
  * Neue Tests decken die Byline-Erzeugung und das Einfügen in verschiedene HTML-Szenarien ab.

* **Style**
  * Die Byline wurde mit passender Formatierung für Abstände, Trennzeichen und Schriftbild gestaltet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->