### PR TITLE
chore: backfill :tags: for 39 anchors (#668 Phase B)

### DIFF
--- a/docs/anchors/adr-according-to-nygard.adoc
+++ b/docs/anchors/adr-according-to-nygard.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Michael Nygard
+:tags: ADR, architecture decision record, Nygard, decision documentation, architecture decisions
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/adr-according-to-nygard.de.adoc
+++ b/docs/anchors/adr-according-to-nygard.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Michael Nygard
+:tags: ADR, architecture decision record, Nygard, decision documentation, architecture decisions
 
 [%collapsible]
 ====

--- a/docs/anchors/arc42.adoc
+++ b/docs/anchors/arc42.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
+:tags: arc42, architecture documentation, software architecture, documentation template, Starke, Hruschka
 :tier: 3
 :definition: arc42 is a template for documenting software architecture, created by Gernot Starke and Peter Hruschka. It organises an architecture into twelve standardised sections — from goals, constraints, and context through building blocks, runtime, and deployment to decisions, quality, and risks — so teams document consistently and completely.
 

--- a/docs/anchors/arc42.de.adoc
+++ b/docs/anchors/arc42.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
+:tags: arc42, architecture documentation, software architecture, documentation template, Starke, Hruschka
 
 [%collapsible]
 ====

--- a/docs/anchors/bem-methodology.adoc
+++ b/docs/anchors/bem-methodology.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, ux-designer
 :proponents: Yandex development team
+:tags: BEM, Block Element Modifier, CSS, SCSS, naming convention, frontend, stylesheets
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/bem-methodology.de.adoc
+++ b/docs/anchors/bem-methodology.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, ux-designer
 :proponents: Yandex Entwicklungsteam
+:tags: BEM, Block Element Modifier, CSS, SCSS, naming convention, frontend, stylesheets
 
 [%collapsible]
 ====

--- a/docs/anchors/bluf.adoc
+++ b/docs/anchors/bluf.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US Military (Army writing standards), adopted broadly in business and government
+:tags: BLUF, bottom line up front, concise communication, executive summary, clarity
 :tier: 3
 :definition: BLUF — Bottom Line Up Front — is a communication structure from US military practice: state the conclusion, decision, or key request in the very first sentence, then give the supporting detail. The reader gets the essential takeaway immediately instead of reading to the end to find it.
 

--- a/docs/anchors/bluf.de.adoc
+++ b/docs/anchors/bluf.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US-Militär (Army writing standards), weithin in Wirtschaft und Regierung übernommen
+:tags: BLUF, bottom line up front, concise communication, executive summary, clarity
 
 [%collapsible]
 ====

--- a/docs/anchors/c4-diagrams.adoc
+++ b/docs/anchors/c4-diagrams.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead, consultant
 :proponents: Simon Brown
+:tags: C4, C4 model, architecture diagrams, context container component code, Simon Brown, visualization
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/c4-diagrams.de.adoc
+++ b/docs/anchors/c4-diagrams.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead, consultant
 :proponents: Simon Brown
+:tags: C4, C4 model, architecture diagrams, context container component code, Simon Brown, visualization
 
 [%collapsible]
 ====

--- a/docs/anchors/chain-of-thought.adoc
+++ b/docs/anchors/chain-of-thought.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
+:tags: chain of thought, CoT, reasoning, step-by-step, prompting, LLM reasoning
 :tier: 3
 :definition: Chain of Thought (CoT) is a prompting technique for large language models that asks the model to reason step by step before stating a final answer. Making the intermediate steps explicit improves accuracy on multi-step arithmetic, logic, and reasoning tasks compared with answering directly.
 

--- a/docs/anchors/chain-of-thought.de.adoc
+++ b/docs/anchors/chain-of-thought.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
+:tags: chain of thought, CoT, reasoning, step-by-step, prompting, LLM reasoning
 
 [%collapsible]
 ====

--- a/docs/anchors/clean-architecture.adoc
+++ b/docs/anchors/clean-architecture.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
+:tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
 :tier: 3
 :definition: Clean Architecture, formulated by Robert C. Martin, organises code into concentric layers whose dependencies point only inward toward the domain. Business rules sit at the centre, independent of frameworks, UI, and databases at the outer edges. The Dependency Rule keeps the core testable and insulated from external change.
 

--- a/docs/anchors/clean-architecture.de.adoc
+++ b/docs/anchors/clean-architecture.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
+:tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
 
 [%collapsible]
 ====

--- a/docs/anchors/control-chart-shewhart.adoc
+++ b/docs/anchors/control-chart-shewhart.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead
 :proponents: Walter A. Shewhart
+:tags: control chart, Shewhart, SPC, statistical process control, quality, variation
 :tier: 3
 :parent-anchor: spc
 

--- a/docs/anchors/control-chart-shewhart.de.adoc
+++ b/docs/anchors/control-chart-shewhart.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead
 :proponents: Walter A. Shewhart
+:tags: control chart, Shewhart, SPC, statistical process control, quality, variation
 
 [%collapsible]
 ====

--- a/docs/anchors/conventional-commits.adoc
+++ b/docs/anchors/conventional-commits.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer
 :proponents: Benjamin E. Coe, James J. Womack, Steve Mao
+:tags: conventional commits, commit messages, semantic commits, changelog, git
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/conventional-commits.de.adoc
+++ b/docs/anchors/conventional-commits.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer
 :proponents: Benjamin E. Coe, James J. Womack, Steve Mao
+:tags: conventional commits, commit messages, semantic commits, changelog, git
 
 [%collapsible]
 ====

--- a/docs/anchors/devils-advocate.adoc
+++ b/docs/anchors/devils-advocate.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-architect, team-lead, consultant, qa-engineer
 :proponents: Roman Catholic Church (advocatus diaboli / Promotor Fidei)
+:tags: devil's advocate, dissent, critical thinking, challenge assumptions, red team
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/devils-advocate.de.adoc
+++ b/docs/anchors/devils-advocate.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-architect, team-lead, consultant, qa-engineer
 :proponents: Roman Catholic Church (advocatus diaboli / Promotor Fidei)
+:tags: devil's advocate, dissent, critical thinking, challenge assumptions, red team
 
 [%collapsible]
 ====

--- a/docs/anchors/diataxis-framework.adoc
+++ b/docs/anchors/diataxis-framework.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, educator
 :proponents: Daniele Procida
+:tags: Diataxis, documentation, tutorials, how-to, reference, explanation, Procida
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/diataxis-framework.de.adoc
+++ b/docs/anchors/diataxis-framework.de.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, educator
 :proponents: Daniele Procida
+:tags: Diataxis, documentation, tutorials, how-to, reference, explanation, Procida
 
 [%collapsible]
 ====

--- a/docs/anchors/docs-as-code.adoc
+++ b/docs/anchors/docs-as-code.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, software-developer, devops-engineer
 :proponents: Ralf D. Müller
+:tags: docs as code, documentation, AsciiDoc, version control, technical writing, Mueller
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/docs-as-code.de.adoc
+++ b/docs/anchors/docs-as-code.de.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, software-developer, devops-engineer
 :proponents: Ralf D. Müller
+:tags: docs as code, documentation, AsciiDoc, version control, technical writing, Mueller
 
 [%collapsible]
 ====

--- a/docs/anchors/domain-driven-design.adoc
+++ b/docs/anchors/domain-driven-design.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
+:tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
 :tier: 3
 :definition: Domain-Driven Design, introduced by Eric Evans, tackles complex software by centring the design on the business domain. A shared Ubiquitous Language unites developers and domain experts, Bounded Contexts delimit models, and tactical patterns — entities, value objects, aggregates, repositories — express the domain directly in code.
 

--- a/docs/anchors/domain-driven-design.de.adoc
+++ b/docs/anchors/domain-driven-design.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
+:tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
 
 [%collapsible]
 ====

--- a/docs/anchors/ears-requirements.adoc
+++ b/docs/anchors/ears-requirements.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: business-analyst, qa-engineer, technical-writer
 :proponents: Alistair Mavin
+:tags: EARS, requirements syntax, requirements engineering, Mavin, easy approach to requirements syntax
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/ears-requirements.de.adoc
+++ b/docs/anchors/ears-requirements.de.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: business-analyst, qa-engineer, technical-writer
 :proponents: Alistair Mavin
+:tags: EARS, requirements syntax, requirements engineering, Mavin, easy approach to requirements syntax
 
 [%collapsible]
 ====

--- a/docs/anchors/feynman-technique.adoc
+++ b/docs/anchors/feynman-technique.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, educator, consultant, team-lead
 :proponents: Richard Feynman
+:tags: Feynman technique, learning, teaching, explain simply, understanding
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/feynman-technique.de.adoc
+++ b/docs/anchors/feynman-technique.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, educator, consultant, team-lead
 :proponents: Richard Feynman
+:tags: Feynman technique, learning, teaching, explain simply, understanding
 
 [%collapsible]
 ====

--- a/docs/anchors/five-whys.adoc
+++ b/docs/anchors/five-whys.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, qa-engineer, devops-engineer, team-lead
 :proponents: Sakichi Toyoda, Taiichi Ohno (Toyota)
+:tags: five whys, root cause analysis, Toyota, Ohno, lean, problem solving
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/five-whys.de.adoc
+++ b/docs/anchors/five-whys.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, qa-engineer, devops-engineer, team-lead
 :proponents: Sakichi Toyoda, Taiichi Ohno (Toyota)
+:tags: five whys, root cause analysis, Toyota, Ohno, lean, problem solving
 
 [%collapsible]
 ====

--- a/docs/anchors/hexagonal-architecture.adoc
+++ b/docs/anchors/hexagonal-architecture.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
+:tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/hexagonal-architecture.de.adoc
+++ b/docs/anchors/hexagonal-architecture.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
+:tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
 
 [%collapsible]
 ====

--- a/docs/anchors/impact-mapping.adoc
+++ b/docs/anchors/impact-mapping.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, business-analyst, team-lead, consultant
 :proponents: Gojko Adzic
+:tags: impact mapping, Gojko Adzic, strategic planning, goals, deliverables, product
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/impact-mapping.de.adoc
+++ b/docs/anchors/impact-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, business-analyst, team-lead, consultant
 :proponents: Gojko Adzic
+:tags: impact mapping, Gojko Adzic, strategic planning, goals, deliverables, product
 
 [%collapsible]
 ====

--- a/docs/anchors/jobs-to-be-done.adoc
+++ b/docs/anchors/jobs-to-be-done.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, ux-designer, business-analyst
 :proponents: Clayton Christensen, Alan Klement, Bob Moesta
+:tags: jobs to be done, JTBD, Christensen, customer needs, product, innovation
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/jobs-to-be-done.de.adoc
+++ b/docs/anchors/jobs-to-be-done.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, ux-designer, business-analyst
 :proponents: Clayton Christensen, Alan Klement, Bob Moesta
+:tags: jobs to be done, JTBD, Christensen, customer needs, product, innovation
 
 [%collapsible]
 ====

--- a/docs/anchors/madr.adoc
+++ b/docs/anchors/madr.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Oliver Kopp, Olaf Zimmermann (and MADR community)
+:tags: MADR, markdown ADR, architecture decision record, decision documentation
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/madr.de.adoc
+++ b/docs/anchors/madr.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Oliver Kopp, Olaf Zimmermann (and MADR community)
+:tags: MADR, markdown ADR, architecture decision record, decision documentation
 
 [%collapsible]
 ====

--- a/docs/anchors/mece.adoc
+++ b/docs/anchors/mece.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, software-architect, data-scientist
 :proponents: Barbara Minto
+:tags: MECE, mutually exclusive collectively exhaustive, Barbara Minto, structuring, McKinsey
 :tier: 3
 :definition: MECE — Mutually Exclusive, Collectively Exhaustive — is a grouping principle from Barbara Minto’s Pyramid Principle: split a topic into categories that do not overlap and together cover everything. It yields clean, gap-free, duplication-free structures for analysis, communication, and problem decomposition.
 

--- a/docs/anchors/mece.de.adoc
+++ b/docs/anchors/mece.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, software-architect, data-scientist
 :proponents: Barbara Minto
+:tags: MECE, mutually exclusive collectively exhaustive, Barbara Minto, structuring, McKinsey
 
 [%collapsible]
 ====

--- a/docs/anchors/mental-model-according-to-naur.adoc
+++ b/docs/anchors/mental-model-according-to-naur.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, team-lead, educator, consultant
 :related: adr-according-to-nygard, docs-as-code
 :proponents: Peter Naur
+:tags: theory building, Naur, programming as theory building, mental model, tacit knowledge, software maintenance
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/mental-model-according-to-naur.de.adoc
+++ b/docs/anchors/mental-model-according-to-naur.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, team-lead, educator, consultant
 :proponents: Peter Naur
+:tags: theory building, Naur, programming as theory building, mental model, tacit knowledge, software maintenance
 
 [%collapsible]
 ====

--- a/docs/anchors/mutation-testing.adoc
+++ b/docs/anchors/mutation-testing.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Richard Lipton (theoretical foundation, 1971), Richard DeMillo, Timothy Budd
+:tags: mutation testing, test quality, fault injection, test effectiveness, coverage
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/mutation-testing.de.adoc
+++ b/docs/anchors/mutation-testing.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Richard Lipton (theoretical foundation, 1971), Richard DeMillo, Timothy Budd
+:tags: mutation testing, test quality, fault injection, test effectiveness, coverage
 
 [%collapsible]
 ====

--- a/docs/anchors/nelson-rules.adoc
+++ b/docs/anchors/nelson-rules.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer
 :proponents: Lloyd S. Nelson
+:tags: Nelson rules, control chart, SPC, statistical process control, out of control
 :tier: 3
 :parent-anchor: spc
 

--- a/docs/anchors/nelson-rules.de.adoc
+++ b/docs/anchors/nelson-rules.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer
 :proponents: Lloyd S. Nelson
+:tags: Nelson rules, control chart, SPC, statistical process control, out of control
 
 [%collapsible]
 ====

--- a/docs/anchors/property-based-testing.adoc
+++ b/docs/anchors/property-based-testing.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Koen Claessen, John Hughes (QuickCheck)
+:tags: property-based testing, QuickCheck, invariants, generative testing, Hypothesis
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/property-based-testing.de.adoc
+++ b/docs/anchors/property-based-testing.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Koen Claessen, John Hughes (QuickCheck)
+:tags: property-based testing, QuickCheck, invariants, generative testing, Hypothesis
 
 [%collapsible]
 ====

--- a/docs/anchors/pugh-matrix.adoc
+++ b/docs/anchors/pugh-matrix.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: software-architect, team-lead, product-owner
 :proponents: Stuart Pugh
+:tags: Pugh matrix, decision matrix, Stuart Pugh, trade-off analysis, weighted criteria
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/pugh-matrix.de.adoc
+++ b/docs/anchors/pugh-matrix.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: software-architect, team-lead, product-owner
 :proponents: Stuart Pugh
+:tags: Pugh matrix, decision matrix, Stuart Pugh, trade-off analysis, weighted criteria
 
 [%collapsible]
 ====

--- a/docs/anchors/pyramid-principle.adoc
+++ b/docs/anchors/pyramid-principle.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, team-lead, technical-writer
 :proponents: Barbara Minto
+:tags: pyramid principle, Barbara Minto, structured communication, top-down, writing
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/pyramid-principle.de.adoc
+++ b/docs/anchors/pyramid-principle.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, team-lead, technical-writer
 :proponents: Barbara Minto
+:tags: pyramid principle, Barbara Minto, structured communication, top-down, writing
 
 [%collapsible]
 ====

--- a/docs/anchors/semantic-versioning.adoc
+++ b/docs/anchors/semantic-versioning.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer, product-owner
 :proponents: Tom Preston-Werner
+:tags: semantic versioning, SemVer, versioning, major minor patch, Tom Preston-Werner
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/semantic-versioning.de.adoc
+++ b/docs/anchors/semantic-versioning.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer, product-owner
 :proponents: Tom Preston-Werner
+:tags: semantic versioning, SemVer, versioning, major minor patch, Tom Preston-Werner
 
 [%collapsible]
 ====

--- a/docs/anchors/socratic-method.adoc
+++ b/docs/anchors/socratic-method.adoc
@@ -2,6 +2,7 @@
 :categories: dialogue-interaction
 :roles: educator, consultant, team-lead
 :proponents: Socrates, Plato
+:tags: Socratic method, questioning, dialogue, Socrates, critical thinking, inquiry
 :tier: 3
 :definition: The Socratic Method is a form of cooperative inquiry, attributed to Socrates, that advances understanding through disciplined questioning rather than assertion. By probing assumptions, definitions, and consequences, it surfaces contradictions and gaps, helping participants refine their own reasoning instead of being handed the answer.
 

--- a/docs/anchors/socratic-method.de.adoc
+++ b/docs/anchors/socratic-method.de.adoc
@@ -2,6 +2,7 @@
 :categories: dialogue-interaction
 :roles: educator, consultant, team-lead
 :proponents: Socrates, Plato
+:tags: Socratic method, questioning, dialogue, Socrates, critical thinking, inquiry
 
 [%collapsible]
 ====

--- a/docs/anchors/sota.adoc
+++ b/docs/anchors/sota.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, data-scientist, consultant
 :proponents: Community
+:tags: SOTA, state of the art, benchmark, current best, research
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/sota.de.adoc
+++ b/docs/anchors/sota.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, data-scientist, consultant
 :proponents: Community
+:tags: SOTA, state of the art, benchmark, current best, research
 
 [%collapsible]
 ====

--- a/docs/anchors/spc.adoc
+++ b/docs/anchors/spc.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead, qa-engineer
 :proponents: Walter A. Shewhart (founder), W. Edwards Deming (dissemination), Western Electric Company
+:tags: SPC, statistical process control, control charts, Shewhart, quality, variation
 :tier: 3
 :sub-anchors: control-chart-shewhart, nelson-rules
 

--- a/docs/anchors/spc.de.adoc
+++ b/docs/anchors/spc.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead, qa-engineer
 :proponents: Walter A. Shewhart (founder), W. Edwards Deming (dissemination), Western Electric Company
+:tags: SPC, statistical process control, control charts, Shewhart, quality, variation
 
 [%collapsible]
 ====

--- a/docs/anchors/ssot-principle.adoc
+++ b/docs/anchors/ssot-principle.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-architect, data-scientist, business-analyst
 :proponents: Community
+:tags: SSOT, single source of truth, data consistency, canonical source, DRY
 :tier: 1
 
 [%collapsible]

--- a/docs/anchors/ssot-principle.de.adoc
+++ b/docs/anchors/ssot-principle.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-architect, data-scientist, business-analyst
 :proponents: Community
+:tags: SSOT, single source of truth, data consistency, canonical source, DRY
 
 [%collapsible]
 ====

--- a/docs/anchors/tdd-london-school.adoc
+++ b/docs/anchors/tdd-london-school.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
+:tags: TDD, London school, mockist, outside-in, Freeman, Pryce, interaction testing, mocks
 :tier: 3
 :definition: TDD London School — also called mockist or outside-in TDD (Steve Freeman and Nat Pryce) — drives design from the outside in: start at the system boundary, mock collaborators to specify their interactions, and let the required interfaces emerge. It emphasises object roles and message-passing over verifying state.
 

--- a/docs/anchors/tdd-london-school.de.adoc
+++ b/docs/anchors/tdd-london-school.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
+:tags: TDD, London school, mockist, outside-in, Freeman, Pryce, interaction testing, mocks
 
 [%collapsible]
 ====

--- a/docs/anchors/testing-pyramid.adoc
+++ b/docs/anchors/testing-pyramid.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, team-lead, devops-engineer
 :proponents: Mike Cohn
+:tags: testing pyramid, unit tests, integration tests, e2e, test strategy, Mike Cohn
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/testing-pyramid.de.adoc
+++ b/docs/anchors/testing-pyramid.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, team-lead, devops-engineer
 :proponents: Mike Cohn
+:tags: testing pyramid, unit tests, integration tests, e2e, test strategy, Mike Cohn
 
 [%collapsible]
 ====

--- a/docs/anchors/timtowtdi.adoc
+++ b/docs/anchors/timtowtdi.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Larry Wall
+:tags: TIMTOWTDI, there is more than one way to do it, Perl, Larry Wall, flexibility
 :tier: 1
 
 [%collapsible]

--- a/docs/anchors/timtowtdi.de.adoc
+++ b/docs/anchors/timtowtdi.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Larry Wall
+:tags: TIMTOWTDI, there is more than one way to do it, Perl, Larry Wall, flexibility
 
 [%collapsible]
 ====

--- a/docs/anchors/todotxt-flavoured-markdown.adoc
+++ b/docs/anchors/todotxt-flavoured-markdown.adoc
@@ -2,6 +2,7 @@
 :categories: knowledge-management
 :roles: software-developer, team-lead, technical-writer
 :proponents: Combines GitHub-flavoured Markdown task lists with Gina Trapani's todo.txt format
+:tags: todo.txt, task management, markdown, Gina Trapani, plain text, task lists
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/todotxt-flavoured-markdown.de.adoc
+++ b/docs/anchors/todotxt-flavoured-markdown.de.adoc
@@ -2,6 +2,7 @@
 :categories: knowledge-management
 :roles: software-developer, team-lead, technical-writer
 :proponents: Combines GitHub-flavoured Markdown task lists with Gina Trapani's todo.txt format
+:tags: todo.txt, task management, markdown, Gina Trapani, plain text, task lists
 
 [%collapsible]
 ====

--- a/docs/anchors/user-story-mapping.adoc
+++ b/docs/anchors/user-story-mapping.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: product-owner, business-analyst, team-lead, ux-designer
 :proponents: Jeff Patton
+:tags: user story mapping, Jeff Patton, backlog, product, user journey, stories
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/user-story-mapping.de.adoc
+++ b/docs/anchors/user-story-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: product-owner, business-analyst, team-lead, ux-designer
 :proponents: Jeff Patton
+:tags: user story mapping, Jeff Patton, backlog, product, user journey, stories
 
 [%collapsible]
 ====

--- a/docs/anchors/wardley-mapping.adoc
+++ b/docs/anchors/wardley-mapping.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, software-architect, consultant, team-lead
 :proponents: Simon Wardley
+:tags: Wardley mapping, value chain, strategy, evolution, Simon Wardley
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/wardley-mapping.de.adoc
+++ b/docs/anchors/wardley-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, software-architect, consultant, team-lead
 :proponents: Simon Wardley
+:tags: Wardley mapping, value chain, strategy, evolution, Simon Wardley
 
 [%collapsible]
 ====

--- a/docs/anchors/what-qualifies-as-a-semantic-anchor.adoc
+++ b/docs/anchors/what-qualifies-as-a-semantic-anchor.adoc
@@ -2,6 +2,7 @@
 :categories: meta
 :roles: educator, consultant
 :proponents: Ralf D. Müller (Semantic Anchors project)
+:tags: semantic anchor, meta, criteria, quality, anchor definition, activation
 :tier: 3
 
 === What Qualifies as a Semantic Anchor

--- a/docs/anchors/what-qualifies-as-a-semantic-anchor.de.adoc
+++ b/docs/anchors/what-qualifies-as-a-semantic-anchor.de.adoc
@@ -2,6 +2,7 @@
 :categories: meta
 :roles: educator, consultant
 :proponents: Ralf D. Müller (Semantic Anchors project)
+:tags: semantic anchor, meta, criteria, quality, anchor definition, activation
 
 === Was qualifiziert als semantischer Anker
 

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-07
 
+*Metadata audit — `:tags:` backfill (#668, Phase B):*
+
+* Completes `:tags:` for the whole catalog — 100% of anchors now carry search keywords. Added tags to 39 anchors that lacked them (EN + DE), derived from each concept's name, aliases, key sub-concepts and proponents (e.g. `arc42` → arc42, architecture documentation, Starke, Hruschka). Follows the Phase A `:proponents:` backfill; Phase C (`:related:`) is the remaining follow-up.
+
 *New anchor — DISC (#671), the last of the personality cluster:*
 
 * *link:#/anchor/disc-model[DISC Model]* (William Moulton Marston, 1928) — communication-presentation: four behavioural styles (Dominance, Influence, Steadiness, Conscientiousness) as a lightweight communication-style shorthand. Like MBTI, DISC *passes* the ADR-008 Utility Gate — naming it reliably imposes the four-quadrant frame on output — so it is admitted, at tier ★☆☆ with an `:advisory:` flag (#624) and a fetch-verified Criticism section (classified as pseudoscience; no demonstrated predictive validity; the apparent accuracy is partly the Barnum effect; DISC data are better explained as Big Five combinations). Bilingual, cross-linked with MBTI, Big Five, and HEXACO. Proposed by https://github.com/rdmueller[@rdmueller] in #671. This completes the personality-model cluster under ADR-008.


### PR DESCRIPTION
Phase B of #668. `:tags:` (recommended search metadata) was missing on 39 anchors.

## What
- Added `:tags:` to **39 anchors, EN + DE** (78 files), derived from each concept's name, aliases, key sub-concepts, and proponents — e.g. `arc42` → *arc42, architecture documentation, software architecture, Starke, Hruschka*; `domain-driven-design` → *DDD, bounded context, ubiquitous language, aggregates, Eric Evans*.
- The catalog now has **100% `:tags:` coverage** (188/188).
- Same tag set mirrored EN↔DE (English keywords serve search in both), consistent with existing anchors like MBTI and tdd-chicago-school.

## Not included
- Generated `public/data/*.json` (regenerated by the build).
- **Phase C** (`:related:`, ~148 files) — the remaining follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)