### PR TITLE
fix: repoint dead :related: links to real anchor IDs

### DIFF
--- a/docs/anchors/effective-go.adoc
+++ b/docs/anchors/effective-go.adoc
@@ -1,7 +1,7 @@
 = Effective Go
 :categories: development-workflow
 :roles: software-developer, software-architect
-:related: clean-code, conventional-commits
+:related: effective-java, conventional-commits
 :proponents: The Go Authors
 :tags: go, golang, best-practices, idiomatic, style-guide
 :tier: 3

--- a/docs/anchors/effective-go.de.adoc
+++ b/docs/anchors/effective-go.de.adoc
@@ -1,7 +1,7 @@
 = Effective Go
 :categories: development-workflow
 :roles: software-developer, software-architect
-:related: clean-code, conventional-commits
+:related: effective-java, conventional-commits
 :proponents: The Go Authors
 :tags: go, golang, best-practices, idiomatic, style-guide
 :tier: 3

--- a/docs/anchors/kiss-principle.adoc
+++ b/docs/anchors/kiss-principle.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Kelly Johnson, Robert C. Martin
-:related: yagni, dry-principle, solid-principles
+:related: yagni, dry, solid-principles
 :tags: kiss, simplicity, design-principles, over-engineering, readability
 :tier: 1
 

--- a/docs/anchors/kiss-principle.de.adoc
+++ b/docs/anchors/kiss-principle.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Kelly Johnson, Robert C. Martin
-:related: yagni, dry-principle, solid-principles
+:related: yagni, dry, solid-principles
 :tags: kiss, simplicity, design-principles, over-engineering, readability
 
 [%collapsible]

--- a/docs/anchors/yagni.adoc
+++ b/docs/anchors/yagni.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant
 :proponents: Ron Jeffries, Kent Beck
-:related: dry-principle, spot-principle, tdd-chicago-school, kiss-principle
+:related: dry, ssot-principle, tdd-chicago-school, kiss-principle
 :tags: yagni, extreme-programming, simplicity, incremental-design, over-engineering
 :tier: 1
 

--- a/docs/anchors/yagni.de.adoc
+++ b/docs/anchors/yagni.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant
 :proponents: Ron Jeffries, Kent Beck
-:related: dry-principle, spot-principle, tdd-chicago-school, kiss-principle
+:related: dry, ssot-principle, tdd-chicago-school, kiss-principle
 :tags: yagni, extreme-programming, simplicity, incremental-design, over-engineering
 
 [%collapsible]

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,10 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-07-07
 
+*Fix — dead `:related:` links:*
+
+* Repointed pre-existing broken cross-references to their real anchor IDs: `kiss-principle`/`yagni` → `dry` (was `dry-principle`), `yagni` → `ssot-principle` (was `spot-principle`), `effective-go` → `effective-java` (was `clean-code`). All `:related:` targets across the catalog now resolve to existing anchors.
+
 *Metadata audit — `:related:` backfill (#668, Phase C — audit complete):*
 
 * Added curated `:related:` cross-links to 70 anchors (EN + DE) that lacked them — 2–5 genuinely related anchors each, using category and tag overlap as candidates and hand-curating to real conceptual connections (the SOLID and GoF-pattern clusters, the personality models, the TDD schools, the SPC trio, and so on). 187/188 anchors now carry `:related:` (the meta-anchor `what-qualifies-as-a-semantic-anchor` is intentionally standalone). This closes the #668 metadata audit: Phase A (`:proponents:`), Phase B (`:tags:`), Phase C (`:related:`) — the catalog's required and recommended metadata is now complete.


### PR DESCRIPTION
Pre-existing broken `:related:` targets surfaced by the dead-link scan during #668 Phase C. Repointed to the correct existing anchors (EN + DE):

- `kiss-principle`, `yagni` → **`dry`** (was `dry-principle`, no such ID)
- `yagni` → **`ssot-principle`** (was `spot-principle`; SPOT ≈ Single Source of Truth)
- `effective-go` → **`effective-java`** (was `clean-code`; natural "Effective X" sibling)

After this, every `:related:` target in the catalog resolves to a real anchor (only `_template.adoc`'s placeholder examples remain, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fehlerhafte Verweise in den „Related“-Angaben der Dokumentation wurden korrigiert.
  * Mehrere Themenseiten verweisen jetzt wieder auf gültige, vorhandene Anker.
  * Der Changelog wurde um einen Eintrag zu den behobenen ungültigen Links ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->