### PR TITLE
docs: fix README ADR list (missing ADR-006/007/008) and star-history chart

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 :icons: font
 :experimental:
 
-image:https://api.star-history.com/svg?repos=LLM-Coding/Semantic-Anchors&type=date&legend=top-left[link=https://www.star-history.com/#LLM-Coding/Semantic-Anchors&type=date&legend=top-left]
+image:https://api.star-history.com/svg?repos=LLM-Coding/Semantic-Anchors&type=Date[Star History Chart,link=https://star-history.com/#LLM-Coding/Semantic-Anchors&Date]
 
 == 🚀 Explore the Catalog
 
@@ -161,11 +161,14 @@ The website is automatically deployed to GitHub Pages on push to `main`:
 
 All major decisions documented with Pugh matrices:
 
-* link:docs/specs/adrs/adr-001-vite-static-site-generator.adoc[ADR-001]: Vite as Static Site Generator
-* link:docs/specs/adrs/adr-002-asciidoc-metadata-attributes.adoc[ADR-002]: AsciiDoc Attributes for Metadata
-* link:docs/specs/adrs/adr-003-apache-echarts-treemap.adoc[ADR-003]: Apache ECharts for Treemap (deprecated)
+* link:docs/specs/adrs/adr-001-static-site-generator.adoc[ADR-001]: Vite as Static Site Generator
+* link:docs/specs/adrs/adr-002-metadata-storage.adoc[ADR-002]: AsciiDoc Attributes for Metadata
+* link:docs/specs/adrs/adr-003-treemap-library.adoc[ADR-003]: Apache ECharts for Treemap (superseded by ADR-005)
 * link:docs/specs/adrs/adr-004-one-file-per-anchor.adoc[ADR-004]: One File per Anchor
 * link:docs/specs/adrs/adr-005-card-grid-visualization.adoc[ADR-005]: Card Grid Visualization (current)
+* link:docs/specs/adrs/adr-006-code-review-tooling.adoc[ADR-006]: Code-Review Tooling
+* link:docs/specs/adrs/adr-007-artifact-taxonomy.adoc[ADR-007]: Artifact Taxonomy — Anchor vs. Contract vs. Skill
+* link:docs/specs/adrs/adr-008-personality-assessment-anchors.adoc[ADR-008]: Personality & Assessment Frameworks — the Utility Gate
 
 == Documentation
 


### PR DESCRIPTION
Two defects in `README.adoc` (the README GitHub renders — `README.md` is the non-canonical duplicate).

## ADR list
- Ran only to **ADR-005** and was **missing ADR-006, ADR-007, ADR-008** (incl. the just-added Utility Gate).
- Links for ADR-001/002/003 pointed at **wrong filenames** (`adr-001-vite-static-site-generator.adoc` etc.) → dead links.

Fixed the three filenames and added the three missing ADRs. All eight link targets verified to exist.

## Star-history chart
The URL used `&type=date&legend=top-left` (lowercase `date` + a non-standard `legend` param), which renders as a broken/empty image. Normalized to the working `&type=Date` form.

## Note (not fixed here)
The repo carries **both** `README.adoc` and `README.md`; GitHub renders `README.adoc`, so `README.md` silently drifts (its ADR section is just a directory link). Worth deleting `README.md` or reducing it to a pointer — flagging for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Das Star-History-Badge in der README wurde aktualisiert und zeigt nun die aktuelle Darstellung an.
  * Der Abschnitt zu Architekturentscheidungen wurde erweitert: Verlinkungen und Bezeichnungen der ADR-Liste wurden überarbeitet und um weitere Einträge ergänzt.
  * Bestehende ADR-Verweise wurden aktualisiert, inklusive der Kennzeichnung von ersetzten Entscheidungen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->