### PR TITLE
feat: add role descriptions for all 15 roles (EN + DE)

### DIFF
--- a/docs/roles/business-analyst.adoc
+++ b/docs/roles/business-analyst.adoc
@@ -1,0 +1,13 @@
+= Business Analyst / Requirements Engineer
+:id: business-analyst
+:name-de: Business Analyst / Anforderungsmanager
+
+Elicits, analyzes, and documents requirements. Bridges business needs and technical implementation through structured specification. Manages requirements traceability and change impact.
+
+== Sources
+
+* IREB CPRE Foundation Level — Certified Professional for Requirements Engineering
+* BABOK Guide (IIBA) — Business Analysis Body of Knowledge
+* ITIL 4 — Business Relationship Management, Demand Management practices
+* ISO 20000 — IT Service Management (Service Level Management)
+* IEEE 830 — Recommended Practice for Software Requirements Specifications

--- a/docs/roles/business-analyst.de.adoc
+++ b/docs/roles/business-analyst.de.adoc
@@ -1,0 +1,13 @@
+= Business Analyst / Anforderungsmanager
+:id: business-analyst
+:name-en: Business Analyst / Requirements Engineer
+
+Erhebt, analysiert und dokumentiert Anforderungen. Verbindet fachliche Bedürfnisse und technische Umsetzung durch strukturierte Spezifikation. Verantwortet Anforderungs-Traceability und Change-Impact-Analyse.
+
+== Quellen
+
+* IREB CPRE Foundation Level — Certified Professional for Requirements Engineering
+* BABOK Guide (IIBA) — Business Analysis Body of Knowledge
+* ITIL 4 — Geschäftsbeziehungsmanagement, Nachfragemanagement
+* ISO 20000 — IT-Service-Management (Service-Level-Management)
+* IEEE 830 — Empfohlene Praxis für Software-Anforderungsspezifikationen

--- a/docs/roles/consultant.adoc
+++ b/docs/roles/consultant.adoc
@@ -1,0 +1,13 @@
+= Consultant / Coach
+:id: consultant
+:name-de: Berater / Coach
+
+Advises organizations on process, technology, and strategy. Facilitates change through coaching, training, and expert guidance. Operates as external or internal advisor without line authority.
+
+== Sources
+
+* Systemische Beratung (Heidelberger Schule — Simon, Weber, Stierlin)
+* ITIL 4 — Continual Improvement practice
+* ICAgile — Agile Coaching certification track
+* Schein — Process Consultation (Humble Inquiry)
+* ISO 20000 — IT Service Management (Consultancy in Service Improvement)

--- a/docs/roles/consultant.de.adoc
+++ b/docs/roles/consultant.de.adoc
@@ -1,0 +1,13 @@
+= Berater / Coach
+:id: consultant
+:name-en: Consultant / Coach
+
+Berät Organisationen zu Prozess, Technologie und Strategie. Begleitet Veränderung durch Coaching, Training und fachliche Expertise. Agiert als externer oder interner Berater ohne Linienautorität.
+
+== Quellen
+
+* Systemische Beratung (Heidelberger Schule — Simon, Weber, Stierlin)
+* ITIL 4 — Kontinuierliche Verbesserung
+* ICAgile — Agile-Coaching-Zertifizierungspfad
+* Schein — Prozessberatung (Humble Inquiry)
+* ISO 20000 — IT-Service-Management (Beratung zur Serviceverbesserung)

--- a/docs/roles/data-protection-officer.adoc
+++ b/docs/roles/data-protection-officer.adoc
@@ -1,0 +1,18 @@
+= Data Protection Officer
+:id: data-protection-officer
+:name-de: Datenschutzbeauftragter
+
+Monitors GDPR compliance and advises the controller on data protection obligations. Tasks as defined in Art. 39 GDPR:
+
+* Informing and advising on data protection obligations
+* Monitoring compliance with the GDPR
+* Advising on Data Protection Impact Assessments (DPIA)
+* Cooperating with the supervisory authority
+* Acting as contact point for the supervisory authority
+
+== Sources
+
+* GDPR Art. 37 — Designation of the data protection officer
+* GDPR Art. 38 — Position of the data protection officer
+* GDPR Art. 39 — Tasks of the data protection officer
+* BDSG § 38 — Datenschutzbeauftragte nichtöffentlicher Stellen

