### PR TITLE
chore: backfill curated :related: for 70 anchors (#668 Phase C — audit complete)

### DIFF
--- a/docs/anchors/adr-according-to-nygard.adoc
+++ b/docs/anchors/adr-according-to-nygard.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :proponents: Michael Nygard
 :tags: ADR, architecture decision record, Nygard, decision documentation, architecture decisions
+:related: madr, arc42, c4-diagrams
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/adr-according-to-nygard.de.adoc
+++ b/docs/anchors/adr-according-to-nygard.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :proponents: Michael Nygard
 :tags: ADR, architecture decision record, Nygard, decision documentation, architecture decisions
+:related: madr, arc42, c4-diagrams
 
 [%collapsible]
 ====

--- a/docs/anchors/arc42.adoc
+++ b/docs/anchors/arc42.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
 :tags: arc42, architecture documentation, software architecture, documentation template, Starke, Hruschka
+:related: c4-diagrams, adr-according-to-nygard, quality-attribute-scenario
 :tier: 3
 :definition: arc42 is a template for documenting software architecture, created by Gernot Starke and Peter Hruschka. It organises an architecture into twelve standardised sections — from goals, constraints, and context through building blocks, runtime, and deployment to decisions, quality, and risks — so teams document consistently and completely.
 

--- a/docs/anchors/arc42.de.adoc
+++ b/docs/anchors/arc42.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
 :tags: arc42, architecture documentation, software architecture, documentation template, Starke, Hruschka
+:related: c4-diagrams, adr-according-to-nygard, quality-attribute-scenario
 
 [%collapsible]
 ====

--- a/docs/anchors/bem-methodology.adoc
+++ b/docs/anchors/bem-methodology.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, ux-designer
 :proponents: Yandex development team
 :tags: BEM, Block Element Modifier, CSS, SCSS, naming convention, frontend, stylesheets
+:related: separation-of-concerns, kiss-principle, unix-philosophy
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/bem-methodology.de.adoc
+++ b/docs/anchors/bem-methodology.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, ux-designer
 :proponents: Yandex Entwicklungsteam
 :tags: BEM, Block Element Modifier, CSS, SCSS, naming convention, frontend, stylesheets
+:related: separation-of-concerns, kiss-principle, unix-philosophy
 
 [%collapsible]
 ====

--- a/docs/anchors/big-five.adoc
+++ b/docs/anchors/big-five.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
 :proponents: Lewis R. Goldberg, Paul T. Costa, Robert R. McCrae
 :tags: personality traits, Big Five, OCEAN, Five-Factor Model, FFM, trait psychology, team dynamics
+:related: myers-briggs-type-indicator, hexaco, disc-model
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/big-five.de.adoc
+++ b/docs/anchors/big-five.de.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
 :proponents: Lewis R. Goldberg, Paul T. Costa, Robert R. McCrae
 :tags: Persönlichkeitsmerkmale, Big Five, OCEAN, Fünf-Faktoren-Modell, FFM, Trait-Psychologie, Teamdynamik
+:related: myers-briggs-type-indicator, hexaco, disc-model
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/bluf.adoc
+++ b/docs/anchors/bluf.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US Military (Army writing standards), adopted broadly in business and government
 :tags: BLUF, bottom line up front, concise communication, executive summary, clarity
+:related: pyramid-principle, mece, inverted-pyramid-style, plain-english-strunk-white
 :tier: 3
 :definition: BLUF — Bottom Line Up Front — is a communication structure from US military practice: state the conclusion, decision, or key request in the very first sentence, then give the supporting detail. The reader gets the essential takeaway immediately instead of reading to the end to find it.
 

--- a/docs/anchors/bluf.de.adoc
+++ b/docs/anchors/bluf.de.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US-Militär (Army writing standards), weithin in Wirtschaft und Regierung übernommen
 :tags: BLUF, bottom line up front, concise communication, executive summary, clarity
+:related: pyramid-principle, mece, inverted-pyramid-style, plain-english-strunk-white
 
 [%collapsible]
 ====

--- a/docs/anchors/c4-diagrams.adoc
+++ b/docs/anchors/c4-diagrams.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, technical-writer, team-lead, consultant
 :proponents: Simon Brown
 :tags: C4, C4 model, architecture diagrams, context container component code, Simon Brown, visualization
+:related: arc42, adr-according-to-nygard, domain-driven-design
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/c4-diagrams.de.adoc
+++ b/docs/anchors/c4-diagrams.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, technical-writer, team-lead, consultant
 :proponents: Simon Brown
 :tags: C4, C4 model, architecture diagrams, context container component code, Simon Brown, visualization
+:related: arc42, adr-according-to-nygard, domain-driven-design
 
 [%collapsible]
 ====

--- a/docs/anchors/chain-of-thought.adoc
+++ b/docs/anchors/chain-of-thought.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
 :tags: chain of thought, CoT, reasoning, step-by-step, prompting, LLM reasoning
+:related: first-principles-thinking, feynman-technique, fermi-estimation
 :tier: 3
 :definition: Chain of Thought (CoT) is a prompting technique for large language models that asks the model to reason step by step before stating a final answer. Making the intermediate steps explicit improves accuracy on multi-step arithmetic, logic, and reasoning tasks compared with answering directly.
 

--- a/docs/anchors/chain-of-thought.de.adoc
+++ b/docs/anchors/chain-of-thought.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
 :tags: chain of thought, CoT, reasoning, step-by-step, prompting, LLM reasoning
+:related: first-principles-thinking, feynman-technique, fermi-estimation
 
 [%collapsible]
 ====

--- a/docs/anchors/clean-architecture.adoc
+++ b/docs/anchors/clean-architecture.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
 :tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
+:related: hexagonal-architecture, domain-driven-design, solid-principles
 :tier: 3
 :definition: Clean Architecture, formulated by Robert C. Martin, organises code into concentric layers whose dependencies point only inward toward the domain. Business rules sit at the centre, independent of frameworks, UI, and databases at the outer edges. The Dependency Rule keeps the core testable and insulated from external change.
 

--- a/docs/anchors/clean-architecture.de.adoc
+++ b/docs/anchors/clean-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
 :tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
+:related: hexagonal-architecture, domain-driven-design, solid-principles
 
 [%collapsible]
 ====

--- a/docs/anchors/control-chart-shewhart.adoc
+++ b/docs/anchors/control-chart-shewhart.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer, team-lead
 :proponents: Walter A. Shewhart
 :tags: control chart, Shewhart, SPC, statistical process control, quality, variation
+:related: spc, nelson-rules
 :tier: 3
 :parent-anchor: spc
 

--- a/docs/anchors/control-chart-shewhart.de.adoc
+++ b/docs/anchors/control-chart-shewhart.de.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer, team-lead
 :proponents: Walter A. Shewhart
 :tags: control chart, Shewhart, SPC, statistical process control, quality, variation
+:related: spc, nelson-rules
 
 [%collapsible]
 ====

--- a/docs/anchors/conventional-commits.adoc
+++ b/docs/anchors/conventional-commits.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, devops-engineer
 :proponents: Benjamin E. Coe, James J. Womack, Steve Mao
 :tags: conventional commits, commit messages, semantic commits, changelog, git
+:related: semantic-versioning, github-flow, definition-of-done
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/conventional-commits.de.adoc
+++ b/docs/anchors/conventional-commits.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, devops-engineer
 :proponents: Benjamin E. Coe, James J. Womack, Steve Mao
 :tags: conventional commits, commit messages, semantic commits, changelog, git
+:related: semantic-versioning, github-flow, definition-of-done
 
 [%collapsible]
 ====

--- a/docs/anchors/devils-advocate.adoc
+++ b/docs/anchors/devils-advocate.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, team-lead, consultant, qa-engineer
 :proponents: Roman Catholic Church (advocatus diaboli / Promotor Fidei)
 :tags: devil's advocate, dissent, critical thinking, challenge assumptions, red team
+:related: socratic-method, five-whys, consent-vs-consensus
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/devils-advocate.de.adoc
+++ b/docs/anchors/devils-advocate.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, team-lead, consultant, qa-engineer
 :proponents: Roman Catholic Church (advocatus diaboli / Promotor Fidei)
 :tags: devil's advocate, dissent, critical thinking, challenge assumptions, red team
+:related: socratic-method, five-whys, consent-vs-consensus
 
 [%collapsible]
 ====

--- a/docs/anchors/diataxis-framework.adoc
+++ b/docs/anchors/diataxis-framework.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, educator
 :proponents: Daniele Procida
 :tags: Diataxis, documentation, tutorials, how-to, reference, explanation, Procida
+:related: docs-as-code, arc42, inverted-pyramid-style
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/diataxis-framework.de.adoc
+++ b/docs/anchors/diataxis-framework.de.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, educator
 :proponents: Daniele Procida
 :tags: Diataxis, documentation, tutorials, how-to, reference, explanation, Procida
+:related: docs-as-code, arc42, inverted-pyramid-style
 
 [%collapsible]
 ====

--- a/docs/anchors/docs-as-code.adoc
+++ b/docs/anchors/docs-as-code.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, software-developer, devops-engineer
 :proponents: Ralf D. Müller
 :tags: docs as code, documentation, AsciiDoc, version control, technical writing, Mueller
+:related: diataxis-framework, arc42, conventional-commits
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/docs-as-code.de.adoc
+++ b/docs/anchors/docs-as-code.de.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, software-developer, devops-engineer
 :proponents: Ralf D. Müller
 :tags: docs as code, documentation, AsciiDoc, version control, technical writing, Mueller
+:related: diataxis-framework, arc42, conventional-commits
 
 [%collapsible]
 ====

--- a/docs/anchors/domain-driven-design.adoc
+++ b/docs/anchors/domain-driven-design.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
 :tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
+:related: hexagonal-architecture, clean-architecture, event-storming
 :tier: 3
 :definition: Domain-Driven Design, introduced by Eric Evans, tackles complex software by centring the design on the business domain. A shared Ubiquitous Language unites developers and domain experts, Bounded Contexts delimit models, and tactical patterns — entities, value objects, aggregates, repositories — express the domain directly in code.
 

--- a/docs/anchors/domain-driven-design.de.adoc
+++ b/docs/anchors/domain-driven-design.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
 :tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
+:related: hexagonal-architecture, clean-architecture, event-storming
 
 [%collapsible]
 ====

--- a/docs/anchors/ears-requirements.adoc
+++ b/docs/anchors/ears-requirements.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, qa-engineer, technical-writer
 :proponents: Alistair Mavin
 :tags: EARS, requirements syntax, requirements engineering, Mavin, easy approach to requirements syntax
+:related: cockburn-use-cases, invest, req42
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/ears-requirements.de.adoc
+++ b/docs/anchors/ears-requirements.de.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, qa-engineer, technical-writer
 :proponents: Alistair Mavin
 :tags: EARS, requirements syntax, requirements engineering, Mavin, easy approach to requirements syntax
+:related: cockburn-use-cases, invest, req42
 
 [%collapsible]
 ====

--- a/docs/anchors/feynman-technique.adoc
+++ b/docs/anchors/feynman-technique.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, educator, consultant, team-lead
 :proponents: Richard Feynman
 :tags: Feynman technique, learning, teaching, explain simply, understanding
+:related: blooms-taxonomy, curse-of-knowledge, zone-of-proximal-development
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/feynman-technique.de.adoc
+++ b/docs/anchors/feynman-technique.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, educator, consultant, team-lead
 :proponents: Richard Feynman
 :tags: Feynman technique, learning, teaching, explain simply, understanding
+:related: blooms-taxonomy, curse-of-knowledge, zone-of-proximal-development
 
 [%collapsible]
 ====

--- a/docs/anchors/five-whys.adoc
+++ b/docs/anchors/five-whys.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, devops-engineer, team-lead
 :proponents: Sakichi Toyoda, Taiichi Ohno (Toyota)
 :tags: five whys, root cause analysis, Toyota, Ohno, lean, problem solving
+:related: socratic-method, xy-problem, first-principles-thinking
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/five-whys.de.adoc
+++ b/docs/anchors/five-whys.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, devops-engineer, team-lead
 :proponents: Sakichi Toyoda, Taiichi Ohno (Toyota)
 :tags: five whys, root cause analysis, Toyota, Ohno, lean, problem solving
+:related: socratic-method, xy-problem, first-principles-thinking
 
 [%collapsible]
 ====

--- a/docs/anchors/four-sides-model.adoc
+++ b/docs/anchors/four-sides-model.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator
 :proponents: Friedemann Schulz von Thun
 :tags: communication, psychology, message, misunderstanding, interpersonal
+:related: sender-receiver-discrepancy, curse-of-knowledge, problem-space-nvc
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/four-sides-model.de.adoc
+++ b/docs/anchors/four-sides-model.de.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator
 :proponents: Friedemann Schulz von Thun
 :tags: communication, psychology, message, misunderstanding, interpersonal
+:related: sender-receiver-discrepancy, curse-of-knowledge, problem-space-nvc
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/gof-abstract-factory-pattern.adoc
+++ b/docs/anchors/gof-abstract-factory-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, abstract factory, family, platform independence
+:related: gof-design-patterns, gof-factory-method-pattern, gof-builder-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-abstract-factory-pattern.de.adoc
+++ b/docs/anchors/gof-abstract-factory-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, abstract factory, family, platform independence
+:related: gof-design-patterns, gof-factory-method-pattern, gof-builder-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-adapter-pattern.adoc
+++ b/docs/anchors/gof-adapter-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, adapter, wrapper, interface conversion, compatibility
+:related: gof-design-patterns, gof-facade-pattern, gof-bridge-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-adapter-pattern.de.adoc
+++ b/docs/anchors/gof-adapter-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, adapter, wrapper, interface conversion, compatibility
+:related: gof-design-patterns, gof-facade-pattern, gof-bridge-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-bridge-pattern.adoc
+++ b/docs/anchors/gof-bridge-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, bridge, abstraction, implementation, decoupling
+:related: gof-design-patterns, gof-adapter-pattern, gof-strategy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-bridge-pattern.de.adoc
+++ b/docs/anchors/gof-bridge-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, bridge, abstraction, implementation, decoupling
+:related: gof-design-patterns, gof-adapter-pattern, gof-strategy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-builder-pattern.adoc
+++ b/docs/anchors/gof-builder-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, builder, construction, fluent interface, complex objects
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-factory-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-builder-pattern.de.adoc
+++ b/docs/anchors/gof-builder-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, builder, construction, fluent interface, complex objects
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-factory-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-chain-of-responsibility-pattern.adoc
+++ b/docs/anchors/gof-chain-of-responsibility-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, chain of responsibility, handler, pipeline, middleware
+:related: gof-design-patterns, gof-command-pattern, gof-mediator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-chain-of-responsibility-pattern.de.adoc
+++ b/docs/anchors/gof-chain-of-responsibility-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, chain of responsibility, handler, pipeline, middleware
+:related: gof-design-patterns, gof-command-pattern, gof-mediator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-command-pattern.adoc
+++ b/docs/anchors/gof-command-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, command, undo, queue, encapsulation, action
+:related: gof-design-patterns, gof-chain-of-responsibility-pattern, gof-memento-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-command-pattern.de.adoc
+++ b/docs/anchors/gof-command-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, command, undo, queue, encapsulation, action
+:related: gof-design-patterns, gof-chain-of-responsibility-pattern, gof-memento-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-composite-pattern.adoc
+++ b/docs/anchors/gof-composite-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, composite, tree, hierarchy, part-whole
+:related: gof-design-patterns, gof-decorator-pattern, gof-iterator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-composite-pattern.de.adoc
+++ b/docs/anchors/gof-composite-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, composite, tree, hierarchy, part-whole
+:related: gof-design-patterns, gof-decorator-pattern, gof-iterator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-decorator-pattern.adoc
+++ b/docs/anchors/gof-decorator-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, decorator, wrapper, dynamic behavior, composition
+:related: gof-design-patterns, gof-composite-pattern, gof-proxy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-decorator-pattern.de.adoc
+++ b/docs/anchors/gof-decorator-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, decorator, wrapper, dynamic behavior, composition
+:related: gof-design-patterns, gof-composite-pattern, gof-proxy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-facade-pattern.adoc
+++ b/docs/anchors/gof-facade-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, facade, simplification, subsystem, unified interface
+:related: gof-design-patterns, gof-adapter-pattern, gof-mediator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-facade-pattern.de.adoc
+++ b/docs/anchors/gof-facade-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, facade, simplification, subsystem, unified interface
+:related: gof-design-patterns, gof-adapter-pattern, gof-mediator-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-factory-method-pattern.adoc
+++ b/docs/anchors/gof-factory-method-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, factory, polymorphism, instantiation
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-template-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-factory-method-pattern.de.adoc
+++ b/docs/anchors/gof-factory-method-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, factory, polymorphism, instantiation
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-template-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-flyweight-pattern.adoc
+++ b/docs/anchors/gof-flyweight-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, flyweight, memory optimization, sharing
+:related: gof-design-patterns, gof-proxy-pattern, gof-composite-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-flyweight-pattern.de.adoc
+++ b/docs/anchors/gof-flyweight-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, flyweight, memory optimization, sharing
+:related: gof-design-patterns, gof-proxy-pattern, gof-composite-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-interpreter-pattern.adoc
+++ b/docs/anchors/gof-interpreter-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, interpreter, grammar, DSL, parsing
+:related: gof-design-patterns, gof-visitor-pattern, gof-composite-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-interpreter-pattern.de.adoc
+++ b/docs/anchors/gof-interpreter-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, interpreter, grammar, DSL, parsing
+:related: gof-design-patterns, gof-visitor-pattern, gof-composite-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-iterator-pattern.adoc
+++ b/docs/anchors/gof-iterator-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, iterator, traversal, collection, aggregate
+:related: gof-design-patterns, gof-composite-pattern, gof-visitor-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-iterator-pattern.de.adoc
+++ b/docs/anchors/gof-iterator-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, iterator, traversal, collection, aggregate
+:related: gof-design-patterns, gof-composite-pattern, gof-visitor-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-mediator-pattern.adoc
+++ b/docs/anchors/gof-mediator-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, mediator, loose coupling, coordination, hub
+:related: gof-design-patterns, gof-observer-pattern, gof-facade-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-mediator-pattern.de.adoc
+++ b/docs/anchors/gof-mediator-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, mediator, loose coupling, coordination, hub
+:related: gof-design-patterns, gof-observer-pattern, gof-facade-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-memento-pattern.adoc
+++ b/docs/anchors/gof-memento-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, memento, snapshot, undo, state preservation
+:related: gof-design-patterns, gof-command-pattern, gof-state-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-memento-pattern.de.adoc
+++ b/docs/anchors/gof-memento-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, memento, snapshot, undo, state preservation
+:related: gof-design-patterns, gof-command-pattern, gof-state-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-observer-pattern.adoc
+++ b/docs/anchors/gof-observer-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, observer, publish-subscribe, event, notification, reactive
+:related: gof-design-patterns, gof-mediator-pattern, gof-strategy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-observer-pattern.de.adoc
+++ b/docs/anchors/gof-observer-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, observer, publish-subscribe, event, notification, reactive
+:related: gof-design-patterns, gof-mediator-pattern, gof-strategy-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-prototype-pattern.adoc
+++ b/docs/anchors/gof-prototype-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, prototype, cloning, copy, object creation
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-builder-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-prototype-pattern.de.adoc
+++ b/docs/anchors/gof-prototype-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 2
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, prototype, cloning, copy, object creation
+:related: gof-design-patterns, gof-abstract-factory-pattern, gof-builder-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-proxy-pattern.adoc
+++ b/docs/anchors/gof-proxy-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, proxy, access control, lazy loading, caching, virtual proxy
+:related: gof-design-patterns, gof-decorator-pattern, gof-adapter-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-proxy-pattern.de.adoc
+++ b/docs/anchors/gof-proxy-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, proxy, access control, lazy loading, caching, virtual proxy
+:related: gof-design-patterns, gof-decorator-pattern, gof-adapter-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-singleton-pattern.adoc
+++ b/docs/anchors/gof-singleton-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, singleton, global state, instance control
+:related: gof-design-patterns, gof-abstract-factory-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-singleton-pattern.de.adoc
+++ b/docs/anchors/gof-singleton-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, singleton, global state, instance control
+:related: gof-design-patterns, gof-abstract-factory-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-state-pattern.adoc
+++ b/docs/anchors/gof-state-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, state, state machine, finite automaton, context
+:related: gof-design-patterns, gof-strategy-pattern, gof-memento-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-state-pattern.de.adoc
+++ b/docs/anchors/gof-state-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, state, state machine, finite automaton, context
+:related: gof-design-patterns, gof-strategy-pattern, gof-memento-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-strategy-pattern.adoc
+++ b/docs/anchors/gof-strategy-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, strategy
+:related: gof-design-patterns, gof-state-pattern, gof-template-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-strategy-pattern.de.adoc
+++ b/docs/anchors/gof-strategy-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, strategy
+:related: gof-design-patterns, gof-state-pattern, gof-template-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-template-method-pattern.adoc
+++ b/docs/anchors/gof-template-method-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, template method, algorithm skeleton, hook, inheritance
+:related: gof-design-patterns, gof-strategy-pattern, gof-factory-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-template-method-pattern.de.adoc
+++ b/docs/anchors/gof-template-method-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, template method, algorithm skeleton, hook, inheritance
+:related: gof-design-patterns, gof-strategy-pattern, gof-factory-method-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-visitor-pattern.adoc
+++ b/docs/anchors/gof-visitor-pattern.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, visitor, double dispatch, operations, traversal
+:related: gof-design-patterns, gof-iterator-pattern, gof-interpreter-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/gof-visitor-pattern.de.adoc
+++ b/docs/anchors/gof-visitor-pattern.de.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, visitor, double dispatch, operations, traversal
+:related: gof-design-patterns, gof-iterator-pattern, gof-interpreter-pattern
 
 [%collapsible]
 ====

--- a/docs/anchors/hexaco.adoc
+++ b/docs/anchors/hexaco.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
 :proponents: Kibeom Lee, Michael C. Ashton
 :tags: personality traits, HEXACO, Honesty-Humility, six-factor model, Dark Triad, trait psychology
+:related: big-five, myers-briggs-type-indicator, disc-model
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/hexaco.de.adoc
+++ b/docs/anchors/hexaco.de.adoc
@@ -3,6 +3,7 @@
 :roles: consultant, team-lead, educator, ux-designer, product-owner, data-scientist
 :proponents: Kibeom Lee, Michael C. Ashton
 :tags: Persönlichkeitsmerkmale, HEXACO, Honesty-Humility, Sechs-Faktoren-Modell, Dark Triad, Trait-Psychologie
+:related: big-five, myers-briggs-type-indicator, disc-model
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/hexagonal-architecture.adoc
+++ b/docs/anchors/hexagonal-architecture.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
 :tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
+:related: clean-architecture, domain-driven-design, separation-of-concerns
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/hexagonal-architecture.de.adoc
+++ b/docs/anchors/hexagonal-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
 :tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
+:related: clean-architecture, domain-driven-design, separation-of-concerns
 
 [%collapsible]
 ====

--- a/docs/anchors/impact-mapping.adoc
+++ b/docs/anchors/impact-mapping.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, consultant
 :proponents: Gojko Adzic
 :tags: impact mapping, Gojko Adzic, strategic planning, goals, deliverables, product
+:related: user-story-mapping, wardley-mapping, okr
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/impact-mapping.de.adoc
+++ b/docs/anchors/impact-mapping.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, consultant
 :proponents: Gojko Adzic
 :tags: impact mapping, Gojko Adzic, strategic planning, goals, deliverables, product
+:related: user-story-mapping, wardley-mapping, okr
 
 [%collapsible]
 ====

--- a/docs/anchors/jobs-to-be-done.adoc
+++ b/docs/anchors/jobs-to-be-done.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, ux-designer, business-analyst
 :proponents: Clayton Christensen, Alan Klement, Bob Moesta
 :tags: jobs to be done, JTBD, Christensen, customer needs, product, innovation
+:related: user-story-mapping, kano-model, mvp
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/jobs-to-be-done.de.adoc
+++ b/docs/anchors/jobs-to-be-done.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, ux-designer, business-analyst
 :proponents: Clayton Christensen, Alan Klement, Bob Moesta
 :tags: jobs to be done, JTBD, Christensen, customer needs, product, innovation
+:related: user-story-mapping, kano-model, mvp
 
 [%collapsible]
 ====

--- a/docs/anchors/madr.adoc
+++ b/docs/anchors/madr.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :proponents: Oliver Kopp, Olaf Zimmermann (and MADR community)
 :tags: MADR, markdown ADR, architecture decision record, decision documentation
+:related: adr-according-to-nygard, arc42
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/madr.de.adoc
+++ b/docs/anchors/madr.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :proponents: Oliver Kopp, Olaf Zimmermann (and MADR community)
 :tags: MADR, markdown ADR, architecture decision record, decision documentation
+:related: adr-according-to-nygard, arc42
 
 [%collapsible]
 ====

--- a/docs/anchors/mece.adoc
+++ b/docs/anchors/mece.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, consultant, software-architect, data-scientist
 :proponents: Barbara Minto
 :tags: MECE, mutually exclusive collectively exhaustive, Barbara Minto, structuring, McKinsey
+:related: pyramid-principle, bluf, morphological-box
 :tier: 3
 :definition: MECE — Mutually Exclusive, Collectively Exhaustive — is a grouping principle from Barbara Minto’s Pyramid Principle: split a topic into categories that do not overlap and together cover everything. It yields clean, gap-free, duplication-free structures for analysis, communication, and problem decomposition.
 

--- a/docs/anchors/mece.de.adoc
+++ b/docs/anchors/mece.de.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, consultant, software-architect, data-scientist
 :proponents: Barbara Minto
 :tags: MECE, mutually exclusive collectively exhaustive, Barbara Minto, structuring, McKinsey
+:related: pyramid-principle, bluf, morphological-box
 
 [%collapsible]
 ====

--- a/docs/anchors/mutation-testing.adoc
+++ b/docs/anchors/mutation-testing.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Richard Lipton (theoretical foundation, 1971), Richard DeMillo, Timothy Budd
 :tags: mutation testing, test quality, fault injection, test effectiveness, coverage
+:related: property-based-testing, testing-pyramid
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/mutation-testing.de.adoc
+++ b/docs/anchors/mutation-testing.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Richard Lipton (theoretical foundation, 1971), Richard DeMillo, Timothy Budd
 :tags: mutation testing, test quality, fault injection, test effectiveness, coverage
+:related: property-based-testing, testing-pyramid
 
 [%collapsible]
 ====

--- a/docs/anchors/nelson-rules.adoc
+++ b/docs/anchors/nelson-rules.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer
 :proponents: Lloyd S. Nelson
 :tags: Nelson rules, control chart, SPC, statistical process control, out of control
+:related: control-chart-shewhart, spc
 :tier: 3
 :parent-anchor: spc
 

--- a/docs/anchors/nelson-rules.de.adoc
+++ b/docs/anchors/nelson-rules.de.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer
 :proponents: Lloyd S. Nelson
 :tags: Nelson rules, control chart, SPC, statistical process control, out of control
+:related: control-chart-shewhart, spc
 
 [%collapsible]
 ====

--- a/docs/anchors/problem-space-nvc.adoc
+++ b/docs/anchors/problem-space-nvc.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, product-owner, consultant, ux-designer, team-lead
 :proponents: Marshall Rosenberg
 :tags: nvc, communication, empathy, conflict-resolution, requirements
+:related: jobs-to-be-done, impact-mapping, user-story-mapping
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/problem-space-nvc.de.adoc
+++ b/docs/anchors/problem-space-nvc.de.adoc
@@ -2,6 +2,8 @@
 :categories: requirements-engineering
 :roles: business-analyst, product-owner, consultant, ux-designer
 :proponents: Marshall Rosenberg
+:tags: nvc, communication, empathy, conflict-resolution, requirements
+:related: jobs-to-be-done, impact-mapping, user-story-mapping
 
 [%collapsible]
 ====

--- a/docs/anchors/property-based-testing.adoc
+++ b/docs/anchors/property-based-testing.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Koen Claessen, John Hughes (QuickCheck)
 :tags: property-based testing, QuickCheck, invariants, generative testing, Hypothesis
+:related: mutation-testing, testing-pyramid
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/property-based-testing.de.adoc
+++ b/docs/anchors/property-based-testing.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Koen Claessen, John Hughes (QuickCheck)
 :tags: property-based testing, QuickCheck, invariants, generative testing, Hypothesis
+:related: mutation-testing, testing-pyramid
 
 [%collapsible]
 ====

--- a/docs/anchors/pugh-matrix.adoc
+++ b/docs/anchors/pugh-matrix.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, team-lead, product-owner
 :proponents: Stuart Pugh
 :tags: Pugh matrix, decision matrix, Stuart Pugh, trade-off analysis, weighted criteria
+:related: morphological-box, swot, decisional-balance-sheet
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/pugh-matrix.de.adoc
+++ b/docs/anchors/pugh-matrix.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, team-lead, product-owner
 :proponents: Stuart Pugh
 :tags: Pugh matrix, decision matrix, Stuart Pugh, trade-off analysis, weighted criteria
+:related: morphological-box, swot, decisional-balance-sheet
 
 [%collapsible]
 ====

--- a/docs/anchors/pyramid-principle.adoc
+++ b/docs/anchors/pyramid-principle.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, consultant, team-lead, technical-writer
 :proponents: Barbara Minto
 :tags: pyramid principle, Barbara Minto, structured communication, top-down, writing
+:related: mece, bluf, inverted-pyramid-style
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/pyramid-principle.de.adoc
+++ b/docs/anchors/pyramid-principle.de.adoc
@@ -3,6 +3,7 @@
 :roles: business-analyst, consultant, team-lead, technical-writer
 :proponents: Barbara Minto
 :tags: pyramid principle, Barbara Minto, structured communication, top-down, writing
+:related: mece, bluf, inverted-pyramid-style
 
 [%collapsible]
 ====

--- a/docs/anchors/semantic-versioning.adoc
+++ b/docs/anchors/semantic-versioning.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, devops-engineer, product-owner
 :proponents: Tom Preston-Werner
 :tags: semantic versioning, SemVer, versioning, major minor patch, Tom Preston-Werner
+:related: conventional-commits, twelve-factor-app
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/semantic-versioning.de.adoc
+++ b/docs/anchors/semantic-versioning.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, devops-engineer, product-owner
 :proponents: Tom Preston-Werner
 :tags: semantic versioning, SemVer, versioning, major minor patch, Tom Preston-Werner
+:related: conventional-commits, twelve-factor-app
 
 [%collapsible]
 ====

--- a/docs/anchors/socratic-method.adoc
+++ b/docs/anchors/socratic-method.adoc
@@ -3,6 +3,7 @@
 :roles: educator, consultant, team-lead
 :proponents: Socrates, Plato
 :tags: Socratic method, questioning, dialogue, Socrates, critical thinking, inquiry
+:related: five-whys, devils-advocate, laddering
 :tier: 3
 :definition: The Socratic Method is a form of cooperative inquiry, attributed to Socrates, that advances understanding through disciplined questioning rather than assertion. By probing assumptions, definitions, and consequences, it surfaces contradictions and gaps, helping participants refine their own reasoning instead of being handed the answer.
 

--- a/docs/anchors/socratic-method.de.adoc
+++ b/docs/anchors/socratic-method.de.adoc
@@ -3,6 +3,7 @@
 :roles: educator, consultant, team-lead
 :proponents: Socrates, Plato
 :tags: Socratic method, questioning, dialogue, Socrates, critical thinking, inquiry
+:related: five-whys, devils-advocate, laddering
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-dip.adoc
+++ b/docs/anchors/solid-dip.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, DIP, dependency inversion
+:related: solid-principles, solid-srp, solid-ocp, solid-lsp, solid-isp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-dip.de.adoc
+++ b/docs/anchors/solid-dip.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, DIP, dependency inversion
+:related: solid-principles, solid-srp, solid-ocp, solid-lsp, solid-isp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-isp.adoc
+++ b/docs/anchors/solid-isp.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, ISP, interface segregation
+:related: solid-principles, solid-dip, solid-srp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-isp.de.adoc
+++ b/docs/anchors/solid-isp.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, ISP, interface segregation
+:related: solid-principles, solid-dip, solid-srp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-lsp.adoc
+++ b/docs/anchors/solid-lsp.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Robert C. Martin, Barbara Liskov
 :tags: SOLID, design principle, LSP, liskov, substitution
+:related: solid-principles, solid-ocp, solid-dip
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-lsp.de.adoc
+++ b/docs/anchors/solid-lsp.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Robert C. Martin, Barbara Liskov
 :tags: SOLID, design principle, LSP, liskov, substitution
+:related: solid-principles, solid-ocp, solid-dip
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-ocp.adoc
+++ b/docs/anchors/solid-ocp.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Robert C. Martin, Bertrand Meyer
 :tags: SOLID, design principle, OCP, open closed
+:related: solid-principles, solid-lsp, solid-srp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-ocp.de.adoc
+++ b/docs/anchors/solid-ocp.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Robert C. Martin, Bertrand Meyer
 :tags: SOLID, design principle, OCP, open closed
+:related: solid-principles, solid-lsp, solid-srp
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-srp.adoc
+++ b/docs/anchors/solid-srp.adoc
@@ -5,6 +5,7 @@
 :tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, SRP, single responsibility
+:related: solid-principles, separation-of-concerns, single-level-of-abstraction-principle
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-srp.de.adoc
+++ b/docs/anchors/solid-srp.de.adoc
@@ -5,6 +5,7 @@
 :tier: 1
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, SRP, single responsibility
+:related: solid-principles, separation-of-concerns, single-level-of-abstraction-principle
 
 [%collapsible]
 ====

--- a/docs/anchors/sota.adoc
+++ b/docs/anchors/sota.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, data-scientist, consultant
 :proponents: Community
 :tags: SOTA, state of the art, benchmark, current best, research
+:related: llm-evaluations, first-principles-thinking
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/sota.de.adoc
+++ b/docs/anchors/sota.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, data-scientist, consultant
 :proponents: Community
 :tags: SOTA, state of the art, benchmark, current best, research
+:related: llm-evaluations, first-principles-thinking
 
 [%collapsible]
 ====

--- a/docs/anchors/spc.adoc
+++ b/docs/anchors/spc.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer, team-lead, qa-engineer
 :proponents: Walter A. Shewhart (founder), W. Edwards Deming (dissemination), Western Electric Company
 :tags: SPC, statistical process control, control charts, Shewhart, quality, variation
+:related: control-chart-shewhart, nelson-rules
 :tier: 3
 :sub-anchors: control-chart-shewhart, nelson-rules
 

--- a/docs/anchors/spc.de.adoc
+++ b/docs/anchors/spc.de.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, devops-engineer, team-lead, qa-engineer
 :proponents: Walter A. Shewhart (founder), W. Edwards Deming (dissemination), Western Electric Company
 :tags: SPC, statistical process control, control charts, Shewhart, quality, variation
+:related: control-chart-shewhart, nelson-rules
 
 [%collapsible]
 ====

--- a/docs/anchors/ssot-principle.adoc
+++ b/docs/anchors/ssot-principle.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, data-scientist, business-analyst
 :proponents: Community
 :tags: SSOT, single source of truth, data consistency, canonical source, DRY
+:related: dry, single-level-of-abstraction-principle, separation-of-concerns
 :tier: 1
 
 [%collapsible]

--- a/docs/anchors/ssot-principle.de.adoc
+++ b/docs/anchors/ssot-principle.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, data-scientist, business-analyst
 :proponents: Community
 :tags: SSOT, single source of truth, data consistency, canonical source, DRY
+:related: dry, single-level-of-abstraction-principle, separation-of-concerns
 
 [%collapsible]
 ====

--- a/docs/anchors/tdd-chicago-school.adoc
+++ b/docs/anchors/tdd-chicago-school.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Kent Beck, Martin Fowler
 :tags: TDD, classicist TDD, Detroit School, Chicago School, state-based testing, inside-out, Kent Beck
+:related: tdd-london-school, red-green-tdd, testing-pyramid
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/tdd-chicago-school.de.adoc
+++ b/docs/anchors/tdd-chicago-school.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer
 :proponents: Kent Beck, Martin Fowler
 :tags: TDD, classicist TDD, Detroit School, Chicago School, state-based testing, inside-out, Kent Beck
+:related: tdd-london-school, red-green-tdd, testing-pyramid
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/tdd-london-school.adoc
+++ b/docs/anchors/tdd-london-school.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
 :tags: TDD, London school, mockist, outside-in, Freeman, Pryce, interaction testing, mocks
+:related: tdd-chicago-school, red-green-tdd, test-double-mock
 :tier: 3
 :definition: TDD London School — also called mockist or outside-in TDD (Steve Freeman and Nat Pryce) — drives design from the outside in: start at the system boundary, mock collaborators to specify their interactions, and let the required interfaces emerge. It emphasises object roles and message-passing over verifying state.
 

--- a/docs/anchors/tdd-london-school.de.adoc
+++ b/docs/anchors/tdd-london-school.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
 :tags: TDD, London school, mockist, outside-in, Freeman, Pryce, interaction testing, mocks
+:related: tdd-chicago-school, red-green-tdd, test-double-mock
 
 [%collapsible]
 ====

--- a/docs/anchors/testing-pyramid.adoc
+++ b/docs/anchors/testing-pyramid.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, team-lead, devops-engineer
 :proponents: Mike Cohn
 :tags: testing pyramid, unit tests, integration tests, e2e, test strategy, Mike Cohn
+:related: tdd-london-school, tdd-chicago-school, mutation-testing
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/testing-pyramid.de.adoc
+++ b/docs/anchors/testing-pyramid.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, team-lead, devops-engineer
 :proponents: Mike Cohn
 :tags: testing pyramid, unit tests, integration tests, e2e, test strategy, Mike Cohn
+:related: tdd-london-school, tdd-chicago-school, mutation-testing
 
 [%collapsible]
 ====

--- a/docs/anchors/timtowtdi.adoc
+++ b/docs/anchors/timtowtdi.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Larry Wall
 :tags: TIMTOWTDI, there is more than one way to do it, Perl, Larry Wall, flexibility
+:related: unix-philosophy, effective-go, kiss-principle
 :tier: 1
 
 [%collapsible]

--- a/docs/anchors/timtowtdi.de.adoc
+++ b/docs/anchors/timtowtdi.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Larry Wall
 :tags: TIMTOWTDI, there is more than one way to do it, Perl, Larry Wall, flexibility
+:related: unix-philosophy, effective-go, kiss-principle
 
 [%collapsible]
 ====

--- a/docs/anchors/todotxt-flavoured-markdown.adoc
+++ b/docs/anchors/todotxt-flavoured-markdown.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, team-lead, technical-writer
 :proponents: Combines GitHub-flavoured Markdown task lists with Gina Trapani's todo.txt format
 :tags: todo.txt, task management, markdown, Gina Trapani, plain text, task lists
+:related: gtd, para-method
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/todotxt-flavoured-markdown.de.adoc
+++ b/docs/anchors/todotxt-flavoured-markdown.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, team-lead, technical-writer
 :proponents: Combines GitHub-flavoured Markdown task lists with Gina Trapani's todo.txt format
 :tags: todo.txt, task management, markdown, Gina Trapani, plain text, task lists
+:related: gtd, para-method
 
 [%collapsible]
 ====

--- a/docs/anchors/user-story-mapping.adoc
+++ b/docs/anchors/user-story-mapping.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, ux-designer
 :proponents: Jeff Patton
 :tags: user story mapping, Jeff Patton, backlog, product, user journey, stories
+:related: impact-mapping, invest, mvp
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/user-story-mapping.de.adoc
+++ b/docs/anchors/user-story-mapping.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, ux-designer
 :proponents: Jeff Patton
 :tags: user story mapping, Jeff Patton, backlog, product, user journey, stories
+:related: impact-mapping, invest, mvp
 
 [%collapsible]
 ====

--- a/docs/anchors/wardley-mapping.adoc
+++ b/docs/anchors/wardley-mapping.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, software-architect, consultant, team-lead
 :proponents: Simon Wardley
 :tags: Wardley mapping, value chain, strategy, evolution, Simon Wardley
+:related: cynefin-framework, impact-mapping, swot
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/wardley-mapping.de.adoc
+++ b/docs/anchors/wardley-mapping.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, software-architect, consultant, team-lead
 :proponents: Simon Wardley
 :tags: Wardley mapping, value chain, strategy, evolution, Simon Wardley
+:related: cynefin-framework, impact-mapping, swot
 
 [%collapsible]
 ====

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-07
 
+*Metadata audit — `:related:` backfill (#668, Phase C — audit complete):*
+
+* Added curated `:related:` cross-links to 70 anchors (EN + DE) that lacked them — 2–5 genuinely related anchors each, using category and tag overlap as candidates and hand-curating to real conceptual connections (the SOLID and GoF-pattern clusters, the personality models, the TDD schools, the SPC trio, and so on). 187/188 anchors now carry `:related:` (the meta-anchor `what-qualifies-as-a-semantic-anchor` is intentionally standalone). This closes the #668 metadata audit: Phase A (`:proponents:`), Phase B (`:tags:`), Phase C (`:related:`) — the catalog's required and recommended metadata is now complete.
+
 *Metadata audit — `:tags:` backfill (#668, Phase B):*
 
 * Completes `:tags:` for the whole catalog — 100% of anchors now carry search keywords. Added tags to 39 anchors that lacked them (EN + DE), derived from each concept's name, aliases, key sub-concepts and proponents (e.g. `arc42` → arc42, architecture documentation, Starke, Hruschka). Follows the Phase A `:proponents:` backfill; Phase C (`:related:`) is the remaining follow-up.


### PR DESCRIPTION
Phase C of #668 — the final phase. `:related:` (optional cross-reference metadata) was missing on 71 anchors.

## What
- Added **curated `:related:` to 70 anchors, EN + DE**, 2–5 genuinely related anchors each. Category and tag overlap gave the candidates; each set is hand-curated to real conceptual connections, bidirectionally sensible, and validated to point only at existing anchor IDs. Examples:
  - `clean-architecture` → hexagonal-architecture, domain-driven-design, solid-principles
  - the **SOLID** sub-principles cross-link to each other and `solid-principles`
  - the **23 GoF patterns** link to `gof-design-patterns` + natural siblings
  - `tdd-london-school` ↔ `tdd-chicago-school`, red-green-tdd, test-double-mock
  - the personality models (big-five / hexaco) into the MBTI/DISC cluster
- Fixed a DE drift on `problem-space-nvc.de` (was missing `:tags:` too).
- **187/188** anchors now carry `:related:` — the meta-anchor `what-qualifies-as-a-semantic-anchor` is intentionally standalone (no genuine relation; `:related:` is optional).

This **completes the #668 metadata audit**: Phase A (`:proponents:`, 100%), Phase B (`:tags:`, 100%), Phase C (`:related:`).

## Noted separately (pre-existing, not touched here)
A dead-link scan surfaced pre-existing broken `:related:` targets in files outside this change: `kiss-principle`/`yagni` → `dry-principle` (should be `dry`), `yagni` → `spot-principle`, `effective-go` → `clean-code`. Worth a tiny follow-up.

Generated `public/data/*.json` not committed (rebuilt by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Dokumentationsseiten wurden um passende Verweise auf verwandte Themen erweitert, sodass Zusammenhänge leichter auffindbar sind.
  * Die Navigierbarkeit innerhalb der Wissenssammlung wurde dadurch verbessert.

* **Dokumentation**
  * Der Changelog wurde um einen Eintrag ergänzt, der die vollständige Ergänzung der Querverweise dokumentiert.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->