### PR TITLE
feat: hold MBTI to the ADR-008 Utility Gate (Criticism + advisory)

### DIFF
--- a/docs/anchors/myers-briggs-type-indicator.adoc
+++ b/docs/anchors/myers-briggs-type-indicator.adoc
@@ -3,7 +3,9 @@
 :roles: team-lead, consultant, educator, ux-designer, product-owner
 :proponents: Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 :tags: personality types, MBTI, psychological types, communication styles, team dynamics, Jungian psychology
+:related: big-five, hexaco
 :tier: 1
+:advisory: Widely regarded as pseudoscience with low test-retest reliability — use for reflection and dialogue, not selection (see Criticism)
 
 [%collapsible]
 ====
@@ -51,10 +53,13 @@ Historical Context:: Developed during World War II to help women entering the in
 * ✓ "MBTI is a starting point for self-reflection and dialogue" — Correct use is exploratory, not diagnostic
 
 [discrete]
-== *Limitations and Criticisms*:
+== *Criticism*:
 
-* Test-retest reliability is modest — the same person can receive a different type on retaking the assessment
-* Binary dichotomies oversimplify continuous trait distributions
-* Not endorsed for high-stakes hiring or selection decisions
-* Criticized for low predictive validity for job performance compared to, e.g., Big Five personality traits
+* David J. Pittenger, via the https://en.wikipedia.org/wiki/Myers%E2%80%93Briggs_Type_Indicator[MBTI overview] — poor test-retest reliability: between 39% and 76% of respondents obtain a different type when retaking the indicator after only five weeks (about 50% change on at least one scale). Predictive validity for job performance is poor, and the instrument's own manual discourages using it to predict job success.
+* Widely regarded as pseudoscience by the scientific community (organizational psychologist Adam Grant: "there's no evidence behind it") — the four binary dichotomies impose discrete types on traits that are in fact continuous.
+
+[discrete]
+== *Current Status*:
+
+* Scientifically discredited yet commercially dominant — roughly 50 million people have taken it and thousands of businesses and colleges use it. Treat it as a starting point for self-reflection and dialogue, never as a diagnostic or selection tool; this is why the anchor carries an `:advisory:` flag. The empirically validated alternatives are the Big Five / OCEAN and HEXACO.
 ====

--- a/docs/anchors/myers-briggs-type-indicator.de.adoc
+++ b/docs/anchors/myers-briggs-type-indicator.de.adoc
@@ -3,6 +3,9 @@
 :roles: team-lead, consultant, educator, ux-designer, product-owner
 :proponents: Isabel Briggs Myers, Katharine Cook Briggs, Carl Gustav Jung
 :tags: personality types, MBTI, psychological types, communication styles, team dynamics, Jungian psychology
+:related: big-five, hexaco
+:tier: 1
+:advisory: Gilt weithin als Pseudowissenschaft mit geringer Test-Retest-Reliabilität — zur Reflexion und für den Dialog nutzen, nicht zur Auswahl (siehe Criticism)
 
 [%collapsible]
 ====
@@ -50,10 +53,13 @@ Historischer Kontext:: Während des Zweiten Weltkriegs entwickelt, um Frauen bei
 * "MBTI ist ein Ausgangspunkt für Selbstreflexion und Dialog" — Korrekte Nutzung ist explorativ, nicht diagnostisch
 
 [discrete]
-== *Einschränkungen und Kritik*:
+== *Criticism*:
 