--- a/docs/roles/data-protection-officer.de.adoc
+++ b/docs/roles/data-protection-officer.de.adoc
@@ -1,0 +1,18 @@
+= Datenschutzbeauftragter
+:id: data-protection-officer
+:name-en: Data Protection Officer
+
+Überwacht die Einhaltung der DSGVO und berät den Verantwortlichen in datenschutzrechtlichen Pflichten. Aufgaben gemäß Art. 39 DSGVO:
+
+* Unterrichtung und Beratung hinsichtlich datenschutzrechtlicher Pflichten
+* Überwachung der Einhaltung der DSGVO
+* Beratung im Zusammenhang mit der Datenschutz-Folgenabschätzung (DSFA)
+* Zusammenarbeit mit der Aufsichtsbehörde
+* Anlaufstelle für die Aufsichtsbehörde
+
+== Quellen
+
+* DSGVO Art. 37 — Benennung eines Datenschutzbeauftragten
+* DSGVO Art. 38 — Stellung des Datenschutzbeauftragten
+* DSGVO Art. 39 — Aufgaben des Datenschutzbeauftragten
+* BDSG § 38 — Datenschutzbeauftragte nichtöffentlicher Stellen

--- a/docs/roles/data-scientist.adoc
+++ b/docs/roles/data-scientist.adoc
@@ -1,0 +1,13 @@
+= Data Scientist / Statistician
+:id: data-scientist
+:name-de: Datenanalyst / Statistiker / Datenarchitekt
+
+Analyzes data, builds models, and derives insights through statistical methods and machine learning. Validates hypotheses through evidence-based experimentation. Ensures data quality and reproducibility.
+
+== Sources
+
+* CRISP-DM — Cross-Industry Standard Process for Data Mining
+* Statistical foundations (Fisher, Neyman-Pearson)
+* ISO/IEC 20546 — Big Data Reference Architecture
+* DAMA-DMBOK — Data Management Body of Knowledge
+* Google Rules of ML — Best Practices for ML Engineering

--- a/docs/roles/data-scientist.de.adoc
+++ b/docs/roles/data-scientist.de.adoc
@@ -1,0 +1,13 @@
+= Datenanalyst / Statistiker / Datenarchitekt
+:id: data-scientist
+:name-en: Data Scientist / Statistician
+
+Analysiert Daten, baut Modelle und leitet Erkenntnisse durch statistische Methoden und Machine Learning ab. Validiert Hypothesen durch evidenzbasierte Experimente. Stellt Datenqualität und Reproduzierbarkeit sicher.
+
+== Quellen
+
+* CRISP-DM — Branchenübergreifender Standardprozess für Data Mining
+* Statistische Grundlagen (Fisher, Neyman-Pearson)
+* ISO/IEC 20546 — Referenzarchitektur für Big Data
+* DAMA-DMBOK — Wissenssammlung für Datenmanagement
+* Google Rules of ML — Bewährte Praktiken für ML-Engineering

--- a/docs/roles/devops-engineer.adoc
+++ b/docs/roles/devops-engineer.adoc
@@ -1,0 +1,13 @@
+= DevOps Engineer
+:id: devops-engineer
+:name-de: DevOps-Engineer
+
+Builds and operates CI/CD pipelines, infrastructure-as-code, and monitoring. Bridges development and operations to enable continuous delivery. Manages deployment, release, and incident processes.
+
+== Sources
+
+* DORA Metrics — Accelerate (Forsgren, Humble, Kim)
+* Google SRE Book — Site Reliability Engineering
+* ITIL 4 — Deployment Management, Release Management, Monitoring and Event Management practices
+* ISO 20000 — IT Service Management (Release & Deployment)
+* CALMS Framework (Culture, Automation, Lean, Measurement, Sharing)

