### PR TITLE
chore: fold useful systemic dimensions into tags (#519)

### DIFF
--- a/docs/anchors/cap-theorem.adoc
+++ b/docs/anchors/cap-theorem.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, data-scientist, devops-engineer
 :related: event-driven-architecture, fallacies-of-distributed-computing
 :proponents: Eric Brewer, Seth Gilbert, Nancy Lynch
-:tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc
+:tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc, resilience
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/cap-theorem.de.adoc
+++ b/docs/anchors/cap-theorem.de.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, data-scientist, devops-engineer
 :related: event-driven-architecture, fallacies-of-distributed-computing
 :proponents: Eric Brewer, Seth Gilbert, Nancy Lynch
-:tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc
+:tags: cap, distributed-systems, consistency, availability, partition-tolerance, pacelc, resilience
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/circuit-breaker.adoc
+++ b/docs/anchors/circuit-breaker.adoc
@@ -3,7 +3,7 @@
 :roles: software-developer, software-architect, devops-engineer
 :related: fallacies-of-distributed-computing, cap-theorem, event-driven-architecture
 :proponents: Michael Nygard, Martin Fowler
-:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
+:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast, feedback
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/circuit-breaker.de.adoc
+++ b/docs/anchors/circuit-breaker.de.adoc
@@ -3,7 +3,7 @@
 :roles: software-developer, software-architect, devops-engineer
 :related: fallacies-of-distributed-computing, cap-theorem, event-driven-architecture
 :proponents: Michael Nygard, Martin Fowler
-:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast
+:tags: resilience, fault-tolerance, stability-pattern, microservices, fail-fast, feedback
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/conways-law.adoc
+++ b/docs/anchors/conways-law.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, team-lead, product-owner, consultant
 :related: domain-driven-design, cohesion-criteria, vertical-slice-architecture
 :proponents: Melvin E. Conway
-:tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical
+:tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical, feedback
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/conways-law.de.adoc
+++ b/docs/anchors/conways-law.de.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, team-lead, product-owner, consultant
 :related: domain-driven-design, cohesion-criteria, vertical-slice-architecture
 :proponents: Melvin E. Conway
-:tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical
+:tags: conways-law, organization, architecture, team-topologies, communication-structure, sociotechnical, feedback
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/cynefin-framework.adoc
+++ b/docs/anchors/cynefin-framework.adoc
@@ -3,7 +3,7 @@
 :roles: team-lead, consultant, product-owner, software-architect
 :proponents: Dave Snowden
 :related: wardley-mapping
-:tags: complexity, decision-making, sensemaking, strategy, domains
+:tags: complexity, decision-making, sensemaking, strategy, domains, emergence
 :tier: 3
 :definition: Cynefin, created by Dave Snowden, is a sense-making framework that sorts situations into five domains — Clear, Complicated, Complex, Chaotic, and Disorder — each with a different cause-and-effect relationship. It helps choose the right response, from applying best practice in ordered domains to probing and experimenting in the complex one.
 

--- a/docs/anchors/cynefin-framework.de.adoc
+++ b/docs/anchors/cynefin-framework.de.adoc
@@ -4,7 +4,7 @@
 :proponents: Dave Snowden
 :tier: 3
 :related: wardley-mapping
-:tags: complexity, decision-making, sensemaking, strategy, domains
+:tags: complexity, decision-making, sensemaking, strategy, domains, emergence
 
 [%collapsible]
 ====

--- a/docs/anchors/event-driven-architecture.adoc
+++ b/docs/anchors/event-driven-architecture.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, software-developer, devops-engineer
 :proponents: Gregor Hohpe, Bobby Woolf, Martin Fowler
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
-:tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
+:tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency, feedback, emergence
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/event-driven-architecture.de.adoc
+++ b/docs/anchors/event-driven-architecture.de.adoc
@@ -4,7 +4,7 @@
 :proponents: Gregor Hohpe, Bobby Woolf, Martin Fowler
 :tier: 3
 :related: domain-driven-design, hexagonal-architecture, clean-architecture
-:tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency
+:tags: eda, events, async, messaging, publish-subscribe, decoupling, eventual-consistency, feedback, emergence
 
 [%collapsible]
 ====

--- a/docs/anchors/site-reliability-engineering.adoc
+++ b/docs/anchors/site-reliability-engineering.adoc
@@ -3,7 +3,7 @@
 :roles: devops-engineer, software-architect, team-lead, software-developer
 :related: five-whys, spc, control-chart-shewhart
 :proponents: Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
-:tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil
+:tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil, resilience, feedback
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/site-reliability-engineering.de.adoc
+++ b/docs/anchors/site-reliability-engineering.de.adoc
@@ -3,7 +3,7 @@
 :roles: devops-engineer, software-architect, team-lead, software-developer
 :related: five-whys, spc, control-chart-shewhart
 :proponents: Ben Treynor Sloss, Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
-:tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil
+:tags: sre, reliability, slo, error-budget, observability, devops, incident-response, toil, resilience, feedback
 :tier: 3
 
 [%collapsible]

--- a/docs/anchors/strangler-fig.adoc
+++ b/docs/anchors/strangler-fig.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :related: domain-driven-design, event-driven-architecture, clean-architecture
 :proponents: Martin Fowler
-:tags: legacy-modernization, migration, refactoring, incremental, facade
+:tags: legacy-modernization, migration, refactoring, incremental, facade, resilience
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/strangler-fig.de.adoc
+++ b/docs/anchors/strangler-fig.de.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, software-developer, team-lead
 :related: domain-driven-design, event-driven-architecture, clean-architecture
 :proponents: Martin Fowler
-:tags: legacy-modernization, migration, refactoring, incremental, facade
+:tags: legacy-modernization, migration, refactoring, incremental, facade, resilience
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/team-topologies.adoc
+++ b/docs/anchors/team-topologies.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, team-lead, product-owner
 :related: conways-law, domain-driven-design, cynefin-framework
 :proponents: Matthew Skelton, Manuel Pais
-:tags: org-design, team-structure, cognitive-load, conways-law, flow
+:tags: org-design, team-structure, cognitive-load, conways-law, flow, feedback
 :tier: 2
 
 [%collapsible]

--- a/docs/anchors/team-topologies.de.adoc
+++ b/docs/anchors/team-topologies.de.adoc
@@ -3,7 +3,7 @@
 :roles: software-architect, team-lead, product-owner
 :related: conways-law, domain-driven-design, cynefin-framework
 :proponents: Matthew Skelton, Manuel Pais
-:tags: org-design, team-structure, cognitive-load, conways-law, flow
+:tags: org-design, team-structure, cognitive-load, conways-law, flow, feedback
 :tier: 2
 
 [%collapsible]


### PR DESCRIPTION
The **outcome of the #519 spike** (PR #689). The spike tagged 12 anchors with the four systemic dimensions and revealed:

- **`boundary` is too broad** — 9 of 12 anchors; a filter that matches 75% has no discriminating power.
- **`emergence` is sparse** (2).
- **`resilience` and `feedback` are coherent, useful groupings** — but that is exactly what the **tag system already does**, and we just shipped 100% tag coverage + search. Notably `circuit-breaker` and `fallacies-of-distributed-computing` *already* tagged `resilience` — the discovery largely worked via tags already.

**Decision:** don't build a parallel dimensions axis (new attribute + filter UI + rubric + 8-dimension catalog-wide enrichment + community process). Fold the useful signal into tags instead. This PR adds `resilience` / `feedback` / `emergence` tags where genuinely missing (EN + DE, 8 anchors), and the spike (#689) is closed unmerged.

Consistent with KISS / YAGNI: the spike did its job — it stopped us building machinery the tag system already covers.