### PR TITLE
docs: ADR-008 — personality/assessment frameworks as anchors (the Utility Gate)

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-anchor.yml
+++ b/.github/ISSUE_TEMPLATE/propose-anchor.yml
@@ -32,7 +32,7 @@ body:
 
         The review agent **rejects** proposals that are:
         - Pure philosophy without actionable instructions (e.g., "TIMTOWTDI")
-        - Personality/assessment frameworks without LLM utility (e.g., "MBTI")
+        - Recognition-only terms that fail the viability test — naming them does not change output structure. This gate is topic-neutral: personality/assessment frameworks (MBTI, DISC, Big Five, HEXACO) are judged by utility, not topic (see ADR-008)
         - Fully covered by an existing anchor (e.g., "Rubber Duck Debugging" ≈ Socratic Method)
         - Too vague to produce consistent LLM output (e.g., "Keep it simple")
         - Not an established concept (invented by the proposer)

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -100,6 +100,8 @@ Recognition is not activation. A model can talk fluently *about* a term while na
 
 A term that passes the four Quality Criteria but fails the viability test is a *Contract*, not an Anchor.
 
+*This gate is topic-neutral.* No subject area is privileged or banned — personality and assessment frameworks (MBTI, DISC, Big Five, HEXACO) are neither excluded for their topic nor admitted for being well-known. They must clear the same Viability Test as any other candidate, and — given their contested empirical standing — carry a `== Criticism` / `== Current Status` section. The rationale is in link:docs/specs/adrs/adr-008-personality-assessment-anchors.adoc[ADR-008].
+
 == Developer Setup
 
 === Prerequisites

--- a/docs/CONTRIBUTING.de.adoc
+++ b/docs/CONTRIBUTING.de.adoc
@@ -98,6 +98,8 @@ Erkennung ist nicht Aktivierung. Ein Modell kann flüssig *über* einen Begriff 
 
 Ein Term, der die vier Qualitätskriterien besteht, aber den Viability-Test nicht, ist ein *Contract*, kein Anchor.
 
+*Dieses Gate ist themenneutral.* Kein Themengebiet ist bevorzugt oder verboten — Persönlichkeits- und Assessment-Modelle (MBTI, DISC, Big Five, HEXACO) werden weder wegen ihres Themas ausgeschlossen noch wegen ihrer Bekanntheit aufgenommen. Sie müssen denselben Viability-Test bestehen wie jeder andere Kandidat und — angesichts ihrer umstrittenen empirischen Absicherung — einen `== Criticism` / `== Current Status`-Abschnitt tragen. Die Begründung steht in link:specs/adrs/adr-008-personality-assessment-anchors.adoc[ADR-008].
+
 == Wie man einen neuen Anker vorschlägt
 
 Wir verwenden einen *automatisierten Workflow mit GitHub Copilot* zur Validierung und Anreicherung von Vorschlägen:

--- a/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -43,6 +43,11 @@ Dieses Kapitel referenziert die detaillierten Architecture Decision Records (ADR
 |**Artefakt-Taxonomie** — Anchor vs. Contract vs. Skill
 |Explizite Dreiteilung beseitigt die wiederholt ad hoc rekonstruierte Grenze (Pugh +63); Thin-Prior-Regel macht #585 und #640 konsistent
 |Accepted
+
+|link:../../specs/adrs/adr-008-personality-assessment-anchors.adoc[ADR-008]
+|**Persönlichkeits-/Assessment-Modelle als Anker** — der Utility-Gate
+|Topic-neutrales Kriterium: Aufnahme entscheidet Utility (Viability-Test), nicht das Thema (Pugh +63); löst den Widerspruch Template↔Katalog und unterwirft MBTI demselben Test
+|Accepted
 |===
 
 === ADR-001: Vite als Static Site Generator
@@ -198,7 +203,7 @@ Issue #59 (Text-Truncation), Issue #60 (Map-Cut-off), Issue #61 (Poor Contrast).
 
 === Zukünftige Entscheidungen
 
-Künftige Architekturentscheidungen erhalten die jeweils nächste freie ADR-Nummer (aktuell **ADR-008**). Nummern werden nicht mehr vorab reserviert: Eine frühere Fassung dieser Liste hatte ADR-006 für die Suchindex-Implementierung und ADR-007 für eine Analytics-Lösung vorgemerkt — beide Nummern sind inzwischen anderweitig vergeben (ADR-006 Code-Review-Tooling, ADR-007 Artefakt-Taxonomie), was genau die Kollision zeigt, die das Vorab-Reservieren erzeugt.
+Künftige Architekturentscheidungen erhalten die jeweils nächste freie ADR-Nummer (aktuell **ADR-009**). Nummern werden nicht mehr vorab reserviert: Eine frühere Fassung dieser Liste hatte ADR-006 für die Suchindex-Implementierung und ADR-007 für eine Analytics-Lösung vorgemerkt — beide Nummern sind inzwischen anderweitig vergeben (ADR-006 Code-Review-Tooling, ADR-007 Artefakt-Taxonomie), was genau die Kollision zeigt, die das Vorab-Reservieren erzeugt.
 
 **Noch nicht als ADR erfasste Themen:**
 

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -2,6 +2,12 @@
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 
+== 2026-07-06
+
+*ADR-008 — Personality & assessment frameworks as anchors (the Utility Gate):*
+
+* The catalog held one personality anchor (MBTI) while the proposal template rejected "personality/assessment frameworks" — a contradiction that recurred with each new proposal (DISC #671, Big Five/OCEAN #673, HEXACO #674). ADR-008 resolves it with a *topic-neutral Utility Gate*: no subject area is banned or blessed; a framework is admitted only if naming it demonstrably changes the LLM's output structure (the existing Viability Test), and carries a Criticism section. MBTI is re-subjected to the same test rather than grandfathered. CONTRIBUTING (EN + DE) and the proposal template are updated to state the topic-neutral rule; the arc42 Chapter 9 ADR index lists ADR-008.
+
 == 2026-07-05
 
 *Metadata audit — `:proponents:` backfill (#668, Phase A):*

--- a/docs/specs/adrs/adr-008-personality-assessment-anchors.adoc
+++ b/docs/specs/adrs/adr-008-personality-assessment-anchors.adoc
@@ -1,0 +1,151 @@
+= ADR-008: Personality & Assessment Frameworks as Anchors — the Utility Gate
+:toc:
+:icons: font
+
+== Status
+
+**Accepted** — 2026-07-06
+
+Surfaced while reviewing a cluster of personality/assessment proposals — DISC
+(https://github.com/LLM-Coding/Semantic-Anchors/issues/671[#671]), Big Five / OCEAN
+(https://github.com/LLM-Coding/Semantic-Anchors/issues/673[#673]), HEXACO
+(https://github.com/LLM-Coding/Semantic-Anchors/issues/674[#674]) — against an
+existing anchor, `myers-briggs-type-indicator`, and a proposal template that lists
+_"personality/assessment frameworks without LLM utility (e.g. MBTI)"_ as a rejection
+criterion. The catalog was deciding each case ad hoc, and the template appeared to
+contradict its own catalog. This ADR removes the contradiction by naming the actual
+criterion.
+
+== Context
+
+The catalog holds one personality-model anchor (`myers-briggs-type-indicator`,
+tier ★★★ by legacy acceptance) while its `propose-anchor` template rejects
+"personality/assessment frameworks without LLM utility." Read as a *topic* rule, that
+is a contradiction — MBTI is such a framework. Read as a *utility* rule, it is not: the
+operative words are "without LLM utility."
+
+Meanwhile four candidates arrived at once:
+
+* **DISC (#671)** — behavioural model (Marston); proposal empty, needs viability data.
+* **Big Five / OCEAN (#673)** — the empirically robust five-factor model
+  (Goldberg; Costa & McCrae). OCEAN and Five-Factor Model are the *same* model.
+* **HEXACO (#674)** — six-factor extension (Lee & Ashton) adding Honesty-Humility.
+* **WEIRD (#675)** — *not* a personality model; a methodological-bias lens
+  (Henrich, Heine & Norenzayan, 2010).
+
+Without a stated rule, each is litigated from scratch, and the MBTI-vs-template tension
+recurs every time.
+
+=== The core insight
+
+The catalog already defines an anchor by *activation*, not *recognition*. ADR-007
+fixes the artifact taxonomy (Anchor = focusing signal for knowledge already dense in
+training data); `CONTRIBUTING.adoc` already carries a **Viability Test** — _"a term
+that passes the four Quality Criteria but fails the viability test is a Contract, not an
+Anchor"_ — and #640 formalises "recognition ≠ activation." The criterion for admission
+is therefore **whether naming the term reliably changes the LLM's output structure**,
+never the term's subject area. Nothing in the catalog's theory licenses banning or
+blessing a *topic*.
+
+=== Requirements
+
+* **One rule, uniformly applied** — to existing anchors (MBTI) and new proposals alike.
+* **No arbitrary topic bans** — the criterion is utility, not subject area.
+* **Preserves the "anchor = changes output" thesis** — no drift toward a glossary.
+* **Resolves the template↔catalog contradiction** — template and catalog must agree.
+* **Low churn** — reuse the existing Viability Test; avoid mass rework.
+
+== Decision
+
+**We adopt a topic-neutral Utility Gate.** No subject area is privileged or banned. A
+personality or assessment framework is admitted as an Anchor **if and only if** it
+clears the same bar as any other candidate:
+
+. It passes the four Quality Criteria (precise, rich, consistent, attributable), and
+. It passes the **Viability Test** in `CONTRIBUTING.adoc` — naming it demonstrably
+  changes the output structure of a task (before/after), on at least one weak and one
+  strong model — not mere recognition, and
+. Given the contested empirical standing typical of these frameworks, it carries a
+  `== Criticism` / `== Current Status` section (per #603).
+
+A framework that is only *recognised* (fluent description, no output-structure change)
+is **★☆☆ descriptive-only → rejected**, exactly as the template already states. "MBTI"
+is not banned for being about personality; a personality model is not admitted for
+being well-known. Utility decides.
+
+=== Consequences for the open set
+
+[cols="2,3", options="header"]
+|===
+| Proposal | Ruling under the Utility Gate
+
+| Big Five / OCEAN (#673) | Admissible *if* a documented activation pattern is shown (e.g. "profile along OCEAN dimensions" yields structured, comparable output). Likely tier ★★☆ (needs the qualified form). The empirically strongest of the personality set.
+| HEXACO (#674) | Admit *only if* the Honesty-Humility factor delivers utility beyond Big Five; otherwise "covered by an existing anchor" (ADR-007) → reject as redundant.
+| DISC (#671) | Same gate. Proposal currently lacks viability data; bounce back until the before/after test is supplied.
+| WEIRD (#675) | Not a personality model — an analytical lens whose naming triggers a concrete generalisability check. Passes the gate on its own merit; judged on domain fit, not on this ADR's personality tension.
+| MBTI (in catalog) | Re-subjected to the same gate. It must document an activation pattern (a before/after where naming MBTI changes output) *and* gain a Criticism section, or be reclassified — downgraded in tier, or deprecated to the Rejected Proposals page. Its legacy ★★★ is not grandfathered.
+|===
+
+=== Where the decision lives
+
+Both. This ADR is the reasoned record; the operational rule already exists as the
+Viability Test in `CONTRIBUTING.adoc`, which gains one sentence making topic-neutrality
+explicit and citing this ADR. The `propose-anchor` template's rejection bullet is
+reworded from the MBTI example to the topic-neutral gate.
+
+=== Pugh matrix
+
+Baseline: keep deciding case-by-case with no stated rule (status quo) = 0.
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Criterion (weight) | Utility gate (chosen) | Status quo (baseline) | Exclude category | Liberal admit
+
+| Consistency with "anchor = activation" thesis (10) | +2 | 0 | 0 | -2
+| Resolves template↔catalog contradiction (9) | +2 | 0 | +1 | +1
+| No arbitrary topic ban / applies uniformly (8) | +2 | 0 | -2 | +1
+| Keeps catalog focused (anti-glossary) (7) | +2 | 0 | +1 | -2
+| Low churn / migration cost (5) | -1 | 0 | -2 | +1
+| **Weighted total** | **+63** | **0** | **-10** | **-12**
+|===
+
+The Utility Gate wins decisively. "Exclude category" scores negative because banning a
+subject area is arbitrary (it would also delete a working anchor and reject WEIRD, which
+is not even a personality model). "Liberal admit" abandons the activation thesis and
+drifts the catalog toward a glossary.
+
+== Consequences
+
+=== Positive
+
+* One criterion, stated once, applied to every candidate — no more ad-hoc litigation.
+* Template and catalog agree; the apparent contradiction dissolves.
+* The catalog's identity ("anchors change output") is protected against glossary drift.
+* Reuses machinery already in `CONTRIBUTING.adoc`; almost no new process.
+
+=== Negative / risks
+
+* **MBTI must be re-justified or reclassified.** Removing/downgrading an existing
+  ★★★ anchor is visible churn and may surprise contributors who cited it. Mitigation:
+  treat it as a tracked follow-up, not a silent deletion; give it the before/after test
+  first.
+* **Viability evidence is judgement-laden.** "Does the output structure change?" has a
+  grey zone. Mitigation: require the before/after artefact in the proposal, on a weak
+  *and* a strong model, per the existing test.
+* **Borderline utility for genuinely useful topics.** Some frameworks with real-world
+  value but weak *LLM* utility will be rejected; that is the intended cost of a
+  utility-defined catalog, not a defect.
+
+=== Open questions (deferred, not blocking)
+
+* Should reclassified anchors (e.g. MBTI if it fails) move to Rejected Proposals with a
+  "was previously listed" note, or stay as a downgraded ★☆☆ with a caveat? Decide when
+  the first reclassification actually happens.
+
+== References
+
+* ADR-007 — Artifact Taxonomy (Anchor vs. Contract vs. Skill): the activation-vs-recognition basis this ADR applies.
+* `CONTRIBUTING.adoc` — _Viability Test_ and _Quality Criteria_ (the operational gate).
+* https://github.com/LLM-Coding/Semantic-Anchors/issues/640[#640] — recognition ≠ activation (viability test).
+* https://github.com/LLM-Coding/Semantic-Anchors/issues/671[#671] (DISC), https://github.com/LLM-Coding/Semantic-Anchors/issues/673[#673] (Big Five/OCEAN), https://github.com/LLM-Coding/Semantic-Anchors/issues/674[#674] (HEXACO), https://github.com/LLM-Coding/Semantic-Anchors/issues/675[#675] (WEIRD) — the proposals that motivated this ADR.
+* https://github.com/LLM-Coding/Semantic-Anchors/issues/603[#603] — Criticism / Current Status requirement.


### PR DESCRIPTION
Records the decision requested in the review of the personality-model proposals: **does the catalog admit personality/assessment frameworks as anchors, and by what rule?**

## Decision

A **topic-neutral Utility Gate**. No subject area is banned or blessed. A personality/assessment framework is admitted as an anchor **iff** it (1) passes the four Quality Criteria, (2) passes the existing **Viability Test** (naming it demonstrably changes the LLM's output structure — not mere recognition), and (3) carries a Criticism/Current Status section. This makes the template's existing "without LLM utility" wording the general law, and removes the contradiction with the in-catalog MBTI anchor by subjecting MBTI to the same test.

Pugh: Utility Gate **+63** vs. exclude-category −10 vs. liberal-admit −12 (baseline status-quo 0).

## Consequences for the open proposals

- **Big Five/OCEAN (#673)** — admissible with a documented activation pattern (★★☆).
- **HEXACO (#674)** — only if Honesty-Humility adds utility beyond Big Five, else redundant.
- **DISC (#671)** — same gate; needs viability data.
- **WEIRD (#675)** — not a personality model; passes on its own merit.
- **MBTI (in catalog)** — re-justify with a before/after + Criticism section, or reclassify. Not grandfathered (named as a risk in the ADR).

## Changed

- New `docs/specs/adrs/adr-008-personality-assessment-anchors.adoc` (Nygard + Pugh, matching ADR-007).
- `CONTRIBUTING.adoc` + `docs/CONTRIBUTING.de.adoc` — one sentence making the gate topic-neutral, citing ADR-008.
- `propose-anchor.yml` — rejection bullet reworded from the MBTI example to the topic-neutral gate.
- arc42 Chapter 9 ADR index — ADR-008 row; next-free-number note bumped to ADR-009.

Decision taken under delegation ("let's decide now and record as ADR"); amend the Status/ruling if you'd prefer a different option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * Neue ADR-008 ergänzt die Entscheidungsgrundlage für „Personality &amp; assessment frameworks“ als Anker („Utility Gate“) mit Status *Accepted*.
  * Beitragshinweise (EN/DE) und das Proposal-Template wurden aktualisiert: Ablehnung erfolgt themenneutral, wenn ein Begriff keinen nachweisbaren Output-Nutzen zeigt; „Recognition-only“ fällt durch.
  * Ergänzend wird eine `== Criticism` / `== Current Status`-Sektion für umstrittene Begriffe eingefordert.
  * Changelog und Architektur-Übersicht wurden um ADR-008 erweitert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->