### PR TITLE
fix: sync EN/DE metadata parity across 100 anchors

### DIFF
--- a/docs/anchors/adr-according-to-nygard.de.adoc
+++ b/docs/anchors/adr-according-to-nygard.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Michael Nygard
+:tier: 3
 :tags: ADR, architecture decision record, Nygard, decision documentation, architecture decisions
 :related: madr, arc42, c4-diagrams
 

--- a/docs/anchors/arc42.de.adoc
+++ b/docs/anchors/arc42.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead
 :proponents: Gernot Starke, Peter Hruschka
+:tier: 3
 :tags: arc42, architecture documentation, software architecture, documentation template, Starke, Hruschka
 :related: c4-diagrams, adr-according-to-nygard, quality-attribute-scenario
 

--- a/docs/anchors/atam.de.adoc
+++ b/docs/anchors/atam.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, team-lead, product-owner
 :related: arc42, adr-according-to-nygard, quality-attribute-scenario
 :proponents: Rick Kazman, Mark Klein, Paul Clements
+:tier: 3
 :tags: architecture evaluation, quality attributes, tradeoffs, utility tree, SEI, risk analysis
 
 [%collapsible]

--- a/docs/anchors/bdd-given-when-then.de.adoc
+++ b/docs/anchors/bdd-given-when-then.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, business-analyst, product-owner
 :proponents: Dan North
+:tier: 3
 :related: tdd-london-school, tdd-chicago-school, user-story-mapping
 :tags: bdd, gherkin, cucumber, specification-by-example, three-amigos, given-when-then, living-documentation
 

--- a/docs/anchors/bem-methodology.de.adoc
+++ b/docs/anchors/bem-methodology.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, ux-designer
 :proponents: Yandex Entwicklungsteam
+:tier: 3
 :tags: BEM, Block Element Modifier, CSS, SCSS, naming convention, frontend, stylesheets
 :related: separation-of-concerns, kiss-principle, unix-philosophy
 

--- a/docs/anchors/bluf.de.adoc
+++ b/docs/anchors/bluf.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, team-lead, technical-writer, consultant
 :proponents: US-Militär (Army writing standards), weithin in Wirtschaft und Regierung übernommen
+:tier: 3
 :tags: BLUF, bottom line up front, concise communication, executive summary, clarity
 :related: pyramid-principle, mece, inverted-pyramid-style, plain-english-strunk-white
 

--- a/docs/anchors/c4-diagrams.de.adoc
+++ b/docs/anchors/c4-diagrams.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, technical-writer, team-lead, consultant
 :proponents: Simon Brown
+:tier: 3
 :tags: C4, C4 model, architecture diagrams, context container component code, Simon Brown, visualization
 :related: arc42, adr-according-to-nygard, domain-driven-design
 

--- a/docs/anchors/chain-of-thought.de.adoc
+++ b/docs/anchors/chain-of-thought.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, data-scientist, business-analyst
 :proponents: Wei et al. (Google Research, 2022), "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
+:tier: 3
 :tags: chain of thought, CoT, reasoning, step-by-step, prompting, LLM reasoning
 :related: first-principles-thinking, feynman-technique, fermi-estimation
 

--- a/docs/anchors/clean-architecture.de.adoc
+++ b/docs/anchors/clean-architecture.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
+:tier: 3
 :tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
 :related: hexagonal-architecture, domain-driven-design, solid-principles
 

--- a/docs/anchors/control-chart-shewhart.de.adoc
+++ b/docs/anchors/control-chart-shewhart.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead
 :proponents: Walter A. Shewhart
+:tier: 3
 :tags: control chart, Shewhart, SPC, statistical process control, quality, variation
 :related: spc, nelson-rules
 

--- a/docs/anchors/conventional-commits.de.adoc
+++ b/docs/anchors/conventional-commits.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer
 :proponents: Benjamin E. Coe, James J. Womack, Steve Mao
+:tier: 3
 :tags: conventional commits, commit messages, semantic commits, changelog, git
 :related: semantic-versioning, github-flow, definition-of-done
 

--- a/docs/anchors/cqrs.de.adoc
+++ b/docs/anchors/cqrs.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Greg Young, Bertrand Meyer, Udi Dahan
+:tier: 3
 :related: domain-driven-design, hexagonal-architecture, fowler-patterns
 :tags: cqrs, cqs, architecture, commands, queries, read-write-separation
 

--- a/docs/anchors/cynefin-framework.de.adoc
+++ b/docs/anchors/cynefin-framework.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: team-lead, consultant, product-owner, software-architect
 :proponents: Dave Snowden
+:tier: 3
 :related: wardley-mapping
 :tags: complexity, decision-making, sensemaking, strategy, domains
 

--- a/docs/anchors/devils-advocate.de.adoc
+++ b/docs/anchors/devils-advocate.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-architect, team-lead, consultant, qa-engineer
 :proponents: Roman Catholic Church (advocatus diaboli / Promotor Fidei)