--- a/docs/roles/devops-engineer.de.adoc
+++ b/docs/roles/devops-engineer.de.adoc
@@ -1,0 +1,13 @@
+= DevOps-Engineer
+:id: devops-engineer
+:name-en: DevOps Engineer
+
+Baut und betreibt CI/CD-Pipelines, Infrastructure-as-Code und Monitoring. Verbindet Entwicklung und Betrieb für Continuous Delivery. Verantwortet Deployment-, Release- und Incident-Prozesse.
+
+== Quellen
+
+* DORA Metrics — Accelerate (Forsgren, Humble, Kim)
+* Google SRE Book — Site Reliability Engineering
+* ITIL 4 — Bereitstellungsmanagement, Releasemanagement, Überwachung und Ereignismanagement
+* ISO 20000 — IT-Service-Management (Release & Bereitstellung)
+* CALMS Framework (Culture, Automation, Lean, Measurement, Sharing)

--- a/docs/roles/educator.adoc
+++ b/docs/roles/educator.adoc
@@ -1,0 +1,13 @@
+= Educator / Trainer
+:id: educator
+:name-de: Dozent / Trainer
+
+Teaches concepts, facilitates learning, and develops training material. Makes complex topics accessible through didactic methods. Evaluates learning outcomes and adapts teaching approaches.
+
+== Sources
+
+* Bloom's Taxonomy — Cognitive learning levels
+* Feynman Technique — Teaching as understanding test
+* Didaktik der Informatik (German CS education framework)
+* Kirkpatrick Model — Training evaluation (4 levels)
+* ADDIE Model — Instructional design process

--- a/docs/roles/educator.de.adoc
+++ b/docs/roles/educator.de.adoc
@@ -1,0 +1,13 @@
+= Dozent / Trainer
+:id: educator
+:name-en: Educator / Trainer
+
+Vermittelt Konzepte, begleitet Lernprozesse und entwickelt Trainingsmaterial. Macht komplexe Themen durch didaktische Methoden zugänglich. Evaluiert Lernergebnisse und adaptiert Lehransätze.
+
+== Quellen
+
+* Bloom'sche Taxonomie — Kognitive Lernstufen
+* Feynman-Technik — Lehren als Verständnistest
+* Didaktik der Informatik
+* Kirkpatrick-Modell — Trainingsevaluation (4 Ebenen)
+* ADDIE-Modell — Prozess für Instruktionsdesign

--- a/docs/roles/ethics-officer.adoc
+++ b/docs/roles/ethics-officer.adoc
@@ -1,0 +1,21 @@
+= Ethics Officer / AI Ethics Board
+:id: ethics-officer
+:name-de: Ethikbeauftragter / KI-Ethikgremium
+
+Assesses ethical implications of AI systems and ensures human-centred development. Oversees risk management for high-risk AI systems and defines ethical guidelines. May operate as individual role or as collective board.
+
+== Responsibilities
+
+* Ethical impact assessment of AI systems
+* Oversight of AI risk management (high-risk classification)
+* Definition and monitoring of ethical guidelines
+* Stakeholder engagement on AI ethics questions
+* Bias detection and fairness evaluation
+
+== Sources
+
+* EU AI Act Art. 9 — Risk management system for high-risk AI
+* ISO/IEC 42001 — Artificial Intelligence Management System
+* IEEE 7000 — Model Process for Addressing Ethical Concerns During System Design
+* EU Commission — Ethics Guidelines for Trustworthy AI (2019)
+* OECD AI Principles (2019)