-* Die Test-Retest-Reliabilität ist mäßig — dieselbe Person kann bei erneuter Durchführung einen anderen Typ erhalten
-* Binäre Dichotomien vereinfachen kontinuierliche Merkmalsverteilungen zu stark
-* Nicht empfohlen für Einstellungsentscheidungen oder Personalauswahl mit hohem Einsatz
-* Kritisiert wegen geringer prädiktiver Validität für Arbeitsleistung im Vergleich zu z.B. Big-Five-Persönlichkeitsmerkmalen
+* David J. Pittenger, via die https://en.wikipedia.org/wiki/Myers%E2%80%93Briggs_Type_Indicator[MBTI-Übersicht] — schlechte Test-Retest-Reliabilität: zwischen 39% und 76% der Befragten erhalten bei erneuter Durchführung nach nur fünf Wochen einen anderen Typ (etwa 50% ändern sich auf mindestens einer Skala). Die prädiktive Validität für Arbeitsleistung ist gering, und das eigene Manual rät davon ab, den Test zur Vorhersage von Berufserfolg zu nutzen.
+* Wird von der Fachgemeinschaft weithin als Pseudowissenschaft betrachtet (Organisationspsychologe Adam Grant: „there's no evidence behind it") — die vier binären Dichotomien zwingen kontinuierlichen Merkmalen diskrete Typen auf.
+
+[discrete]
+== *Current Status*:
+
+* Wissenschaftlich diskreditiert, aber kommerziell dominant — rund 50 Millionen Menschen haben ihn abgelegt, tausende Unternehmen und Hochschulen nutzen ihn. Als Ausgangspunkt für Selbstreflexion und Dialog behandeln, niemals als Diagnose- oder Auswahlinstrument; deshalb trägt der Anker ein `:advisory:`-Flag. Die empirisch validierten Alternativen sind die Big Five / OCEAN und HEXACO.
 ====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-06
 
+*MBTI held to the ADR-008 Utility Gate:*
+
+* Applying ADR-008 to the existing *link:#/anchor/myers-briggs-type-indicator[MBTI]* anchor, without grandfathering. MBTI *passes* the gate — naming it reliably imposes the 16-type / four-dichotomy structure on output, which is genuine output-structure change, not mere recognition — so it stays. But its criticism did not meet the #603 convention: it now carries a proper fetch-verified `== Criticism` section (Pittenger — 39–76% receive a different type on a five-week retest; widely regarded as pseudoscience) and a `== Current Status`, plus an `:advisory:` flag (#624) and `:related:` links to the empirically validated Big Five and HEXACO. The gate keeps its teeth: MBTI clears it on utility while being held to the same criticism standard as new anchors.
+
 *New anchor — HEXACO (#674):*
 
 * *link:#/anchor/hexaco[HEXACO]* (Kibeom Lee & Michael C. Ashton) — communication-presentation: the six-factor personality model — Big Five plus *Honesty-Humility*, the strongest trait predictor of unethical/exploitative behaviour and the Dark Triad. Admitted under ADR-008 because that sixth factor delivers distinct utility the Big Five cannot (the redundancy test, not a synonym). Tier ★★☆ (fires with the qualified form "assess along HEXACO, especially Honesty-Humility"), bilingual, with a fetch-verified Criticism section (De Raad et al. — the sixth factor does not always replicate cross-culturally) and a Current Status referencing the Big Five. Proposed by https://github.com/raifdmueller[@raifdmueller] in #674.


### PR DESCRIPTION
The honest lackmus test for ADR-008: apply the Utility Gate to the anchor already in the catalog, without grandfathering.

## Result: MBTI passes — and stays

Running the viability test, naming "MBTI" reliably imposes the 16-type / four-dichotomy structure on the output (before/after: generic work-style prose → INTJ-style typed frame). That is genuine output-structure change, **not** mere recognition, so MBTI clears the gate. ADR-008 separates *utility* from *scientific validity* — the weak validity is handled by the Criticism section, not by exclusion. The gate still has teeth (it would reject a recognition-only term); MBTI simply isn't one.

## What changed

Its criticism did not meet the #603 convention (an unlinked "Limitations" list, no Current Status). Now:
- Proper **`== Criticism`** with a fetch-verified source (Pittenger, via the MBTI overview): 39–76% get a different type on a five-week retest; poor predictive validity; widely regarded as pseudoscience.
- **`== Current Status`**: scientifically discredited yet commercially dominant; use for reflection, never selection.
- **`:advisory:`** flag (#624) — same treatment as the Eisenhower Matrix.
- **`:related:`** big-five, hexaco (the empirically validated alternatives).
- Added the missing `:tier: 1` to the DE file (parity).

EN + DE. Addresses the ADR-008 consequence I flagged for MBTI; relates to #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)