+:tier: 3
 :tags: devil's advocate, dissent, critical thinking, challenge assumptions, red team
 :related: socratic-method, five-whys, consent-vs-consensus
 

--- a/docs/anchors/diataxis-framework.de.adoc
+++ b/docs/anchors/diataxis-framework.de.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, educator
 :proponents: Daniele Procida
+:tier: 3
 :tags: Diataxis, documentation, tutorials, how-to, reference, explanation, Procida
 :related: docs-as-code, arc42, inverted-pyramid-style
 

--- a/docs/anchors/docs-as-code.de.adoc
+++ b/docs/anchors/docs-as-code.de.adoc
@@ -2,6 +2,7 @@
 :categories: documentation
 :roles: technical-writer, software-developer, devops-engineer
 :proponents: Ralf D. Müller
+:tier: 3
 :tags: docs as code, documentation, AsciiDoc, version control, technical writing, Mueller
 :related: diataxis-framework, arc42, conventional-commits
 

--- a/docs/anchors/domain-driven-design.de.adoc
+++ b/docs/anchors/domain-driven-design.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
+:tier: 3
 :tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
 :related: hexagonal-architecture, clean-architecture, event-storming
 

--- a/docs/anchors/ears-requirements.de.adoc
+++ b/docs/anchors/ears-requirements.de.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: business-analyst, qa-engineer, technical-writer
 :proponents: Alistair Mavin
+:tier: 3
 :tags: EARS, requirements syntax, requirements engineering, Mavin, easy approach to requirements syntax
 :related: cockburn-use-cases, invest, req42
 

--- a/docs/anchors/event-driven-architecture.de.adoc
+++ b/docs/anchors/event-driven-architecture.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, devops-engineer
 :proponents: Gregor Hohpe, Bobby Woolf, Martin Fowler
+:tier: 3
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
 :tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
 

--- a/docs/anchors/feynman-technique.de.adoc
+++ b/docs/anchors/feynman-technique.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, educator, consultant, team-lead
 :proponents: Richard Feynman
+:tier: 3
 :tags: Feynman technique, learning, teaching, explain simply, understanding
 :related: blooms-taxonomy, curse-of-knowledge, zone-of-proximal-development
 

--- a/docs/anchors/fichtean-curve.de.adoc
+++ b/docs/anchors/fichtean-curve.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: John Gardner ("The Art of Fiction"), Janet Burroway ("Writing Fiction")
+:tags: storytelling, narrative, crisis, rising-action, pacing, tension, fichtean, short-story, constant-conflict
+:related: three-act-structure, freytags-pyramid, save-the-cat
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/five-whys.de.adoc
+++ b/docs/anchors/five-whys.de.adoc
@@ -2,6 +2,7 @@
 :categories: problem-solving
 :roles: software-developer, qa-engineer, devops-engineer, team-lead
 :proponents: Sakichi Toyoda, Taiichi Ohno (Toyota)
+:tier: 3
 :tags: five whys, root cause analysis, Toyota, Ohno, lean, problem solving
 :related: socratic-method, xy-problem, first-principles-thinking
 

--- a/docs/anchors/fowler-patterns.de.adoc
+++ b/docs/anchors/fowler-patterns.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-architect, software-developer, team-lead
 :proponents: Martin Fowler
+:tier: 3
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
 :tags: enterprise, architecture, patterns, design-patterns, orm
 

--- a/docs/anchors/freytags-pyramid.de.adoc
+++ b/docs/anchors/freytags-pyramid.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Gustav Freytag ("Die Technik des Dramas", 1863), John Yorke ("Into the Woods")
+:tags: storytelling, drama, five-act, pyramid, freytag, exposition, rising-action, climax, falling-action, denouement, tragedy, classical
+:related: three-act-structure, heros-journey, fichtean-curve, save-the-cat
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/gherkin.de.adoc
+++ b/docs/anchors/gherkin.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, qa-engineer, business-analyst, product-owner
 :related: bdd-given-when-then, ears-requirements, tdd-london-school
 :proponents: Aslak Hellesøy
+:tier: 3
 :tags: gherkin, bdd, cucumber, given-when-then, specification-by-example, dsl, acceptance-testing, living-documentation
 
 [%collapsible]

--- a/docs/anchors/gof-abstract-factory-pattern.de.adoc
+++ b/docs/anchors/gof-abstract-factory-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, abstract factory, family, platform independence
 :related: gof-design-patterns, gof-factory-method-pattern, gof-builder-pattern

--- a/docs/anchors/gof-adapter-pattern.de.adoc
+++ b/docs/anchors/gof-adapter-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, adapter, wrapper, interface conversion, compatibility
 :related: gof-design-patterns, gof-facade-pattern, gof-bridge-pattern

--- a/docs/anchors/gof-bridge-pattern.de.adoc
+++ b/docs/anchors/gof-bridge-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, bridge, abstraction, implementation, decoupling
 :related: gof-design-patterns, gof-adapter-pattern, gof-strategy-pattern