--- a/docs/roles/ethics-officer.de.adoc
+++ b/docs/roles/ethics-officer.de.adoc
@@ -1,0 +1,21 @@
+= Ethikbeauftragter / KI-Ethikgremium
+:id: ethics-officer
+:name-en: Ethics Officer / AI Ethics Board
+
+Bewertet ethische Implikationen von KI-Systemen und stellt menschenzentrierte Entwicklung sicher. Überwacht Risikomanagement für Hochrisiko-KI-Systeme und definiert ethische Leitlinien. Kann als Einzelrolle oder als kollektives Gremium agieren.
+
+== Aufgaben
+
+* Ethische Folgenabschätzung von KI-Systemen
+* Überwachung des KI-Risikomanagements (Hochrisiko-Klassifizierung)
+* Definition und Monitoring ethischer Leitlinien
+* Stakeholder-Einbindung bei KI-Ethikfragen
+* Bias-Erkennung und Fairness-Bewertung
+
+== Quellen
+
+* KI-Verordnung (EU AI Act) Art. 9 — Risikomanagementsystem für Hochrisiko-KI
+* ISO/IEC 42001 — Managementsystem für Künstliche Intelligenz
+* IEEE 7000 — Modellprozess zur Berücksichtigung ethischer Belange im Systemdesign
+* EU-Kommission — Ethik-Leitlinien für vertrauenswürdige KI (2019)
+* OECD-Grundsätze zur KI (2019)

--- a/docs/roles/legal-compliance.adoc
+++ b/docs/roles/legal-compliance.adoc
@@ -1,0 +1,23 @@
+= Legal / Compliance Counsel
+:id: legal-compliance
+:name-de: Syndikusanwalt / Unternehmensjurist / Compliance-Beauftragter
+
+Ensures legal and regulatory compliance — from regulatory requirements (EU AI Act, NIS2) through management systems (ISO 9001, ISO 27001, ISO 20000) to sector-specific standards (BSI-Grundschutz, KRITIS). Assesses legal risk and is accountable for audit readiness.
+
+== Responsibilities
+
+* Legal assessment of IT systems and processes
+* Compliance with regulatory frameworks (EU AI Act, NIS2, GDPR)
+* Audit readiness for management system certifications
+* Contract review and legal risk assessment
+* Internal audit support and evidence management
+
+== Sources
+
+* EU AI Act — Conformity assessment, Art. 43
+* ISO 27001 — Information Security Management Systems
+* ISO 9001 — Quality Management Systems
+* ISO 20000 — IT Service Management Systems
+* BSI-Grundschutz Compendium — IT baseline protection (German federal standard)
+* NIS2 Directive (EU 2022/2555) — Cybersecurity
+* § 46 BRAO — In-house counsel (German Federal Lawyers Act)

--- a/docs/roles/legal-compliance.de.adoc
+++ b/docs/roles/legal-compliance.de.adoc
@@ -1,0 +1,23 @@
+= Syndikusanwalt / Unternehmensjurist / Compliance-Beauftragter
+:id: legal-compliance
+:name-en: Legal / Compliance Counsel
+
+Stellt Rechtskonformität sicher — von regulatorischen Anforderungen (KI-Verordnung, NIS2) über Managementsysteme (ISO 9001, ISO 27001, ISO 20000) bis zu branchenspezifischen Standards (BSI-Grundschutz, KRITIS). Bewertet rechtliche Risiken und verantwortet die Auditfähigkeit.
+
+== Aufgaben
+
+* Rechtliche Bewertung von IT-Systemen und Prozessen
+* Compliance mit regulatorischen Rahmenwerken (KI-Verordnung, NIS2, DSGVO)
+* Auditfähigkeit für Managementsystem-Zertifizierungen
+* Vertragsreview und rechtliche Risikobewertung
+* Unterstützung der internen Revision und Nachweisverwaltung
+
+== Quellen
+
+* KI-Verordnung (EU AI Act) — Konformitätsbewertung, Art. 43
+* ISO 27001 — Informationssicherheits-Managementsysteme
+* ISO 9001 — Qualitätsmanagementsysteme
+* ISO 20000 — IT-Service-Managementsysteme
+* BSI-Grundschutz-Kompendium — IT-Grundschutz
+* NIS2-Richtlinie (EU 2022/2555) — Cybersicherheit
+* § 46 BRAO — Syndikusrechtsanwalt

