### PR TITLE
spike: optional :systemic-dimensions: lens on 12 anchors (#519)

### DIFF
--- a/docs/anchors/_template.adoc
+++ b/docs/anchors/_template.adoc
@@ -5,6 +5,10 @@
 :proponents: Author Name, Another Author
 :tags: tag1, tag2, tag3
 :tier: 3
+// Optional experimental lens (#519 spike): the systemic dimensions an anchor
+// operates in. Any of: boundary, emergence, feedback, resilience. Omit unless
+// the anchor is genuinely *about* one of them (not every anchor is).
+//:systemic-dimensions: boundary, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/cap-theorem.adoc
+++ b/docs/anchors/cap-theorem.adoc
@@ -5,6 +5,7 @@
 :proponents: Eric Brewer, Seth Gilbert, Nancy Lynch
 :tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc
 :tier: 3
+:systemic-dimensions: boundary, resilience
 
 [%collapsible]
 ====

--- a/docs/anchors/cap-theorem.de.adoc
+++ b/docs/anchors/cap-theorem.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Eric Brewer, Seth Gilbert, Nancy Lynch
 :tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc
 :tier: 3
+:systemic-dimensions: boundary, resilience
 
 [%collapsible]
 ====

--- a/docs/anchors/circuit-breaker.adoc
+++ b/docs/anchors/circuit-breaker.adoc
@@ -5,6 +5,7 @@
 :proponents: Michael Nygard, Martin Fowler
 :tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
 :tier: 2
+:systemic-dimensions: resilience, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/circuit-breaker.de.adoc
+++ b/docs/anchors/circuit-breaker.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Michael Nygard, Martin Fowler
 :tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
 :tier: 2
+:systemic-dimensions: resilience, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/clean-architecture.adoc
+++ b/docs/anchors/clean-architecture.adoc
@@ -5,6 +5,7 @@
 :tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
 :related: hexagonal-architecture, domain-driven-design, solid-principles
 :tier: 3
+:systemic-dimensions: boundary
 :definition: Clean Architecture, formulated by Robert C. Martin, organises code into concentric layers whose dependencies point only inward toward the domain. Business rules sit at the centre, independent of frameworks, UI, and databases at the outer edges. The Dependency Rule keeps the core testable and insulated from external change.
 
 [%collapsible]

--- a/docs/anchors/clean-architecture.de.adoc
+++ b/docs/anchors/clean-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Robert C. Martin
 :tier: 3
+:systemic-dimensions: boundary
 :tags: clean architecture, dependency rule, layers, Robert C. Martin, ports and adapters
 :related: hexagonal-architecture, domain-driven-design, solid-principles
 

--- a/docs/anchors/conways-law.adoc
+++ b/docs/anchors/conways-law.adoc
@@ -5,6 +5,7 @@
 :proponents: Melvin E. Conway
 :tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical
 :tier: 3
+:systemic-dimensions: boundary, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/conways-law.de.adoc
+++ b/docs/anchors/conways-law.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Melvin E. Conway
 :tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical
 :tier: 3
+:systemic-dimensions: boundary, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/cynefin-framework.adoc
+++ b/docs/anchors/cynefin-framework.adoc
@@ -5,6 +5,7 @@
 :related: wardley-mapping
 :tags: complexity, decision-making, sensemaking, strategy, domains
 :tier: 3
+:systemic-dimensions: emergence, boundary
 :definition: Cynefin, created by Dave Snowden, is a sense-making framework that sorts situations into five domains — Clear, Complicated, Complex, Chaotic, and Disorder — each with a different cause-and-effect relationship. It helps choose the right response, from applying best practice in ordered domains to probing and experimenting in the complex one.
 
 [%collapsible]

--- a/docs/anchors/cynefin-framework.de.adoc
+++ b/docs/anchors/cynefin-framework.de.adoc
@@ -3,6 +3,7 @@
 :roles: team-lead, consultant, product-owner, software-architect
 :proponents: Dave Snowden
 :tier: 3
+:systemic-dimensions: emergence, boundary
 :related: wardley-mapping
 :tags: complexity, decision-making, sensemaking, strategy, domains
 

--- a/docs/anchors/domain-driven-design.adoc
+++ b/docs/anchors/domain-driven-design.adoc
@@ -5,6 +5,7 @@
 :tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
 :related: hexagonal-architecture, clean-architecture, event-storming
 :tier: 3
+:systemic-dimensions: boundary
 :definition: Domain-Driven Design, introduced by Eric Evans, tackles complex software by centring the design on the business domain. A shared Ubiquitous Language unites developers and domain experts, Bounded Contexts delimit models, and tactical patterns — entities, value objects, aggregates, repositories — express the domain directly in code.
 
 [%collapsible]

--- a/docs/anchors/domain-driven-design.de.adoc
+++ b/docs/anchors/domain-driven-design.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, business-analyst, team-lead
 :proponents: Eric Evans
 :tier: 3
+:systemic-dimensions: boundary
 :tags: DDD, domain-driven design, bounded context, ubiquitous language, aggregates, Eric Evans
 :related: hexagonal-architecture, clean-architecture, event-storming
 

--- a/docs/anchors/event-driven-architecture.adoc
+++ b/docs/anchors/event-driven-architecture.adoc
@@ -5,6 +5,7 @@
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
 :tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
 :tier: 3
+:systemic-dimensions: feedback, emergence
 
 [%collapsible]
 ====

--- a/docs/anchors/event-driven-architecture.de.adoc
+++ b/docs/anchors/event-driven-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer, devops-engineer
 :proponents: Gregor Hohpe, Bobby Woolf, Martin Fowler
 :tier: 3
+:systemic-dimensions: feedback, emergence
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
 :tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
 

--- a/docs/anchors/fallacies-of-distributed-computing.adoc
+++ b/docs/anchors/fallacies-of-distributed-computing.adoc
@@ -5,6 +5,7 @@
 :proponents: L. Peter Deutsch, James Gosling
 :tags: distributed-systems, networking, reliability, latency, fallacies, resilience
 :tier: 3
+:systemic-dimensions: resilience, boundary
 
 [%collapsible]
 ====

--- a/docs/anchors/fallacies-of-distributed-computing.de.adoc
+++ b/docs/anchors/fallacies-of-distributed-computing.de.adoc
@@ -5,6 +5,7 @@
 :proponents: L. Peter Deutsch, James Gosling
 :tags: distributed-systems, networking, reliability, latency, fallacies, resilience
 :tier: 3
+:systemic-dimensions: resilience, boundary
 
 [%collapsible]
 ====

--- a/docs/anchors/hexagonal-architecture.adoc
+++ b/docs/anchors/hexagonal-architecture.adoc
@@ -5,6 +5,7 @@
 :tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
 :related: clean-architecture, domain-driven-design, separation-of-concerns
 :tier: 3
+:systemic-dimensions: boundary
 
 [%collapsible]
 ====

--- a/docs/anchors/hexagonal-architecture.de.adoc
+++ b/docs/anchors/hexagonal-architecture.de.adoc
@@ -3,6 +3,7 @@
 :roles: software-architect, software-developer
 :proponents: Alistair Cockburn
 :tier: 3
+:systemic-dimensions: boundary
 :tags: hexagonal architecture, ports and adapters, Cockburn, isolation, boundaries
 :related: clean-architecture, domain-driven-design, separation-of-concerns
 

--- a/docs/anchors/site-reliability-engineering.adoc
+++ b/docs/anchors/site-reliability-engineering.adoc
@@ -5,6 +5,7 @@
 :proponents: Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
 :tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil
 :tier: 3
+:systemic-dimensions: resilience, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/site-reliability-engineering.de.adoc
+++ b/docs/anchors/site-reliability-engineering.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
 :tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil
 :tier: 3
+:systemic-dimensions: resilience, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/strangler-fig.adoc
+++ b/docs/anchors/strangler-fig.adoc
@@ -5,6 +5,7 @@
 :proponents: Martin Fowler
 :tags: legacy-modernization, migration, refactoring, incremental, facade
 :tier: 2
+:systemic-dimensions: boundary, resilience
 
 [%collapsible]
 ====

--- a/docs/anchors/strangler-fig.de.adoc
+++ b/docs/anchors/strangler-fig.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Martin Fowler
 :tags: legacy-modernization, migration, refactoring, incremental, facade
 :tier: 2
+:systemic-dimensions: boundary, resilience
 
 [%collapsible]
 ====

--- a/docs/anchors/team-topologies.adoc
+++ b/docs/anchors/team-topologies.adoc
@@ -5,6 +5,7 @@
 :proponents: Matthew Skelton, Manuel Pais
 :tags: org-design, team-structure, cognitive-load, conways-law, flow
 :tier: 2
+:systemic-dimensions: boundary, feedback
 
 [%collapsible]
 ====

--- a/docs/anchors/team-topologies.de.adoc
+++ b/docs/anchors/team-topologies.de.adoc
@@ -5,6 +5,7 @@
 :proponents: Matthew Skelton, Manuel Pais
 :tags: org-design, team-structure, cognitive-load, conways-law, flow
 :tier: 2
+:systemic-dimensions: boundary, feedback
 
 [%collapsible]
 ====

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -119,6 +119,9 @@ function parseAnchorFile(filePath) {
     related: parseList(attributes.related),
     proponents: parseList(attributes.proponents),
     tags: parseList(attributes.tags),
+    // Optional systemic-dimensions lens (#519 spike): a searchable tag over the
+    // four systemic dimensions — boundary, emergence, feedback, resilience.
+    systemicDimensions: parseList(attributes['systemic-dimensions']),
     filePath: `docs/anchors/${id}.adoc`,
   }
 
@@ -287,6 +290,8 @@ function generateMetadata(anchors, categories, roles) {
       ).toFixed(2),
       anchorsWithTags: anchors.filter((a) => a.tags.length > 0).length,
       anchorsWithRelated: anchors.filter((a) => a.related.length > 0).length,
+      anchorsWithSystemicDimensions: anchors.filter((a) => a.systemicDimensions.length > 0)
+        .length,
     },
   }
 }