--- a/docs/anchors/gof-builder-pattern.de.adoc
+++ b/docs/anchors/gof-builder-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, builder, construction, fluent interface, complex objects
 :related: gof-design-patterns, gof-abstract-factory-pattern, gof-factory-method-pattern

--- a/docs/anchors/gof-chain-of-responsibility-pattern.de.adoc
+++ b/docs/anchors/gof-chain-of-responsibility-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, chain of responsibility, handler, pipeline, middleware
 :related: gof-design-patterns, gof-command-pattern, gof-mediator-pattern

--- a/docs/anchors/gof-command-pattern.de.adoc
+++ b/docs/anchors/gof-command-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, command, undo, queue, encapsulation, action
 :related: gof-design-patterns, gof-chain-of-responsibility-pattern, gof-memento-pattern

--- a/docs/anchors/gof-composite-pattern.de.adoc
+++ b/docs/anchors/gof-composite-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, composite, tree, hierarchy, part-whole
 :related: gof-design-patterns, gof-decorator-pattern, gof-iterator-pattern

--- a/docs/anchors/gof-decorator-pattern.de.adoc
+++ b/docs/anchors/gof-decorator-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, decorator, wrapper, dynamic behavior, composition
 :related: gof-design-patterns, gof-composite-pattern, gof-proxy-pattern

--- a/docs/anchors/gof-design-patterns.de.adoc
+++ b/docs/anchors/gof-design-patterns.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, educator
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
+:tier: 3
 :related: solid-principles, fowler-patterns, clean-architecture
 :tags: design-patterns, gang-of-four, oop, creational, structural, behavioral
 :sub-anchors: gof-strategy-pattern, gof-observer-pattern, gof-factory-method-pattern, gof-singleton-pattern, gof-adapter-pattern, gof-decorator-pattern, gof-command-pattern, gof-facade-pattern, gof-template-method-pattern, gof-builder-pattern, gof-state-pattern, gof-proxy-pattern, gof-abstract-factory-pattern, gof-composite-pattern, gof-iterator-pattern, gof-mediator-pattern, gof-chain-of-responsibility-pattern, gof-bridge-pattern, gof-prototype-pattern, gof-flyweight-pattern, gof-interpreter-pattern, gof-memento-pattern, gof-visitor-pattern

--- a/docs/anchors/gof-facade-pattern.de.adoc
+++ b/docs/anchors/gof-facade-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, facade, simplification, subsystem, unified interface
 :related: gof-design-patterns, gof-adapter-pattern, gof-mediator-pattern

--- a/docs/anchors/gof-factory-method-pattern.de.adoc
+++ b/docs/anchors/gof-factory-method-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, factory, polymorphism, instantiation
 :related: gof-design-patterns, gof-abstract-factory-pattern, gof-template-method-pattern

--- a/docs/anchors/gof-iterator-pattern.de.adoc
+++ b/docs/anchors/gof-iterator-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, iterator, traversal, collection, aggregate
 :related: gof-design-patterns, gof-composite-pattern, gof-visitor-pattern

--- a/docs/anchors/gof-mediator-pattern.de.adoc
+++ b/docs/anchors/gof-mediator-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, mediator, loose coupling, coordination, hub
 :related: gof-design-patterns, gof-observer-pattern, gof-facade-pattern

--- a/docs/anchors/gof-observer-pattern.de.adoc
+++ b/docs/anchors/gof-observer-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, observer, publish-subscribe, event, notification, reactive
 :related: gof-design-patterns, gof-mediator-pattern, gof-strategy-pattern

--- a/docs/anchors/gof-prototype-pattern.de.adoc
+++ b/docs/anchors/gof-prototype-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 2
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, prototype, cloning, copy, object creation
 :related: gof-design-patterns, gof-abstract-factory-pattern, gof-builder-pattern

--- a/docs/anchors/gof-proxy-pattern.de.adoc
+++ b/docs/anchors/gof-proxy-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, structural, proxy, access control, lazy loading, caching, virtual proxy
 :related: gof-design-patterns, gof-decorator-pattern, gof-adapter-pattern

--- a/docs/anchors/gof-singleton-pattern.de.adoc
+++ b/docs/anchors/gof-singleton-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, creational, singleton, global state, instance control
 :related: gof-design-patterns, gof-abstract-factory-pattern

--- a/docs/anchors/gof-state-pattern.de.adoc
+++ b/docs/anchors/gof-state-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, state, state machine, finite automaton, context
 :related: gof-design-patterns, gof-strategy-pattern, gof-memento-pattern

--- a/docs/anchors/gof-strategy-pattern.de.adoc
+++ b/docs/anchors/gof-strategy-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, strategy
 :related: gof-design-patterns, gof-state-pattern, gof-template-method-pattern

--- a/docs/anchors/gof-template-method-pattern.de.adoc
+++ b/docs/anchors/gof-template-method-pattern.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: gof-design-patterns
-:tier: 1
+:tier: 3
 :proponents: Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides
 :tags: GoF, design pattern, behavioral, template method, algorithm skeleton, hook, inheritance
 :related: gof-design-patterns, gof-strategy-pattern, gof-factory-method-pattern