--- a/docs/roles/product-owner.adoc
+++ b/docs/roles/product-owner.adoc
@@ -1,0 +1,13 @@
+= Product Owner / Product Manager
+:id: product-owner
+:name-de: Product Owner / Produktmanager
+
+Maximizes product value by managing the backlog, prioritizing features, and representing stakeholder needs. Accountable for the "what" and "why" of product development. Single point of accountability for product decisions.
+
+== Sources
+
+* Scrum Guide 2020 (Schwaber/Sutherland) — Product Owner accountability
+* SAFe — Product Owner / Product Manager roles
+* Kanban — Flow-based product ownership
+* LeSS — Product Owner in large-scale Scrum
+* Marty Cagan — Inspired: How to Create Tech Products Customers Love

--- a/docs/roles/product-owner.de.adoc
+++ b/docs/roles/product-owner.de.adoc
@@ -1,0 +1,13 @@
+= Product Owner / Produktmanager
+:id: product-owner
+:name-en: Product Owner / Product Manager
+
+Maximiert den Produktwert durch Backlog-Management, Feature-Priorisierung und Vertretung der Stakeholder-Bedürfnisse. Verantwortlich für das „Was" und „Warum" der Produktentwicklung. Einziger Entscheidungspunkt für Produktentscheidungen.
+
+== Quellen
+
+* Scrum Guide 2020 (Schwaber/Sutherland) — Verantwortlichkeit des Product Owners
+* SAFe — Product Owner / Produktmanager-Rollen
+* Kanban — Flow-basierte Produktverantwortung
+* LeSS — Product Owner in Large-Scale Scrum
+* Marty Cagan — Inspired: How to Create Tech Products Customers Love

--- a/docs/roles/qa-engineer.adoc
+++ b/docs/roles/qa-engineer.adoc
@@ -1,0 +1,13 @@
+= QA Engineer / Tester
+:id: qa-engineer
+:name-de: QA-Engineer / Tester
+
+Designs and executes test strategies across all levels (unit, integration, E2E). Ensures quality through systematic verification and validation. Supports quality management systems and audit evidence.
+
+== Sources
+
+* ISTQB Foundation Level Syllabus
+* ISO/IEC 25010 — Systems and Software Quality Models
+* ISO 9001 — Quality Management Systems (verification & validation)
+* ITIL 4 — Service Validation and Testing practice
+* ISO/IEC 12207 — Software Testing Process

--- a/docs/roles/qa-engineer.de.adoc
+++ b/docs/roles/qa-engineer.de.adoc
@@ -1,0 +1,13 @@
+= QA-Engineer / Tester
+:id: qa-engineer
+:name-en: QA Engineer / Tester
+
+Entwirft und führt Teststrategien über alle Ebenen aus (Unit, Integration, E2E). Stellt Qualität durch systematische Verifikation und Validierung sicher. Unterstützt Qualitätsmanagementsysteme und Auditnachweise.
+
+== Quellen
+
+* ISTQB Foundation Level Syllabus
+* ISO/IEC 25010 — Qualitätsmodelle für Systeme und Software
+* ISO 9001 — Qualitätsmanagementsysteme (Verifikation & Validierung)
+* ITIL 4 — Servicevalidierung und Test-Praktik
+* ISO/IEC 12207 — Softwaretestprozess

--- a/docs/roles/software-architect.adoc
+++ b/docs/roles/software-architect.adoc
@@ -1,0 +1,13 @@
+= Software Architect
+:id: software-architect
+:name-de: Softwarearchitekt
+
+Designs system structures, defines quality attributes, and makes cross-cutting technical decisions. Documents architecture using established frameworks (arc42, C4, ADRs). Ensures architectural integrity across development teams.
+
+== Sources
+
+* ISO/IEC 42010 — Architecture Description
+* ISO 20000 — IT Service Management (Service Design)
+* ITIL 4 — Service Design, Architecture Management practice
+* iSAQB Foundation/Advanced Level Curriculum
+* SEI — Software Architecture in Practice (Bass, Clements, Kazman)

