### PR TITLE
fix: correct relative paths to ADR files in arc42 chapter 9

### DIFF
--- a/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -9,27 +9,27 @@ Dieses Kapitel referenziert die detaillierten Architecture Decision Records (ADR
 |===
 |ADR |Entscheidung |Begründung |Status
 
-|link:../specs/adrs/adr-001-static-site-generator.adoc[ADR-001]
+|link:../../specs/adrs/adr-001-static-site-generator.adoc[ADR-001]
 |**Vite** als Static Site Generator
 |Maximale Flexibilität für Custom-Visualisierung, beste Performance, kein Framework-Lock-in
 |Accepted
 
-|link:../specs/adrs/adr-002-metadata-storage.adoc[ADR-002]
+|link:../../specs/adrs/adr-002-metadata-storage.adoc[ADR-002]
 |**AsciiDoc Attributes** für Metadata
 |Single Source of Truth, einfache Contribution, keine Sync-Probleme
 |Accepted
 
-|link:../specs/adrs/adr-003-treemap-library.adoc[ADR-003]
+|link:../../specs/adrs/adr-003-treemap-library.adoc[ADR-003]
 |**Apache ECharts** für Treemap
 |Native Treemap-Unterstützung, exzellente DX, Built-in Theming, Open Source
 |Superseded by ADR-005
 
-|link:../specs/adrs/adr-004-one-file-per-anchor.adoc[ADR-004]
+|link:../../specs/adrs/adr-004-one-file-per-anchor.adoc[ADR-004]
 |**Ein File pro Anchor** + Includes
 |Minimale Merge-Konflikte, klare Git-History, skaliert perfekt
 |Accepted
 
-|link:../specs/adrs/adr-005-card-grid-visualization.adoc[ADR-005]
+|link:../../specs/adrs/adr-005-card-grid-visualization.adoc[ADR-005]
 |**Card Grid** statt Treemap für Visualisierung
 |Löst fundamentale Usability-Probleme (Text-Truncation, Kontrast, Viewport), größerer Pugh-Score (+137)
 |Accepted
@@ -54,7 +54,7 @@ Dieses Kapitel referenziert die detaillierten Architecture Decision Records (ADR
 * ✅ Keine unnötigen Abstraktionen
 * ❌ Mehr Custom-Code nötig (aber akzeptabel)
 
-**Details:** link:../specs/adrs/adr-001-static-site-generator.adoc[ADR-001]
+**Details:** link:../../specs/adrs/adr-001-static-site-generator.adoc[ADR-001]
 
 === ADR-002: AsciiDoc Attributes für Metadata
 
@@ -85,7 +85,7 @@ Dieses Kapitel referenziert die detaillierten Architecture Decision Records (ADR
 :proponents: Steve Freeman, Nat Pryce
 ```
 
-**Details:** link:../specs/adrs/adr-002-metadata-storage.adoc[ADR-002]
+**Details:** link:../../specs/adrs/adr-002-metadata-storage.adoc[ADR-002]
 
 === ADR-003: Apache ECharts für Treemap
 
@@ -119,7 +119,7 @@ chart.setOption({
 });
 ```
 
-**Details:** link:../specs/adrs/adr-003-treemap-library.adoc[ADR-003]
+**Details:** link:../../specs/adrs/adr-003-treemap-library.adoc[ADR-003]
 
 === ADR-004: Ein File pro Anchor
 
@@ -157,7 +157,7 @@ docs/
     └── ...
 ```
 
-**Details:** link:../specs/adrs/adr-004-one-file-per-anchor.adoc[ADR-004]
+**Details:** link:../../specs/adrs/adr-004-one-file-per-anchor.adoc[ADR-004]
 
 === ADR-005: Card Grid statt Treemap für Visualisierung
 
@@ -184,7 +184,7 @@ docs/
 **Hintergrund:** Playwright-Testing zeigte fundamentale Usability-Probleme bei der Treemap:
 Issue #59 (Text-Truncation), Issue #60 (Map-Cut-off), Issue #61 (Poor Contrast).
 
-**Details:** link:../specs/adrs/adr-005-card-grid-visualization.adoc[ADR-005]
+**Details:** link:../../specs/adrs/adr-005-card-grid-visualization.adoc[ADR-005]
 
 === Zukünftige Entscheidungen
 
@@ -207,4 +207,4 @@ Alle ADRs folgen dem **Nygard-Format**:
 
 Zusätzlich: **Pugh-Matrix** für objektiven Vergleich von Alternativen.
 
-**Template:** link:../specs/adrs/_template.adoc[ADR Template]
+**Template:** link:../../specs/adrs/_template.adoc[ADR Template]


### PR DESCRIPTION
## Summary

The ADR links in `docs/arc42/chapters/09_architecture_decisions.adoc` used `../specs/adrs/` as relative path. Since the file lives two levels deep (`docs/arc42/chapters/`), the correct relative path to `docs/specs/adrs/` is `../../specs/adrs/`.

## What changed

All 11 ADR link references corrected from `../specs/adrs/` → `../../specs/adrs/`.

## Tested

Verified that the corrected paths resolve to existing files in the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Aktualisierte mehrere ADR-Links in der Architektur-Dokumentation, sodass die Verweise wieder korrekt auf die Entscheidungsdokumente zeigen.
  * Alle betroffenen „Details“-Links für ADR-001 bis ADR-005 wurden entsprechend angepasst.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->