--- a/docs/anchors/gom.de.adoc
+++ b/docs/anchors/gom.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, business-analyst, consultant, team-lead
 :related: arc42, c4-diagrams, morphological-box
 :proponents: Jörg Becker, Michael Rosemann, Rolf Schütte
+:tier: 2
 :tags: modeling, enterprise-architecture, business-process, bpm, principles, quality
 
 [%collapsible]

--- a/docs/anchors/gutes-deutsch-wolf-schneider.de.adoc
+++ b/docs/anchors/gutes-deutsch-wolf-schneider.de.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, consultant, educator, business-analyst
 :related: bluf, pyramid-principle
 :proponents: Wolf Schneider
+:tier: 3
 :tags: writing, german, clarity, style, prose, language
 
 [%collapsible]

--- a/docs/anchors/hemingway-bridge.de.adoc
+++ b/docs/anchors/hemingway-bridge.de.adoc
@@ -2,6 +2,9 @@
 :categories: knowledge-management
 :roles: software-developer, technical-writer, educator, consultant
 :proponents: Tiago Forte, Ernest Hemingway
+:tags: productivity, session-management, creative-flow, re-entry, momentum, writer-block
+:related: gtd, para-method
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/heros-journey.de.adoc
+++ b/docs/anchors/heros-journey.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Joseph Campbell ("The Hero with a Thousand Faces"), Christopher Vogler ("The Writer's Journey")
+:tags: storytelling, monomyth, mythology, campbell, vogler, transformation, archetype, narrative, hero, call-to-adventure
+:related: three-act-structure, story-circle-dan-harmon, freytags-pyramid
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/hexagonal-architecture.de.adoc
+++ b/docs/anchors/hexagonal-architecture.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
+:tier: 3
 :tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
 :related: clean-architecture, domain-driven-design, separation-of-concerns
 

--- a/docs/anchors/iec-61508-sil-levels.de.adoc
+++ b/docs/anchors/iec-61508-sil-levels.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, software-architect, qa-engineer, devops-engineer, consultant
 :proponents: International Electrotechnical Commission (IEC)
+:tier: 3
 :related: testing-pyramid, mutation-testing
 :tags: safety, functional-safety, SIL, standards, certification, risk-assessment
 

--- a/docs/anchors/impact-mapping.de.adoc
+++ b/docs/anchors/impact-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, business-analyst, team-lead, consultant
 :proponents: Gojko Adzic
+:tier: 3
 :tags: impact mapping, Gojko Adzic, strategic planning, goals, deliverables, product
 :related: user-story-mapping, wardley-mapping, okr
 

--- a/docs/anchors/iso-25010.de.adoc
+++ b/docs/anchors/iso-25010.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, qa-engineer, product-owner, business-analyst, team-lead
 :related: atam, arc42, adr-according-to-nygard
 :proponents: ISO/IEC JTC 1/SC 7
+:tier: 3
 :tags: quality model, software quality, quality attributes, product quality, quality in use, assessment, ISO, IEC
 
 [%collapsible]

--- a/docs/anchors/jobs-to-be-done.de.adoc
+++ b/docs/anchors/jobs-to-be-done.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, ux-designer, business-analyst
 :proponents: Clayton Christensen, Alan Klement, Bob Moesta
+:tier: 3
 :tags: jobs to be done, JTBD, Christensen, customer needs, product, innovation
 :related: user-story-mapping, kano-model, mvp
 

--- a/docs/anchors/kishotenketsu.de.adoc
+++ b/docs/anchors/kishotenketsu.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Traditional Chinese and Japanese narrative tradition; Tzvetan Todorov (structural analysis)
+:tags: storytelling, narrative, four-act, japanese, chinese, ki-sho-ten-ketsu, twist, non-conflict, eastern, manga, haiku, recontextualisation
+:related: three-act-structure, story-circle-dan-harmon, heros-journey
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/kiss-principle.de.adoc
+++ b/docs/anchors/kiss-principle.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Kelly Johnson, Robert C. Martin
+:tier: 1
 :related: yagni, dry, solid-principles
 :tags: kiss, simplicity, design-principles, over-engineering, readability
 

--- a/docs/anchors/lasr.de.adoc
+++ b/docs/anchors/lasr.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, qa-engineer, team-lead, consultant
 :related: atam, arc42, quality-attribute-scenario
 :proponents: Stefan Toth, Stefan Zörner
+:tier: 3
 :tags: software-reviews, architecture-review, quality-attributes, risks, lightweight, atam-alternative
 
 [%collapsible]

--- a/docs/anchors/lehmans-classification.de.adoc
+++ b/docs/anchors/lehmans-classification.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, requirements-engineer, team-lead, educator
 :related: arc42, cohesion-criteria
 :proponents: Meir M. Lehman
+:tier: 2
 :tags: klassifikation, software-evolution, requirements, wartung, s-type, p-type, e-type
 
 [%collapsible]