--- a/docs/roles/software-architect.de.adoc
+++ b/docs/roles/software-architect.de.adoc
@@ -1,0 +1,13 @@
+= Softwarearchitekt
+:id: software-architect
+:name-en: Software Architect
+
+Entwirft Systemstrukturen, definiert Qualitätsattribute und trifft querschnittliche technische Entscheidungen. Dokumentiert Architektur mit etablierten Frameworks (arc42, C4, ADRs). Stellt architektonische Integrität über Entwicklungsteams hinweg sicher.
+
+== Quellen
+
+* ISO/IEC 42010 — Architekturbeschreibung
+* ISO 20000 — IT-Service-Management (Service-Design)
+* ITIL 4 — Service-Design, Architekturmanagement-Praktik
+* iSAQB Foundation/Advanced Level Curriculum
+* SEI — Software Architecture in Practice (Bass, Clements, Kazman)

--- a/docs/roles/software-developer.adoc
+++ b/docs/roles/software-developer.adoc
@@ -1,0 +1,13 @@
+= Software Developer / Engineer
+:id: software-developer
+:name-de: Softwareentwickler
+
+Implements, tests, and maintains software systems. Applies design patterns, coding standards, and test practices in daily work. Responsible for code quality, peer reviews, and continuous integration.
+
+== Sources
+
+* IEEE 610.12 — Standard Glossary of Software Engineering Terminology
+* ISO/IEC 24765 — Systems and Software Engineering Vocabulary
+* ISO/IEC 12207 — Software Life Cycle Processes (Developer role)
+* Scrum Guide 2020 — Developer accountability
+* SAFe — Agile Team member

--- a/docs/roles/software-developer.de.adoc
+++ b/docs/roles/software-developer.de.adoc
@@ -1,0 +1,13 @@
+= Softwareentwickler
+:id: software-developer
+:name-en: Software Developer / Engineer
+
+Implementiert, testet und pflegt Softwaresysteme. Wendet Design Patterns, Coding-Standards und Testpraktiken in der täglichen Arbeit an. Verantwortlich für Code-Qualität, Peer Reviews und Continuous Integration.
+
+== Quellen
+
+* IEEE 610.12 — Standard Glossary of Software Engineering Terminology
+* ISO/IEC 24765 — System- und Software-Engineering-Vokabular
+* ISO/IEC 12207 — Lebenszyklusprozesse für Software (Entwicklerrolle)
+* Scrum Guide 2020 — Verantwortlichkeit des Developers
+* SAFe — Agiles Teammitglied

--- a/docs/roles/team-lead.adoc
+++ b/docs/roles/team-lead.adoc
@@ -1,0 +1,14 @@
+= Team Lead / Engineering Manager
+:id: team-lead
+:name-de: Teamleiter / Engineering Manager
+
+Leads engineering teams — balances people management, technical direction, and delivery accountability. Enables team effectiveness and removes impediments. Ensures process compliance within the team.
+
+== Sources
+
+* Scrum Guide 2020 — Scrum Master accountability (overlap)
+* SAFe — Release Train Engineer, Agile Team Lead
+* ITIL 4 — Service Owner practice
+* ISO 20000 — IT Service Management (process responsibility)
+* Camille Fournier — The Manager's Path
+* Servant Leadership (Robert K. Greenleaf)

--- a/docs/roles/team-lead.de.adoc
+++ b/docs/roles/team-lead.de.adoc
@@ -1,0 +1,14 @@
+= Teamleiter / Engineering Manager
+:id: team-lead
+:name-en: Team Lead / Engineering Manager
+
+Führt Engineering-Teams — balanciert Personalführung, technische Richtung und Delivery-Verantwortung. Ermöglicht Team-Effektivität und räumt Hindernisse aus. Stellt Prozess-Compliance im Team sicher.
+
+== Quellen
+
+* Scrum Guide 2020 — Verantwortlichkeit des Scrum Masters (Überschneidung)
+* SAFe — Release Train Engineer, Agile Team Lead
+* ITIL 4 — Service-Owner-Praktik
+* ISO 20000 — IT-Service-Management (Prozessverantwortung)
+* Camille Fournier — The Manager's Path
+* Servant Leadership (Robert K. Greenleaf)

