### PR TITLE
fix: add name=image attribute to og:image for LinkedIn

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -2,6 +2,12 @@
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 
+== 2026-07-03
+
+*LinkedIn preview robustness:*
+
+* The `og:image` tag now also carries the `name="image"` attribute (`<meta name="image" property="og:image" …>`), a form LinkedIn's scraper reads more reliably. The image, filenames and other tags were already correct (see 2026-07-02); this only hardens how strict scrapers pick it up.
+
 == 2026-07-02
 
 *Social-media preview image (Open Graph / Twitter card):*

--- a/website/index.html
+++ b/website/index.html
@@ -29,7 +29,7 @@
     <meta property="og:url" content="https://llm-coding.github.io/Semantic-Anchors/" />
     <meta property="og:title" content="Semantic Anchors - Shared Vocabulary for LLM Communication" />
     <meta property="og:description" content="A curated catalog of semantic anchors and semantic contracts — shared vocabulary for precise communication with Large Language Models." />
-    <meta property="og:image" content="https://llm-coding.github.io/Semantic-Anchors/og-image.png" />
+    <meta name="image" property="og:image" content="https://llm-coding.github.io/Semantic-Anchors/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="en_US" />

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -27,7 +27,7 @@ import {
 } from './components/onboarding-modal.js'
 import { renderContractsPage, initContractsPage } from './components/contracts-page.js'
 
-const APP_VERSION = '0.8.2'
+const APP_VERSION = '0.8.3'
 
 window.copyAnchorLink = async function copyAnchorLink(anchorId) {
   const url = `${window.location.origin}${import.meta.env.BASE_URL}anchor/${anchorId}`


### PR DESCRIPTION
Follow-up to #669. LinkedIn's Post Inspector showed no preview image even though the image (`og-image.png`) returns HTTP 200 at 1200×630 (<5 MB) and the tags are otherwise correct.

## Change

`og:image` now also carries `name="image"`:

```html
<meta name="image" property="og:image" content="https://llm-coding.github.io/Semantic-Anchors/og-image.png" />
```

LinkedIn's scraper is documented to read this dual-attribute form more reliably. `scripts/prerender-routes.js` `applyHead()` does not touch `og:image`, so this single shell edit propagates to every pre-rendered page.

Bump `APP_VERSION` → 0.8.3, changelog entry.

## Note

The most likely reason the inspector showed nothing is LinkedIn's **cache of the earlier 404** (before #669 shipped the image). This tag hardens scraper pickup, but the definitive refresh is re-scraping via the Facebook Sharing Debugger / opengraph.xyz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)