--- a/docs/anchors/llm-evaluations.de.adoc
+++ b/docs/anchors/llm-evaluations.de.adoc
@@ -3,6 +3,7 @@
 :roles: data-scientist, software-developer, qa-engineer, software-architect
 :related: chain-of-thought, sota, mutation-testing
 :proponents: Percy Liang (Stanford HELM), EleutherAI (Open LLM Leaderboard), LMSYS (Chatbot Arena)
+:tier: 3
 :tags: llm, evaluation, benchmarks, metrics, leaderboard, nlp, ai
 
 [%collapsible]

--- a/docs/anchors/madr.de.adoc
+++ b/docs/anchors/madr.de.adoc
@@ -2,6 +2,7 @@
 :categories: software-architecture
 :roles: software-architect, software-developer, team-lead
 :proponents: Oliver Kopp, Olaf Zimmermann (and MADR community)
+:tier: 3
 :tags: MADR, markdown ADR, architecture decision record, decision documentation
 :related: adr-according-to-nygard, arc42
 

--- a/docs/anchors/mece.de.adoc
+++ b/docs/anchors/mece.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, software-architect, data-scientist
 :proponents: Barbara Minto
+:tier: 3
 :tags: MECE, mutually exclusive collectively exhaustive, Barbara Minto, structuring, McKinsey
 :related: pyramid-principle, bluf, morphological-box
 

--- a/docs/anchors/mental-model-according-to-naur.de.adoc
+++ b/docs/anchors/mental-model-according-to-naur.de.adoc
@@ -2,6 +2,8 @@
 :categories: development-workflow
 :roles: software-developer, team-lead, educator, consultant
 :proponents: Peter Naur
+:related: adr-according-to-nygard, docs-as-code
+:tier: 2
 :tags: theory building, Naur, programming as theory building, mental model, tacit knowledge, software maintenance
 
 [%collapsible]

--- a/docs/anchors/morphological-box.de.adoc
+++ b/docs/anchors/morphological-box.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, product-owner, consultant, software-developer
 :related: mece, pugh-matrix
 :proponents: Fritz Zwicky
+:tier: 3
 :tags: innovation, creativity, problem-solving, systematic-design, combinatorial-analysis
 
 [%collapsible]

--- a/docs/anchors/moscow.de.adoc
+++ b/docs/anchors/moscow.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, consultant
 :related: user-story-mapping, impact-mapping
 :proponents: Dai Clegg
+:tier: 3
 :tags: prioritization, requirements, agile, dsdm
 
 [%collapsible]

--- a/docs/anchors/mutation-testing.de.adoc
+++ b/docs/anchors/mutation-testing.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Richard Lipton (theoretical foundation, 1971), Richard DeMillo, Timothy Budd
+:tier: 3
 :tags: mutation testing, test quality, fault injection, test effectiveness, coverage
 :related: property-based-testing, testing-pyramid
 

--- a/docs/anchors/nelson-rules.de.adoc
+++ b/docs/anchors/nelson-rules.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer
 :proponents: Lloyd S. Nelson
+:tier: 3
 :tags: Nelson rules, control chart, SPC, statistical process control, out of control
 :related: control-chart-shewhart, spc
 

--- a/docs/anchors/owasp-top-10.de.adoc
+++ b/docs/anchors/owasp-top-10.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, software-architect, qa-engineer, devops-engineer, consultant, team-lead
 :related: regulated-environment, iec-61508-sil-levels
 :proponents: OWASP Foundation
+:tier: 3
 :tags: security, web-security, vulnerabilities, risk, appsec, owasp
 
 [%collapsible]

--- a/docs/anchors/pert.de.adoc
+++ b/docs/anchors/pert.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, team-lead, consultant, educator
 :related: moscow, user-story-mapping, impact-mapping
 :proponents: D.G. Malcolm, J.H. Roseboom, C.E. Clark, W. Fazar
+:tier: 2
 :tags: pert, project-planning, estimation, schedule, uncertainty, three-point-estimation, critical-path, network-diagram
 
 [%collapsible]

--- a/docs/anchors/plain-english-strunk-white.de.adoc
+++ b/docs/anchors/plain-english-strunk-white.de.adoc
@@ -3,6 +3,7 @@
 :roles: technical-writer, software-developer, consultant, educator, business-analyst
 :related: gutes-deutsch-wolf-schneider, bluf, pyramid-principle
 :proponents: William Strunk Jr., E.B. White
+:tier: 3
 :tags: writing, english, clarity, style, prose, language, plain-english
 
 [%collapsible]

--- a/docs/anchors/problem-space-nvc.de.adoc
+++ b/docs/anchors/problem-space-nvc.de.adoc
@@ -1,7 +1,8 @@
 = Problem Space NVC
-:categories: requirements-engineering
-:roles: business-analyst, product-owner, consultant, ux-designer
+:categories: requirements-engineering, communication-presentation
+:roles: business-analyst, product-owner, consultant, ux-designer, team-lead
 :proponents: Marshall Rosenberg