--- a/docs/roles/technical-writer.adoc
+++ b/docs/roles/technical-writer.adoc
@@ -1,0 +1,13 @@
+= Technical Writer / Documentation Specialist
+:id: technical-writer
+:name-de: Technischer Redakteur
+
+Creates and maintains technical documentation — user guides, API docs, architecture documentation. Applies information architecture, docs-as-code practices, and structured authoring.
+
+== Sources
+
+* Diátaxis Framework (Procida) — Tutorial, How-To, Reference, Explanation
+* docs-as-code — Documentation versioniert im Repository
+* tekom — Technische Kommunikation (German professional association)
+* ISO/IEC/IEEE 26511 — Requirements for managers of information for users
+* ITIL 4 — Knowledge Management practice

--- a/docs/roles/technical-writer.de.adoc
+++ b/docs/roles/technical-writer.de.adoc
@@ -1,0 +1,13 @@
+= Technischer Redakteur
+:id: technical-writer
+:name-en: Technical Writer / Documentation Specialist
+
+Erstellt und pflegt technische Dokumentation — Benutzerhandbücher, API-Dokumentation, Architekturdokumentation. Wendet Informationsarchitektur, Docs-as-Code-Praktiken und strukturiertes Authoring an.
+
+== Quellen
+
+* Diátaxis Framework (Procida) — Tutorial, How-To, Referenz, Erklärung
+* docs-as-code — Dokumentation versioniert im Repository
+* tekom — Technische Kommunikation (Berufsverband)
+* ISO/IEC/IEEE 26511 — Anforderungen an das Management von Benutzerinformationen
+* ITIL 4 — Wissensmanagement-Praktik

--- a/docs/roles/ux-designer.adoc
+++ b/docs/roles/ux-designer.adoc
@@ -1,0 +1,13 @@
+= UX Designer / Researcher
+:id: ux-designer
+:name-de: UX-Designer / UX-Researcher
+
+Designs user interactions and conducts user research to ensure usability. Translates user needs into interaction patterns and validates through usability testing. Advocates for the end user in product decisions.
+
+== Sources
+
+* ISO 9241-210 — Human-Centred Design for Interactive Systems
+* Nielsen Norman Group — Usability Heuristics
+* Design Thinking (d.school Stanford)
+* UXQB CPUX Foundation Level — Certified Professional for Usability and UX
+* ISO 25010 — Usability as quality attribute

--- a/docs/roles/ux-designer.de.adoc
+++ b/docs/roles/ux-designer.de.adoc
@@ -1,0 +1,13 @@
+= UX-Designer / UX-Researcher
+:id: ux-designer
+:name-en: UX Designer / Researcher
+
+Gestaltet Benutzerinteraktionen und führt User Research durch um Usability sicherzustellen. Übersetzt Nutzerbedürfnisse in Interaktionsmuster und validiert durch Usability-Tests. Vertritt den Endnutzer bei Produktentscheidungen.
+
+== Quellen
+
+* ISO 9241-210 — Menschzentrierte Gestaltung interaktiver Systeme
+* Nielsen Norman Group — Usability-Heuristiken
+* Design Thinking (d.school Stanford)
+* UXQB CPUX Foundation Level — Certified Professional for Usability and UX
+* ISO 25010 — Gebrauchstauglichkeit als Qualitätsattribut

--- a/scripts/extract-metadata.js
+++ b/scripts/extract-metadata.js
@@ -203,6 +203,7 @@ function generateRolesData(anchors) {
         roleMap.set(roleId, {
           id: roleId,
           name: roleIdToName(roleId),
+          name_de: roleIdToNameDe(roleId),
           anchors: [],
         })
       }
