### PR TITLE
feat: add Big Five / OCEAN anchor (#673)

### DIFF
--- a/docs/anchors/big-five.adoc
+++ b/docs/anchors/big-five.adoc
@@ -1,0 +1,64 @@
+= Big Five (OCEAN) Personality Traits
+:categories: communication-presentation
+:roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
+:proponents: Lewis R. Goldberg, Paul T. Costa, Robert R. McCrae
+:tags: personality traits, Big Five, OCEAN, Five-Factor Model, FFM, trait psychology, team dynamics
+:tier: 2
+
+[%collapsible]
+====
+Full Name:: Big Five Personality Traits / Five-Factor Model (FFM)
+
+Also known as:: OCEAN, Five-Factor Model (FFM), the Big Five, CANOE
+
+[discrete]
+== *Core Concepts*:
+
+Five Broad Dimensions (OCEAN):: The model describes personality along five continuous, largely independent dimensions:
+* *Openness to experience* — imagination, curiosity, preference for novelty vs. routine and convention
+* *Conscientiousness* — organisation, dependability, self-discipline vs. spontaneity and carelessness
+* *Extraversion* — sociability, assertiveness, energy drawn from the outer world vs. reserve
+* *Agreeableness* — compassion, cooperation, trust vs. antagonism and skepticism
+* *Neuroticism* (vs. Emotional Stability) — proneness to anxiety, moodiness, emotional reactivity vs. calm
+
+Continuous Traits, Not Types:: Each dimension is a spectrum a person scores high or low on; the model deliberately does not sort people into discrete types (contrast MBTI's 16 boxes).
+
+Facets:: Each factor decomposes into narrower facets (e.g., Conscientiousness → order, dutifulness, self-discipline, achievement-striving), giving finer-grained profiles.
+
+Lexical Hypothesis:: The five factors emerged empirically via the lexical hypothesis — the idea that the most important personality differences become encoded as single words in language — through factor analysis of trait adjectives.
+
+Two Lineages, One Model:: Lewis Goldberg's "Big Five" (lexical, adjective-based) and Costa & McCrae's Five-Factor Model (questionnaire-based, the NEO-PI-R) converge on the same five dimensions; OCEAN is the shared mnemonic.
+
+Predictive Use:: Trait scores correlate — modestly but consistently — with outcomes such as job performance (especially Conscientiousness), well-being, and academic achievement.
+
+Key Proponents:: Lewis R. Goldberg (coined "Big Five", early 1980s); Paul T. Costa & Robert R. McCrae (Five-Factor Model / NEO-PI-R). Early lexical roots: Tupes & Christal (1961).
+
+[discrete]
+== *When to Use*:
+
+For reliable activation, name the model *and the task* — "profile this persona along the five OCEAN dimensions" — rather than the bare term.
+
+* Building richer, evidence-based user personas in UX research (score along OCEAN instead of inventing ad-hoc traits)
+* Tailoring communication or messaging to a described audience's trait profile
+* Reasoning about team composition and likely friction (e.g., high- vs. low-Conscientiousness pairings)
+* Coaching and self-reflection grounded in a validated trait vocabulary
+* Structuring qualitative analysis of interview or survey text into comparable trait dimensions
+
+[discrete]
+== *Common Misunderstandings*:
+
+* ❌ "Big Five sorts people into types" — it describes continuous traits, not categories
+* ❌ "Scores are fixed" — traits are relatively stable in adulthood but shift across the lifespan
+* ❌ "It explains *why* someone behaves as they do" — the model is descriptive and predictive, not causal
+* ✓ "Big Five is the empirically dominant trait model" — it is, which is why it is the usual scientific benchmark against MBTI and DISC
+====
+
+== Criticism:
+
+* Michael Gurven et al., https://pmc.ncbi.nlm.nih.gov/articles/PMC4104167/["How Universal Is the Big Five?", _Journal of Personality and Social Psychology_ 104(2)] (2013) — the five-factor structure failed to replicate among the Tsimane of the Bolivian Amazon; a two-factor "prosociality / industriousness" structure fit better, challenging the model's claimed universality. The evidence base is heavily WEIRD (Western, Educated, Industrialized, Rich, Democratic).
+* The model is *descriptive, not explanatory*: derived from the lexical hypothesis and factor analysis, it names covarying traits without a causal theory of their origin.
+
+[discrete]
+== Current Status:
+
+* Still the dominant, most empirically validated trait model in academic psychology, and the standard scientific benchmark against which other personality instruments are judged. The main structured challenger is the six-factor https://en.wikipedia.org/wiki/HEXACO_model_of_personality_structure[HEXACO model] (Ashton & Lee), which adds *Honesty-Humility*. The prior most training data serves is the five-factor OCEAN model.

--- a/docs/anchors/big-five.de.adoc
+++ b/docs/anchors/big-five.de.adoc
@@ -1,0 +1,64 @@
+= Big Five (OCEAN) Persönlichkeitsmerkmale
+:categories: communication-presentation
+:roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
+:proponents: Lewis R. Goldberg, Paul T. Costa, Robert R. McCrae
+:tags: Persönlichkeitsmerkmale, Big Five, OCEAN, Fünf-Faktoren-Modell, FFM, Trait-Psychologie, Teamdynamik
+:tier: 2
+
+[%collapsible]
+====
+Vollständiger Name:: Big Five Persönlichkeitsmerkmale / Fünf-Faktoren-Modell (FFM)
+
+Auch bekannt als:: OCEAN, Fünf-Faktoren-Modell (FFM), die Big Five, CANOE
+
+[discrete]
+== *Kernkonzepte*:
+
+Fünf breite Dimensionen (OCEAN):: Das Modell beschreibt Persönlichkeit entlang fünf kontinuierlicher, weitgehend unabhängiger Dimensionen:
+* *Openness / Offenheit für Erfahrungen* — Fantasie, Neugier, Vorliebe für Neues vs. Routine und Konvention
+* *Conscientiousness / Gewissenhaftigkeit* — Organisation, Verlässlichkeit, Selbstdisziplin vs. Spontaneität und Nachlässigkeit
+* *Extraversion* — Geselligkeit, Durchsetzungsstärke, Energie aus der Außenwelt vs. Zurückhaltung
+* *Agreeableness / Verträglichkeit* — Mitgefühl, Kooperation, Vertrauen vs. Antagonismus und Skepsis
+* *Neuroticism / Neurotizismus* (vs. emotionale Stabilität) — Neigung zu Angst, Launenhaftigkeit, emotionaler Reaktivität vs. Gelassenheit
+
+Kontinuierliche Merkmale, keine Typen:: Jede Dimension ist ein Spektrum, auf dem eine Person hoch oder niedrig liegt; das Modell sortiert Menschen bewusst nicht in diskrete Typen (im Gegensatz zu den 16 Kästchen des MBTI).
+
+Facetten:: Jeder Faktor zerfällt in engere Facetten (z. B. Gewissenhaftigkeit → Ordnung, Pflichtbewusstsein, Selbstdisziplin, Leistungsstreben) und erlaubt so feinere Profile.
+
+Lexikalische Hypothese:: Die fünf Faktoren ergaben sich empirisch aus der lexikalischen Hypothese — dass die wichtigsten Persönlichkeitsunterschiede als einzelne Wörter in der Sprache kodiert werden — über Faktorenanalyse von Eigenschaftsadjektiven.
+
+Zwei Linien, ein Modell:: Lewis Goldbergs „Big Five" (lexikalisch, adjektivbasiert) und Costa & McCraes Fünf-Faktoren-Modell (fragebogenbasiert, das NEO-PI-R) konvergieren auf dieselben fünf Dimensionen; OCEAN ist das gemeinsame Merkwort.
+
+Prädiktiver Nutzen:: Merkmalswerte korrelieren — moderat, aber konsistent — mit Ergebnissen wie Arbeitsleistung (besonders Gewissenhaftigkeit), Wohlbefinden und Studienerfolg.
+
+Wichtige Proponenten:: Lewis R. Goldberg (prägte „Big Five", frühe 1980er); Paul T. Costa & Robert R. McCrae (Fünf-Faktoren-Modell / NEO-PI-R). Frühe lexikalische Wurzeln: Tupes & Christal (1961).
+
+[discrete]
+== *Wann einzusetzen*:
+
+Für zuverlässige Aktivierung das Modell *und die Aufgabe* nennen — „profiliere diese Persona entlang der fünf OCEAN-Dimensionen" — statt des nackten Begriffs.
+
+* Reichhaltigere, evidenzbasierte User Personas in der UX-Forschung (nach OCEAN bewerten statt Ad-hoc-Eigenschaften zu erfinden)
+* Kommunikation oder Botschaften auf das Merkmalsprofil einer beschriebenen Zielgruppe zuschneiden
+* Über Teamzusammensetzung und wahrscheinliche Reibung nachdenken (z. B. Paarungen mit hoher vs. niedriger Gewissenhaftigkeit)
+* Coaching und Selbstreflexion auf einem validierten Merkmalsvokabular
+* Qualitative Analyse von Interview- oder Umfragetext in vergleichbare Merkmalsdimensionen strukturieren
+
+[discrete]
+== *Häufige Missverständnisse*:
+
+* ❌ „Big Five sortiert Menschen in Typen" — es beschreibt kontinuierliche Merkmale, keine Kategorien
+* ❌ „Werte sind festgelegt" — Merkmale sind im Erwachsenenalter relativ stabil, verschieben sich aber über die Lebensspanne
+* ❌ „Es erklärt, *warum* jemand sich so verhält" — das Modell ist deskriptiv und prädiktiv, nicht kausal
+* ✓ „Big Five ist das empirisch dominante Merkmalsmodell" — ist es, weshalb es der übliche wissenschaftliche Maßstab gegenüber MBTI und DISC ist
+====
+
+== Criticism:
+
+* Michael Gurven et al., https://pmc.ncbi.nlm.nih.gov/articles/PMC4104167/["How Universal Is the Big Five?", _Journal of Personality and Social Psychology_ 104(2)] (2013) — die Fünf-Faktoren-Struktur replizierte bei den Tsimane im bolivianischen Amazonasgebiet nicht; eine Zwei-Faktoren-Struktur („Prosozialität / Fleiß") passte besser und stellt die behauptete Universalität in Frage. Die Datenbasis ist stark WEIRD (Western, Educated, Industrialized, Rich, Democratic).
+* Das Modell ist *deskriptiv, nicht erklärend*: aus lexikalischer Hypothese und Faktorenanalyse abgeleitet, benennt es kovariierende Merkmale ohne kausale Theorie ihrer Herkunft.
+
+[discrete]
+== Current Status:
+
+* Nach wie vor das dominante, empirisch am besten validierte Merkmalsmodell der akademischen Psychologie und der Standard-Maßstab, an dem andere Persönlichkeitsinstrumente gemessen werden. Der wichtigste strukturierte Herausforderer ist das sechsfaktorielle https://en.wikipedia.org/wiki/HEXACO_model_of_personality_structure[HEXACO-Modell] (Ashton & Lee), das *Honesty-Humility* (Ehrlichkeit-Bescheidenheit) ergänzt. Der Prior, den die meisten Trainingsdaten bedienen, ist das fünffaktorielle OCEAN-Modell.

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-06
 
+*New anchor — Big Five / OCEAN (#673), the first admitted under ADR-008:*
+
+* *link:#/anchor/big-five[Big Five / OCEAN]* (Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae) — communication-presentation: five continuous trait dimensions (Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism), the empirically dominant trait model and the scientific benchmark against MBTI/DISC. Added as the first anchor to clear the new Utility Gate: tier ★★☆ (fires with the qualified form "profile along the OCEAN dimensions"), bilingual, with a fetch-verified Criticism section (Gurven et al. 2013 — the structure failed to replicate among the Tsimane; the evidence base is heavily WEIRD) and a Current Status pointing to the HEXACO challenger. Proposed by https://github.com/raifdmueller[@raifdmueller] in #673.
+
 *ADR-008 — Personality & assessment frameworks as anchors (the Utility Gate):*
 
 * The catalog held one personality anchor (MBTI) while the proposal template rejected "personality/assessment frameworks" — a contradiction that recurred with each new proposal (DISC #671, Big Five/OCEAN #673, HEXACO #674). ADR-008 resolves it with a *topic-neutral Utility Gate*: no subject area is banned or blessed; a framework is admitted only if naming it demonstrably changes the LLM's output structure (the existing Viability Test), and carries a Criticism section. MBTI is re-subjected to the same test rather than grandfathered. CONTRIBUTING (EN + DE) and the proposal template are updated to state the topic-neutral rule; the arc42 Chapter 9 ADR index lists ADR-008.

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -605,6 +605,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 - **Core:** Four dichotomies (E/I, S/N, T/F, J/P) produce 16 personality types describing communication preferences, decision-making styles, and team dynamics
 
+### Big Five (OCEAN) Personality Traits
+- **Also known as:** OCEAN, Five-Factor Model (FFM), the Big Five, CANOE
+- **Proponents:** Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae
+- **Core:** Five continuous, largely independent trait dimensions — Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism — scored on a spectrum (not types); the empirically dominant trait model. Name the task ("profile along the five OCEAN dimensions") for reliable activation
+
 ### Curse of Knowledge
 - **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
 - **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -605,6 +605,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 - **Core:** Four dichotomies (E/I, S/N, T/F, J/P) produce 16 personality types describing communication preferences, decision-making styles, and team dynamics
 
+### Big Five (OCEAN) Personality Traits
+- **Also known as:** OCEAN, Five-Factor Model (FFM), the Big Five, CANOE
+- **Proponents:** Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae
+- **Core:** Five continuous, largely independent trait dimensions — Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism — scored on a spectrum (not types); the empirically dominant trait model. Name the task ("profile along the five OCEAN dimensions") for reliable activation
+
 ### Curse of Knowledge
 - **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
 - **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience


### PR DESCRIPTION
Closes #673. The first anchor admitted under **ADR-008**'s topic-neutral Utility Gate.

## What

- New bilingual anchor **Big Five / OCEAN** (`docs/anchors/big-five.adoc` + `.de.adoc`), aliases OCEAN / Five-Factor Model / FFM.
- **Tier ★★☆** (`:tier: 2`) — utility fires with the qualified form ("profile along the OCEAN dimensions"), documented in *When to Use*, not from the bare name.
- **Proponents:** Lewis R. Goldberg (coined "Big Five"); Paul T. Costa & Robert R. McCrae (FFM / NEO-PI-R).
- **Criticism section (fetch-verified, #603):** Gurven et al. (2013, *J. Personality and Social Psychology*) — the five-factor structure failed to replicate among the Tsimane; the evidence base is heavily WEIRD.
- **Current Status:** still the dominant trait model; points to the HEXACO challenger (#674).
- AgentSkill catalog + changelog updated.

## Why it clears the gate (ADR-008)

Naming "profile along OCEAN" changes output structure (fließtext → five named, scored dimensions) — utility, not mere recognition. It is the empirically robust member of the personality-model family and the standard benchmark against MBTI/DISC.

Generated `public/data/*.json` not committed (regenerated by the build, per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)