### PR TITLE
feat: add HEXACO anchor (#674)

### DIFF
--- a/docs/anchors/hexaco.adoc
+++ b/docs/anchors/hexaco.adoc
@@ -1,0 +1,61 @@
+= HEXACO Personality Model
+:categories: communication-presentation
+:roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
+:proponents: Kibeom Lee, Michael C. Ashton
+:tags: personality traits, HEXACO, Honesty-Humility, six-factor model, Dark Triad, trait psychology
+:tier: 2
+
+[%collapsible]
+====
+Full Name:: HEXACO Model of Personality Structure
+
+Also known as:: HEXACO, Six-Factor Model, the H Factor
+
+[discrete]
+== *Core Concepts*:
+
+Six Dimensions (HEXACO):: The model describes personality along six continuous dimensions:
+* *Honesty-Humility (H)* — sincerity, fairness, greed-avoidance, modesty vs. manipulativeness, entitlement, greed
+* *Emotionality (E)* — fearfulness, anxiety, sentimentality, need for support (a rotated variant of Big Five Neuroticism)
+* *eXtraversion (X)* — social self-esteem, sociability, liveliness
+* *Agreeableness (A)* — forgiveness, gentleness, patience (a rotated variant — anger/temper sits here, not in Emotionality)
+* *Conscientiousness (C)* — organisation, diligence, prudence
+* *Openness to Experience (O)* — aesthetic appreciation, curiosity, unconventionality
+
+The Sixth Factor Is the Point:: HEXACO is essentially the Big Five *plus* Honesty-Humility. Three factors (X, C, O) map onto Big Five counterparts; Emotionality and Agreeableness are "rotated variants" with shifted content; Honesty-Humility is genuinely new.
+
+Honesty-Humility Predicts the Dark Side:: The H factor is the strongest single trait predictor of unethical, exploitative, and manipulative behaviour, and correlates strongly (inversely) with the Dark Triad — Machiavellianism, narcissism, psychopathy. This is coverage the Big Five does not provide, and the reason HEXACO earns its own place rather than being an alias of Big Five.
+
+Lexical, Cross-Language Origin:: The six factors recurred across factor-analytic lexical studies in many languages (Dutch, German, Korean, Italian, Hungarian, Polish, and others).
+
+Continuous Traits, Not Types:: Like the Big Five, each dimension is a spectrum, not a category.
+
+Key Proponents:: Kibeom Lee & Michael C. Ashton (first papers ~2004; book _The H Factor of Personality_, 2013).
+
+[discrete]
+== *When to Use*:
+
+For reliable activation, name the model *and the task* — "assess along the HEXACO dimensions, especially Honesty-Humility" — rather than the bare term.
+
+* When integrity, fairness, or exploitation risk is the relevant axis (ethics discussions, counterparty modelling) — the Honesty-Humility factor the Big Five omits
+* Reasoning about dark-personality patterns (Dark Triad) with a validated trait vocabulary
+* Richer persona or team modelling where honesty-humility carries signal
+* Any Big Five use case where the extra sixth dimension adds discriminating information
+
+[discrete]
+== *Common Misunderstandings*:
+
+* ❌ "HEXACO is just the Big Five renamed" — it adds a genuinely distinct sixth factor (H) and rotates two others
+* ❌ "Honesty-Humility is a truthfulness test" — it is a personality disposition, not a lie detector
+* ✓ "HEXACO's reason to exist is the H factor" — its distinct utility over Big Five is Honesty-Humility
+====
+
+== Criticism:
+
+* Boele De Raad and colleagues, via the https://en.wikipedia.org/wiki/HEXACO_model_of_personality_structure[HEXACO model overview] — only three factors (Extraversion, Agreeableness, Conscientiousness) replicate fully across cultures; the sixth factor Honesty-Humility is "not always consistently replicated", and alternative sixth factors (e.g. hedonism-spontaneity) emerge in some lexical studies, so claims of six-factor universality should be treated cautiously.
+* Big Five proponents argue Honesty-Humility can be largely accommodated within (low) Big Five Agreeableness, questioning whether a distinct sixth factor is warranted.
+
+[discrete]
+== Current Status:
+
+* An actively researched six-factor alternative to the Big Five, with growing adoption — particularly in integrity, ethics, and Dark-Triad research, where the Honesty-Humility factor shows distinct predictive value. The Big Five (see the Big Five / OCEAN anchor) remains the more widely used default; the prior most training data serves is still five-factor, with HEXACO the recognised six-factor challenger.

--- a/docs/anchors/hexaco.de.adoc
+++ b/docs/anchors/hexaco.de.adoc
@@ -1,0 +1,61 @@
+= HEXACO Persönlichkeitsmodell
+:categories: communication-presentation
+:roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
+:proponents: Kibeom Lee, Michael C. Ashton
+:tags: Persönlichkeitsmerkmale, HEXACO, Honesty-Humility, Sechs-Faktoren-Modell, Dark Triad, Trait-Psychologie
+:tier: 2
+
+[%collapsible]
+====
+Vollständiger Name:: HEXACO Model of Personality Structure
+
+Auch bekannt als:: HEXACO, Sechs-Faktoren-Modell, der H-Faktor
+
+[discrete]
+== *Kernkonzepte*:
+
+Sechs Dimensionen (HEXACO):: Das Modell beschreibt Persönlichkeit entlang sechs kontinuierlicher Dimensionen:
+* *Honesty-Humility (H) / Ehrlichkeit-Bescheidenheit* — Aufrichtigkeit, Fairness, Gier-Vermeidung, Bescheidenheit vs. Manipulation, Anspruchsdenken, Gier
+* *Emotionality (E) / Emotionalität* — Ängstlichkeit, Besorgnis, Sentimentalität, Bedürfnis nach Unterstützung (rotierte Variante des Big-Five-Neurotizismus)
+* *eXtraversion (X)* — soziales Selbstwertgefühl, Geselligkeit, Lebhaftigkeit
+* *Agreeableness (A) / Verträglichkeit* — Vergebungsbereitschaft, Sanftmut, Geduld (rotierte Variante — Ärger/Temperament liegt hier, nicht in Emotionalität)
+* *Conscientiousness (C) / Gewissenhaftigkeit* — Organisation, Fleiß, Umsicht
+* *Openness to Experience (O) / Offenheit* — ästhetisches Empfinden, Neugier, Unkonventionalität
+
+Der sechste Faktor ist der Kern:: HEXACO ist im Wesentlichen die Big Five *plus* Honesty-Humility. Drei Faktoren (X, C, O) entsprechen Big-Five-Pendants; Emotionalität und Verträglichkeit sind „rotierte Varianten" mit verschobenem Inhalt; Honesty-Humility ist tatsächlich neu.
+
+Honesty-Humility sagt die dunkle Seite vorher:: Der H-Faktor ist der stärkste einzelne Merkmals-Prädiktor für unethisches, ausbeuterisches und manipulatives Verhalten und korreliert stark (invers) mit der Dark Triad — Machiavellismus, Narzissmus, Psychopathie. Das leistet die Big Five nicht, und genau deshalb verdient HEXACO einen eigenen Platz statt Alias der Big Five zu sein.
+
+Lexikalischer, sprachübergreifender Ursprung:: Die sechs Faktoren traten wiederholt in faktorenanalytischen lexikalischen Studien vieler Sprachen auf (Niederländisch, Deutsch, Koreanisch, Italienisch, Ungarisch, Polnisch u. a.).
+
+Kontinuierliche Merkmale, keine Typen:: Wie bei der Big Five ist jede Dimension ein Spektrum, keine Kategorie.
+
+Wichtige Proponenten:: Kibeom Lee & Michael C. Ashton (erste Arbeiten ~2004; Buch _The H Factor of Personality_, 2013).
+
+[discrete]
+== *Wann einzusetzen*:
+
+Für zuverlässige Aktivierung das Modell *und die Aufgabe* nennen — „bewerte entlang der HEXACO-Dimensionen, besonders Honesty-Humility" — statt des nackten Begriffs.
+
+* Wenn Integrität, Fairness oder Ausbeutungsrisiko die relevante Achse ist (Ethik-Diskussionen, Modellierung von Gegenparteien) — der Honesty-Humility-Faktor, den die Big Five auslässt
+* Über Dark-Personality-Muster (Dark Triad) mit einem validierten Merkmalsvokabular nachdenken
+* Reichhaltigere Persona- oder Teammodellierung, wenn Honesty-Humility Signal trägt
+* Jeder Big-Five-Anwendungsfall, in dem die zusätzliche sechste Dimension unterscheidende Information liefert
+
+[discrete]
+== *Häufige Missverständnisse*:
+
+* ❌ „HEXACO ist nur die Big Five umbenannt" — es ergänzt einen tatsächlich eigenständigen sechsten Faktor (H) und rotiert zwei weitere
+* ❌ „Honesty-Humility ist ein Wahrheitstest" — es ist eine Persönlichkeitsdisposition, kein Lügendetektor
+* ✓ „HEXACOs Daseinsberechtigung ist der H-Faktor" — seine eigenständige Utility gegenüber Big Five ist Honesty-Humility
+====
+
+== Criticism:
+
+* Boele De Raad und Kollegen, via die https://en.wikipedia.org/wiki/HEXACO_model_of_personality_structure[HEXACO-Modell-Übersicht] — nur drei Faktoren (Extraversion, Verträglichkeit, Gewissenhaftigkeit) replizieren vollständig über Kulturen hinweg; der sechste Faktor Honesty-Humility wird „nicht immer konsistent repliziert", und in einigen lexikalischen Studien treten alternative sechste Faktoren auf (z. B. Hedonismus-Spontaneität), weshalb Universalitätsansprüche vorsichtig zu behandeln sind.
+* Big-Five-Vertreter argumentieren, Honesty-Humility lasse sich weitgehend in (niedriger) Big-Five-Verträglichkeit unterbringen, und stellen infrage, ob ein eigener sechster Faktor gerechtfertigt ist.
+
+[discrete]
+== Current Status:
+
+* Eine aktiv beforschte sechsfaktorielle Alternative zur Big Five mit wachsender Verbreitung — besonders in der Integritäts-, Ethik- und Dark-Triad-Forschung, wo der Honesty-Humility-Faktor eigenständigen prädiktiven Wert zeigt. Die Big Five (siehe Big Five / OCEAN Anchor) bleibt der verbreitetere Standard; der Prior, den die meisten Trainingsdaten bedienen, ist weiterhin fünffaktoriell, mit HEXACO als anerkanntem sechsfaktoriellem Herausforderer.

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-06
 
+*New anchor — HEXACO (#674):*
+
+* *link:#/anchor/hexaco[HEXACO]* (Kibeom Lee & Michael C. Ashton) — communication-presentation: the six-factor personality model — Big Five plus *Honesty-Humility*, the strongest trait predictor of unethical/exploitative behaviour and the Dark Triad. Admitted under ADR-008 because that sixth factor delivers distinct utility the Big Five cannot (the redundancy test, not a synonym). Tier ★★☆ (fires with the qualified form "assess along HEXACO, especially Honesty-Humility"), bilingual, with a fetch-verified Criticism section (De Raad et al. — the sixth factor does not always replicate cross-culturally) and a Current Status referencing the Big Five. Proposed by https://github.com/raifdmueller[@raifdmueller] in #674.
+
 *New anchor — Big Five / OCEAN (#673), the first admitted under ADR-008:*
 
 * *link:#/anchor/big-five[Big Five / OCEAN]* (Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae) — communication-presentation: five continuous trait dimensions (Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism), the empirically dominant trait model and the scientific benchmark against MBTI/DISC. Added as the first anchor to clear the new Utility Gate: tier ★★☆ (fires with the qualified form "profile along the OCEAN dimensions"), bilingual, with a fetch-verified Criticism section (Gurven et al. 2013 — the structure failed to replicate among the Tsimane; the evidence base is heavily WEIRD) and a Current Status pointing to the HEXACO challenger. Proposed by https://github.com/raifdmueller[@raifdmueller] in #673.

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -610,6 +610,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae
 - **Core:** Five continuous, largely independent trait dimensions — Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism — scored on a spectrum (not types); the empirically dominant trait model. Name the task ("profile along the five OCEAN dimensions") for reliable activation
 
+### HEXACO Personality Model
+- **Also known as:** HEXACO, Six-Factor Model, the H Factor
+- **Proponents:** Kibeom Lee & Michael C. Ashton
+- **Core:** Six trait dimensions — Honesty-Humility, Emotionality, eXtraversion, Agreeableness, Conscientiousness, Openness. Essentially Big Five plus Honesty-Humility (H), the strongest trait predictor of unethical/exploitative behaviour and the Dark Triad — its distinct value over Big Five. Name the task ("assess along HEXACO, especially Honesty-Humility") for reliable activation
+
 ### Curse of Knowledge
 - **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
 - **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -610,6 +610,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Lewis R. Goldberg; Paul T. Costa & Robert R. McCrae
 - **Core:** Five continuous, largely independent trait dimensions — Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism — scored on a spectrum (not types); the empirically dominant trait model. Name the task ("profile along the five OCEAN dimensions") for reliable activation
 
+### HEXACO Personality Model
+- **Also known as:** HEXACO, Six-Factor Model, the H Factor
+- **Proponents:** Kibeom Lee & Michael C. Ashton
+- **Core:** Six trait dimensions — Honesty-Humility, Emotionality, eXtraversion, Agreeableness, Conscientiousness, Openness. Essentially Big Five plus Honesty-Humility (H), the strongest trait predictor of unethical/exploitative behaviour and the Dark Triad — its distinct value over Big Five. Name the task ("assess along HEXACO, especially Honesty-Humility") for reliable activation
+
 ### Curse of Knowledge
 - **Proponents:** Camerer, Loewenstein & Weber; popularized by Chip & Dan Heath
 - **Core:** Once you know something you cannot imagine not knowing it, so experts overestimate shared context and leave jargon and steps unexplained; the antidote is to surface assumptions, define terms, and model the audience


### PR DESCRIPTION
Closes #674. Six-factor personality model (Lee & Ashton) — Big Five **plus Honesty-Humility**.

Admitted under **ADR-008**: it passes the redundancy test because the H factor (strongest trait predictor of unethical/exploitative behaviour, strong Dark-Triad link) delivers distinct utility the Big Five cannot — so it is its own anchor, not a Big Five alias.

- Bilingual, tier ★★☆ (qualified form "assess along HEXACO, especially Honesty-Humility").
- Proponents: Kibeom Lee & Michael C. Ashton.
- Fetch-verified Criticism (De Raad et al. — the sixth factor is not always replicated cross-culturally; alternative sixth factors emerge).
- Current Status references the Big Five / OCEAN anchor (#673).
- AgentSkill catalog + changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)