@@ -256,6 +257,36 @@ function roleIdToName(id) {
     consultant: 'Consultant / Coach',
     'team-lead': 'Team Lead / Engineering Manager',
     educator: 'Educator / Trainer',
+  }
+  return (
+    names[id] ||
+    id
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ')
+  )
+}
+
+/**
+ * Convert role ID to German human-readable name
+ */
+function roleIdToNameDe(id) {
+  const names = {
+    'software-developer': 'Softwareentwickler',
+    'software-architect': 'Softwarearchitekt',
+    'qa-engineer': 'QA-Engineer / Tester',
+    'devops-engineer': 'DevOps-Engineer',
+    'product-owner': 'Product Owner / Produktmanager',
+    'business-analyst': 'Business Analyst / Anforderungsmanager',
+    'technical-writer': 'Technischer Redakteur',
+    'ux-designer': 'UX-Designer / UX-Researcher',
+    'data-scientist': 'Datenanalyst / Statistiker / Datenarchitekt',
+    consultant: 'Berater / Coach',
+    'team-lead': 'Teamleiter / Engineering Manager',
+    educator: 'Dozent / Trainer',
+    'data-protection-officer': 'Datenschutzbeauftragter',
+    'legal-compliance': 'Syndikusanwalt / Unternehmensjurist / Compliance-Beauftragter',
+    'ethics-officer': 'Ethikbeauftragter / KI-Ethikgremium',
   }
   return (
     names[id] ||


### PR DESCRIPTION
## Summary

Adds `docs/roles/<role-id>.adoc` and `docs/roles/<role-id>.de.adoc` for all 15 roles in the `:roles:` vocabulary, and extends `extract-metadata.js` with a `roleIdToNameDe()` mapping.

Addresses open Question 5 from #542 and review feedback on #659 (point 4, @raifdmueller):

> *"confirm the role display names in extract-metadata.js show DE labels too (or note it as a follow-up), and decide whether they get docs/roles/*.adoc files"*

## Changes

- 30 new files: `docs/roles/<role-id>.adoc` + `docs/roles/<role-id>.de.adoc` for all 15 roles
- Each file contains: role title (localized), short description, sources (standards/frameworks/legal refs)
- `scripts/extract-metadata.js`: added `roleIdToNameDe()` function + `name_de` field in generated role objects

## Role overview

| ID | EN | DE |
|----|----|----|
| `software-developer` | Software Developer / Engineer | Softwareentwickler |
| `software-architect` | Software Architect | Softwarearchitekt |
| `qa-engineer` | QA Engineer / Tester | QA-Engineer / Tester |
| `devops-engineer` | DevOps Engineer | DevOps-Engineer |
| `product-owner` | Product Owner / Product Manager | Product Owner / Produktmanager |
| `business-analyst` | Business Analyst / Requirements Engineer | Business Analyst / Anforderungsmanager |
| `technical-writer` | Technical Writer / Documentation Specialist | Technischer Redakteur |
| `ux-designer` | UX Designer / Researcher | UX-Designer / UX-Researcher |
| `data-scientist` | Data Scientist / Statistician | Datenanalyst / Statistiker / Datenarchitekt |
| `consultant` | Consultant / Coach | Berater / Coach |
| `team-lead` | Team Lead / Engineering Manager | Teamleiter / Engineering Manager |
| `educator` | Educator / Trainer | Dozent / Trainer |
| `data-protection-officer` | Data Protection Officer | Datenschutzbeauftragter |
| `legal-compliance` | Legal / Compliance Counsel | Syndikusanwalt / Unternehmensjurist / Compliance-Beauftragter |
| `ethics-officer` | Ethics Officer / AI Ethics Board | Ethikbeauftragter / KI-Ethikgremium |

> Alle Rollenbezeichnungen sind generisch zu verstehen und beinhalten keine Genderaussage.

## Sources per role type

- **Technical roles (12):** ISO/IEC standards, ITIL 4, Scrum Guide, SAFe, iSAQB, ISTQB, IREB, tekom, UXQB
- **Governance roles (3):** GDPR Art. 37–39, EU AI Act Art. 9/43, ISO/IEC 42001, IEEE 7000, § 46 BRAO, BSI-Grundschutz, NIS2

## Not included (follow-up)

- Website integration (rendering role filter with `name_de` based on `i18n.currentLang()`) — separate PR

## Related

- #542 — Role Taxonomy Proposal (Question 5: role description files)
- #659 — Governance roles PR (review point 4: i18n + role docs)