### PR DESCRIPTION
A **bounded, throwaway-able spike** for #519 (systemic/human dimensions), per the maintainer's decision to test the idea before any catalog-wide rollout.

## Scope (deliberately small)
- **One axis only** — the four *systemic* dimensions (`boundary`, `emergence`, `feedback`, `resilience`). The four *human* dimensions are intentionally left out until this proves out.
- **One optional attribute** `:systemic-dimensions:`, parsed in `extract-metadata.js` (+ a `anchorsWithSystemicDimensions` stat for evaluation) and documented as optional/experimental in `_template.adoc`.
- **12 anchors tagged** (EN + DE), only where the dimension genuinely fits:
  - `cynefin-framework` → emergence, boundary
  - `circuit-breaker`, `site-reliability-engineering` → resilience, feedback
  - `domain-driven-design`, `clean-architecture`, `hexagonal-architecture` → boundary
  - `conways-law`, `team-topologies` → boundary, feedback
  - `event-driven-architecture` → feedback, emergence
  - `strangler-fig`, `cap-theorem`, `fallacies-of-distributed-computing` → boundary/resilience

## Explicitly NOT in scope (phase 2, only if the lens earns its keep)
- No website filter, no changelog entry, no human dimensions, no catalog-wide enrichment.

## Evaluation question
Does tagging these 12 make the systemic lens feel useful/discoverable — enough to justify (a) a website filter and (b) enriching the rest? If not, revert; it's a spike.

**Related decision (#518a):** recorded on #518 — *"Semantic Contract" is not renamed to "Structural Coupling Contract"* (load-bearing term; niche replacement; high churn). A future system-theory contract concept gets its own distinct name instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Dokument-Anchor-Seiten wurden um zusätzliche Metadaten für „systemic dimensions“ erweitert.
  * Die Metadaten-Auswertung erfasst nun diese Dimensionen und zählt entsprechende Einträge mit.

* **Dokumentation**
  * Mehrere englische und deutsche Anchor-Seiten sind jetzt mit passenden systemischen Dimensionen gekennzeichnet, z. B. für Boundary, Resilience, Feedback, Emergence und ähnliche Themen.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->