+:tier: 3
 :tags: nvc, communication, empathy, conflict-resolution, requirements
 :related: jobs-to-be-done, impact-mapping, user-story-mapping
 

--- a/docs/anchors/property-based-testing.de.adoc
+++ b/docs/anchors/property-based-testing.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer
 :proponents: Koen Claessen, John Hughes (QuickCheck)
+:tier: 3
 :tags: property-based testing, QuickCheck, invariants, generative testing, Hypothesis
 :related: mutation-testing, testing-pyramid
 

--- a/docs/anchors/pugh-matrix.de.adoc
+++ b/docs/anchors/pugh-matrix.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: software-architect, team-lead, product-owner
 :proponents: Stuart Pugh
+:tier: 2
 :tags: Pugh matrix, decision matrix, Stuart Pugh, trade-off analysis, weighted criteria
 :related: morphological-box, swot, decisional-balance-sheet
 

--- a/docs/anchors/pyramid-principle.de.adoc
+++ b/docs/anchors/pyramid-principle.de.adoc
@@ -2,6 +2,7 @@
 :categories: communication-presentation
 :roles: business-analyst, consultant, team-lead, technical-writer
 :proponents: Barbara Minto
+:tier: 3
 :tags: pyramid principle, Barbara Minto, structured communication, top-down, writing
 :related: mece, bluf, inverted-pyramid-style
 

--- a/docs/anchors/regulated-environment.de.adoc
+++ b/docs/anchors/regulated-environment.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, software-architect, qa-engineer, devops-engineer, team-lead, consultant, business-analyst
 :related: iec-61508-sil-levels, docs-as-code, conventional-commits, semantic-versioning
 :proponents: FDA (21 CFR Part 11), EMA (GMP Annex 11), ISO 9001, IEC 62304, GAMP 5
+:tier: 2
 :tags: compliance, validation, traceability, audit-trail, change-control, documentation, GxP, FDA, IEC, ISO
 
 [%collapsible]

--- a/docs/anchors/save-the-cat.de.adoc
+++ b/docs/anchors/save-the-cat.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Blake Snyder ("Save the Cat! The Last Book on Screenwriting You'll Ever Need")
+:tags: storytelling, screenplay, beats, blake-snyder, commercial, plot, structure, save-the-cat, beat-sheet, genre
+:related: three-act-structure, freytags-pyramid, fichtean-curve
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/semantic-versioning.de.adoc
+++ b/docs/anchors/semantic-versioning.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, devops-engineer, product-owner
 :proponents: Tom Preston-Werner
+:tier: 3
 :tags: semantic versioning, SemVer, versioning, major minor patch, Tom Preston-Werner
 :related: conventional-commits, twelve-factor-app
 

--- a/docs/anchors/socratic-method.de.adoc
+++ b/docs/anchors/socratic-method.de.adoc
@@ -2,6 +2,7 @@
 :categories: dialogue-interaction
 :roles: educator, consultant, team-lead
 :proponents: Socrates, Plato
+:tier: 3
 :tags: Socratic method, questioning, dialogue, Socrates, critical thinking, inquiry
 :related: five-whys, devils-advocate, laddering
 

--- a/docs/anchors/solid-dip.de.adoc
+++ b/docs/anchors/solid-dip.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: solid-principles
-:tier: 1
+:tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, DIP, dependency inversion
 :related: solid-principles, solid-srp, solid-ocp, solid-lsp, solid-isp

--- a/docs/anchors/solid-isp.de.adoc
+++ b/docs/anchors/solid-isp.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: solid-principles
-:tier: 1
+:tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, ISP, interface segregation
 :related: solid-principles, solid-dip, solid-srp

--- a/docs/anchors/solid-lsp.de.adoc
+++ b/docs/anchors/solid-lsp.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: solid-principles
-:tier: 1
+:tier: 3
 :proponents: Robert C. Martin, Barbara Liskov
 :tags: SOLID, design principle, LSP, liskov, substitution
 :related: solid-principles, solid-ocp, solid-dip

--- a/docs/anchors/solid-ocp.de.adoc
+++ b/docs/anchors/solid-ocp.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: solid-principles
-:tier: 1
+:tier: 3
 :proponents: Robert C. Martin, Bertrand Meyer
 :tags: SOLID, design principle, OCP, open closed
 :related: solid-principles, solid-lsp, solid-srp

--- a/docs/anchors/solid-principles.de.adoc
+++ b/docs/anchors/solid-principles.de.adoc
@@ -2,6 +2,9 @@
 :categories: design-principles
 :roles: software-developer, software-architect, educator, consultant
 :proponents: Robert C. Martin
+:tags: design-principles, oop, solid, uncle-bob
+:related: gof-design-patterns, clean-architecture
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/solid-srp.de.adoc
+++ b/docs/anchors/solid-srp.de.adoc
@@ -2,7 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect
 :umbrella: solid-principles
-:tier: 1
+:tier: 3
 :proponents: Robert C. Martin
 :tags: SOLID, design principle, SRP, single responsibility
 :related: solid-principles, separation-of-concerns, single-level-of-abstraction-principle

