### PR TITLE
chore: surface Detroit School / Classicist aliases in tdd-chicago-school tags (#678)

### DIFF
--- a/docs/anchors/tdd-chicago-school.adoc
+++ b/docs/anchors/tdd-chicago-school.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Kent Beck, Martin Fowler
+:tags: TDD, classicist TDD, Detroit School, Chicago School, state-based testing, inside-out, Kent Beck
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/tdd-chicago-school.de.adoc
+++ b/docs/anchors/tdd-chicago-school.de.adoc
@@ -2,6 +2,8 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Kent Beck, Martin Fowler
+:tags: TDD, classicist TDD, Detroit School, Chicago School, state-based testing, inside-out, Kent Beck
+:tier: 3
 
 [%collapsible]
 ====


### PR DESCRIPTION
Closes #678.

"Detroit School" and "Classicist TDD" are synonyms of the Chicago School (verified: same classic, inside-out, state-based style from Kent Beck / XP's Chrysler C3 project in Detroit). They were listed in the anchor's "Also known as" prose but **not in searchable `:tags:`** — the file had none — so a search for "Detroit School" would miss it.

## Change
- Add `:tags:` to `tdd-chicago-school` (EN + DE): `TDD, classicist TDD, Detroit School, Chicago School, state-based testing, inside-out, Kent Beck`.
- Add the missing `:tier: 3` to the DE file (it was only in EN) — parity fix.

No new anchor — Detroit School is correctly an alias, not a separate entry (per ADR-007 redundancy / the OCEAN = Big Five synonym logic). Also knocks one file off #668 Phase B (`:tags:` backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)