--- a/docs/anchors/sota.de.adoc
+++ b/docs/anchors/sota.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, data-scientist, consultant
 :proponents: Community
+:tier: 3
 :tags: SOTA, state of the art, benchmark, current best, research
 :related: llm-evaluations, first-principles-thinking
 

--- a/docs/anchors/spc.de.adoc
+++ b/docs/anchors/spc.de.adoc
@@ -2,6 +2,7 @@
 :categories: statistical-methods
 :roles: data-scientist, devops-engineer, team-lead, qa-engineer
 :proponents: Walter A. Shewhart (founder), W. Edwards Deming (dissemination), Western Electric Company
+:tier: 3
 :tags: SPC, statistical process control, control charts, Shewhart, quality, variation
 :related: control-chart-shewhart, nelson-rules
 

--- a/docs/anchors/ssot-principle.de.adoc
+++ b/docs/anchors/ssot-principle.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-architect, data-scientist, business-analyst
 :proponents: Community
+:tier: 1
 :tags: SSOT, single source of truth, data consistency, canonical source, DRY
 :related: dry, single-level-of-abstraction-principle, separation-of-concerns
 

--- a/docs/anchors/story-circle-dan-harmon.de.adoc
+++ b/docs/anchors/story-circle-dan-harmon.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Dan Harmon (Community, Rick and Morty)
+:tags: storytelling, narrative, circle, harmon, campbell, eight-steps, transformation, want-need, television, episodic
+:related: heros-journey, three-act-structure, kishotenketsu
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/stride.de.adoc
+++ b/docs/anchors/stride.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-developer, software-architect, qa-engineer, devops-engineer, consultant, team-lead
 :related: owasp-top-10, regulated-environment
 :proponents: Loren Kohnfelder, Praerit Garg, Adam Shostack
+:tier: 3
 :tags: security, threat-modeling, appsec, risk, threats
 
 [%collapsible]

--- a/docs/anchors/swot.de.adoc
+++ b/docs/anchors/swot.de.adoc
@@ -3,6 +3,7 @@
 :roles: product-owner, business-analyst, consultant, team-lead, software-architect
 :related: pugh-matrix, wardley-mapping, moscow
 :proponents: Albert Humphrey
+:tier: 3
 :tags: swot, strategic-planning, analysis, strengths, weaknesses, opportunities, threats, business-analysis
 
 [%collapsible]

--- a/docs/anchors/tdd-london-school.de.adoc
+++ b/docs/anchors/tdd-london-school.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, software-architect
 :proponents: Steve Freeman, Nat Pryce ("Growing Object-Oriented Software, Guided by Tests")
+:tier: 3
 :tags: TDD, London school, mockist, outside-in, Freeman, Pryce, interaction testing, mocks
 :related: tdd-chicago-school, red-green-tdd, test-double-mock
 

--- a/docs/anchors/test-double-meszaros.de.adoc
+++ b/docs/anchors/test-double-meszaros.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, educator
 :proponents: Gerard Meszaros
+:tier: 3
 :related: tdd-london-school, tdd-chicago-school, property-based-testing
 :tags: test-double, mock, stub, spy, fake, dummy, xunit, testing, isolation
 

--- a/docs/anchors/testing-pyramid.de.adoc
+++ b/docs/anchors/testing-pyramid.de.adoc
@@ -2,6 +2,7 @@
 :categories: testing-quality
 :roles: software-developer, qa-engineer, team-lead, devops-engineer
 :proponents: Mike Cohn
+:tier: 3
 :tags: testing pyramid, unit tests, integration tests, e2e, test strategy, Mike Cohn
 :related: tdd-london-school, tdd-chicago-school, mutation-testing
 

--- a/docs/anchors/three-act-structure.de.adoc
+++ b/docs/anchors/three-act-structure.de.adoc
@@ -2,6 +2,9 @@
 :categories: creative-writing
 :roles: technical-writer, educator, consultant
 :proponents: Aristotle ("Poetics"), Syd Field ("Screenplay"), Robert McKee ("Story")
+:tags: storytelling, narrative, screenplay, plot, structure, fiction, three-acts, setup, confrontation, resolution
+:related: heros-journey, freytags-pyramid, save-the-cat, fichtean-curve, story-circle-dan-harmon
+:tier: 3
 
 [%collapsible]
 ====

--- a/docs/anchors/timtowtdi.de.adoc
+++ b/docs/anchors/timtowtdi.de.adoc
@@ -2,6 +2,7 @@
 :categories: development-workflow
 :roles: software-developer, software-architect, consultant, educator
 :proponents: Larry Wall
+:tier: 1
 :tags: TIMTOWTDI, there is more than one way to do it, Perl, Larry Wall, flexibility
 :related: unix-philosophy, effective-go, kiss-principle
 

--- a/docs/anchors/todotxt-flavoured-markdown.de.adoc
+++ b/docs/anchors/todotxt-flavoured-markdown.de.adoc
@@ -2,6 +2,7 @@
 :categories: knowledge-management
 :roles: software-developer, team-lead, technical-writer
 :proponents: Combines GitHub-flavoured Markdown task lists with Gina Trapani's todo.txt format
+:tier: 3
 :tags: todo.txt, task management, markdown, Gina Trapani, plain text, task lists
 :related: gtd, para-method
 

--- a/docs/anchors/user-story-mapping.de.adoc
+++ b/docs/anchors/user-story-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: requirements-engineering
 :roles: product-owner, business-analyst, team-lead, ux-designer
 :proponents: Jeff Patton
+:tier: 3
 :tags: user story mapping, Jeff Patton, backlog, product, user journey, stories
 :related: impact-mapping, invest, mvp
 

--- a/docs/anchors/vertical-slice-architecture.de.adoc
+++ b/docs/anchors/vertical-slice-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :related: clean-architecture, hexagonal-architecture, cqrs
 :proponents: Jimmy Bogard
+:tier: 3
 :tags: feature slices, vertical slices, VSA, feature cohesion, CQRS
 
 [%collapsible]

--- a/docs/anchors/wardley-mapping.de.adoc
+++ b/docs/anchors/wardley-mapping.de.adoc
@@ -2,6 +2,7 @@
 :categories: strategic-planning
 :roles: product-owner, software-architect, consultant, team-lead
 :proponents: Simon Wardley
+:tier: 3
 :tags: Wardley mapping, value chain, strategy, evolution, Simon Wardley
 :related: cynefin-framework, impact-mapping, swot
 

--- a/docs/anchors/what-qualifies-as-a-semantic-anchor.de.adoc
+++ b/docs/anchors/what-qualifies-as-a-semantic-anchor.de.adoc
@@ -2,6 +2,7 @@
 :categories: meta
 :roles: educator, consultant
 :proponents: Ralf D. Müller (Semantic Anchors project)
+:tier: 3
 :tags: semantic anchor, meta, criteria, quality, anchor definition, activation
 
 === Was qualifiziert als semantischer Anker

--- a/docs/anchors/yagni.de.adoc
+++ b/docs/anchors/yagni.de.adoc
@@ -2,6 +2,7 @@
 :categories: design-principles
 :roles: software-developer, software-architect, consultant
 :proponents: Ron Jeffries, Kent Beck
+:tier: 1
 :related: dry, ssot-principle, tdd-chicago-school, kiss-principle
 :tags: yagni, extreme-programming, simplicity, incremental-design, over-engineering
 

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -2,6 +2,12 @@
 
 A chronological record of all semantic anchors added to the catalog. Community contributors are credited with thanks.
 
+== 2026-07-08
+
+*Fix — EN/DE metadata parity:*
+
+* A parity audit found 121 metadata drifts between anchors' English and German files: `:tier:` was missing from ~90 German files, the GoF-pattern and SOLID German files carried tiers inconsistent with their English source (EN 3 vs DE 1/2), and several narrative anchors (three-act-structure, hero's-journey, save-the-cat, …) had `:related:` / `:tags:` only in English; `problem-space-nvc.de` was also missing a category and a role. Synced all identifier/number metadata (`:categories:`, `:roles:`, `:tier:`, `:related:`, `:tags:`) from the authoritative English files to their German counterparts across 100 files. Two `:proponents:` fields keep their localized German phrasing, by design.
+
 == 2026-07-07
 
 *Fix — dead `:related:` links:*


### PR DESCRIPTION
A systematic parity audit of every anchor's English vs German file found **121 metadata drifts** — the same class of drift I'd been fixing ad hoc (MBTI tier, tdd-chicago tier, problem-space-nvc). Rather than keep patching individually, this syncs them all.

## Drifts found
- **`:tier:` missing from ~90 German files** — most DE files never carried the tier.
- **GoF-pattern & SOLID German tiers inconsistent with English** — EN uniformly `3`, DE a mix of `1`/`2`. EN is the authoritative, internally-consistent source.
- **`:related:` / `:tags:` English-only** on several narrative anchors (three-act-structure, hero's-journey, save-the-cat, freytags-pyramid, kishotenketsu, story-circle, solid-principles, …).
- **`problem-space-nvc.de`** missing a category (`communication-presentation`) and a role (`team-lead`).

## Fix
Synced all identifier/number metadata (`:categories:`, `:roles:`, `:tier:`, `:related:`, `:tags:`) from the English files to their German counterparts — **0 hard drifts remain**. Two `:proponents:` fields (bem-methodology, bluf) keep their intentional localized German phrasing.

Verified: parity re-scan clean, renders OK. Generated data not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Viele Dokumentseiten wurden um einheitliche Metadaten ergänzt oder aktualisiert.
  * Dadurch sind Inhalte jetzt konsistenter kategorisiert und besser verknüpft.
  * Mehrere deutschsprachige Seiten erhielten fehlende Angaben wie Einstufung, Verweise und Schlagwörter.
  * Ein Changelog-Eintrag dokumentiert die bereinigte Metadaten-Synchronisierung über die betroffenen Seiten hinweg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->