### PR TITLE
feat: add Effective Python semantic anchor (EN + DE)

### DIFF
--- a/docs/anchors/effective-python.adoc
+++ b/docs/anchors/effective-python.adoc
@@ -1,0 +1,58 @@
+= Effective Python
+:categories: development-workflow
+:roles: software-developer, software-architect
+:related: effective-java, effective-go, solid-principles
+:proponents: Brett Slatkin
+:tags: python, best-practices, idiomatic, pythonic, style-guide
+:tier: 3
+
+[%collapsible]
+====
+
+[discrete]
+== *Core Concepts*:
+
+Items format:: A catalog of ~125 short, self-contained "Items", each a concrete best-practice rule with rationale and trade-offs (grouped into chapters)
+
+Pythonic thinking:: Follow PEP 8 style and the Zen of Python; prefer f-strings over `%` and `str.format`; know the difference between `bytes` and `str`; prefer helper functions to complex expressions
+
+Lists and dictionaries:: Prefer comprehensions to `map`/`filter`; use `enumerate` instead of `range`; use `zip` to iterate in parallel; use catch-all unpacking over indexing; avoid `else` blocks after `for`/`while`
+
+Functions:: Prefer raising exceptions to returning `None`; enforce clarity with keyword-only and positional-only arguments; return generators instead of building lists; never modify default argument values (use `None` and docstrings)
+
+Comprehensions and generators:: Use generator expressions for large comprehensions; compose generators with `yield from`; reach for `itertools` before hand-rolling iteration
+
+Classes and interfaces:: Compose classes rather than nesting dicts/tuples deeply; use `@classmethod` polymorphism; prefer public attributes and `@property` over getters/setters; use functions instead of classes for simple interfaces
+
+Metaclasses and attributes:: Use `@property` and descriptors for reusable attribute behaviour; prefer `__getattr__`/`__getattribute__` sparingly; validate subclasses with `__init_subclass__`
+
+Concurrency and parallelism:: Use threads for blocking I/O, not parallelism (the GIL); use `Queue` to coordinate pipelines; use coroutines and `asyncio` for many concurrent functions; use `concurrent.futures` and processes for true parallelism
+
+Robustness, testing, and collaboration:: Make programs robust and performant (new chapters in the 3rd edition); test with `unittest`/`Mock`; document with docstrings; isolate dependencies with virtual environments (`venv`)
+
+Key Proponent:: Brett Slatkin ("Effective Python", Addison-Wesley) — principal software engineer at Google and creator of the book's runnable example suite
+
+[discrete]
+== *When to Use*:
+
+* Onboarding Python developers to idiomatic, robust ("Pythonic") code
+* Code review discussions grounded in a shared, citable rule set ("Item 30: consider generators instead of returning lists")
+* Establishing team-wide Python coding standards and conventions
+* Explaining Python-specific idioms and pitfalls (comprehensions, generators, the GIL, `@property`, keyword-only arguments)
+* Prompting an LLM to produce idiomatic, production-quality Python code
+
+[discrete]
+== *Related Anchors*:
+
+* <<effective-java,Effective Java>>
+* <<effective-go,Effective Go>>
+* <<solid-principles,SOLID Principles>>
+
+[discrete]
+== *Current Status*:
+
+* The 3rd edition (Pearson Addison-Wesley, https://www.informit.com/store/effective-python-125-specific-ways-to-write-better-9780138172183[published 20 November 2024], ISBN 978-0-13-817218-3) is the current edition. It expands from the 2nd edition's 90 Items to 125 Items — https://effectivepython.com/[35 new Items] plus two new chapters on robustness and performance
+* The 1st edition (2015) targeted Python 2 as well as 3; the 2nd edition (2019) was Python-3-only through ~3.8; the 3rd edition covers modern Python 3, including features such as the walrus operator, structural pattern matching, and updated typing and `asyncio` guidance
+* The book's core advice (prefer comprehensions and generators, respect the GIL, compose classes, use `@property`) remains stable across editions; only specific Items track the language. A training-data prior keyed on "Effective Python" most plausibly reflects the 2nd edition (90 Items) and is therefore silent on the 35 Items added in the 3rd edition
+
+====

--- a/docs/anchors/effective-python.de.adoc
+++ b/docs/anchors/effective-python.de.adoc
@@ -1,0 +1,58 @@
+= Effective Python
+:categories: development-workflow
+:roles: software-developer, software-architect
+:related: effective-java, effective-go, solid-principles
+:proponents: Brett Slatkin
+:tags: python, best-practices, idiomatic, pythonic, style-guide
+:tier: 3
+
+[%collapsible]
+====
+
+[discrete]
+== *Kernkonzepte*:
+
+Item-Format:: Ein Katalog von ~125 kurzen, in sich geschlossenen "Items", jedes eine konkrete Best-Practice-Regel mit Begründung und Trade-offs (in Kapiteln gruppiert)
+
+Pythonisches Denken:: Dem PEP-8-Stil und dem Zen of Python folgen; f-Strings gegenüber `%` und `str.format` bevorzugen; den Unterschied zwischen `bytes` und `str` kennen; Hilfsfunktionen komplexen Ausdrücken vorziehen
+
+Listen und Dictionaries:: Comprehensions gegenüber `map`/`filter` bevorzugen; `enumerate` statt `range` verwenden; `zip` zum parallelen Iterieren nutzen; Catch-all-Unpacking statt Indizierung; `else`-Blöcke nach `for`/`while` vermeiden
+
+Funktionen:: Exceptions dem Rückgabewert `None` vorziehen; Klarheit durch keyword-only- und positional-only-Argumente erzwingen; Generatoren statt aufgebauter Listen zurückgeben; veränderliche Default-Argumente nie modifizieren (`None` und Docstrings verwenden)
+
+Comprehensions und Generatoren:: Generator-Ausdrücke für große Comprehensions verwenden; Generatoren mit `yield from` komponieren; `itertools` nutzen, bevor man Iteration selbst schreibt
+
+Klassen und Interfaces:: Klassen komponieren, statt Dicts/Tupel tief zu verschachteln; `@classmethod`-Polymorphie nutzen; öffentliche Attribute und `@property` gegenüber Gettern/Settern bevorzugen; Funktionen statt Klassen für einfache Interfaces verwenden
+
+Metaklassen und Attribute:: `@property` und Deskriptoren für wiederverwendbares Attributverhalten nutzen; `__getattr__`/`__getattribute__` sparsam einsetzen; Subklassen mit `__init_subclass__` validieren
+
+Nebenläufigkeit und Parallelität:: Threads für blockierende I/O nutzen, nicht für Parallelität (das GIL); `Queue` zur Koordination von Pipelines; Coroutinen und `asyncio` für viele nebenläufige Funktionen; `concurrent.futures` und Prozesse für echte Parallelität
+
+Robustheit, Testen und Zusammenarbeit:: Programme robust und performant machen (neue Kapitel in der 3. Auflage); mit `unittest`/`Mock` testen; mit Docstrings dokumentieren; Abhängigkeiten mit virtuellen Umgebungen (`venv`) isolieren
+
+Schlüsselvertreter:: Brett Slatkin ("Effective Python", Addison-Wesley) — Principal Software Engineer bei Google und Autor der lauffähigen Beispielsammlung des Buches
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Einarbeitung von Python-Entwicklern in idiomatischen, robusten ("pythonischen") Code
+* Code-Review-Diskussionen auf Basis eines gemeinsamen, zitierbaren Regelsatzes ("Item 30: consider generators instead of returning lists")
+* Etablierung teamweiter Python-Coding-Standards und Konventionen
+* Erklärung Python-spezifischer Idiome und Fallstricke (Comprehensions, Generatoren, das GIL, `@property`, keyword-only-Argumente)
+* Aufforderung an ein LLM, idiomatischen, produktionsreifen Python-Code zu erzeugen
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<effective-java,Effective Java>>
+* <<effective-go,Effective Go>>
+* <<solid-principles,SOLID Principles>>
+
+[discrete]
+== *Aktueller Status*:
+
+* Die 3. Auflage (Pearson Addison-Wesley, https://www.informit.com/store/effective-python-125-specific-ways-to-write-better-9780138172183[erschienen am 20. November 2024], ISBN 978-0-13-817218-3) ist die aktuelle Auflage. Sie erweitert die 90 Items der 2. Auflage auf 125 Items — https://effectivepython.com/[35 neue Items] sowie zwei neue Kapitel zu Robustheit und Performance
+* Die 1. Auflage (2015) adressierte Python 2 und 3; die 2. Auflage (2019) war Python-3-only bis ~3.8; die 3. Auflage deckt modernes Python 3 ab, einschließlich Features wie den Walross-Operator, strukturelles Pattern Matching sowie aktualisierte Typing- und `asyncio`-Empfehlungen
+* Die Kernaussagen des Buches (Comprehensions und Generatoren bevorzugen, das GIL respektieren, Klassen komponieren, `@property` nutzen) bleiben über die Auflagen stabil; nur einzelne Items folgen der Sprache. Ein auf "Effective Python" geprägter Trainingsdaten-Prior spiegelt am ehesten die 2. Auflage (90 Items) wider und schweigt daher zu den 35 in der 3. Auflage ergänzten Items
+
+====

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -734,6 +734,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Joshua Bloch
 - **Core:** Catalog of ~90 "Items" of idiomatic Java best practice — static factories & the Builder pattern, the equals/hashCode contracts, minimize mutability, composition over inheritance, generics with PECS, enums over int constants, and try-with-resources
 
+### Effective Python
+- **Proponents:** Brett Slatkin
+- **Core:** Catalog of ~125 "Items" of idiomatic ("Pythonic") best practice — PEP 8 & the Zen of Python, comprehensions and generators over map/filter, prefer exceptions to returning None, keyword-only arguments, compose classes and use @property, threads for I/O vs. the GIL, asyncio and concurrent.futures for concurrency
+
 ### 50/72 Rule
 - **Also known as:** Git Commit Message Convention, Seven Rules of Git Commits
 - **Proponents:** Tim Pope

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -734,6 +734,10 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** Joshua Bloch
 - **Core:** Catalog of ~90 "Items" of idiomatic Java best practice — static factories & the Builder pattern, the equals/hashCode contracts, minimize mutability, composition over inheritance, generics with PECS, enums over int constants, and try-with-resources
 
+### Effective Python
+- **Proponents:** Brett Slatkin
+- **Core:** Catalog of ~125 "Items" of idiomatic ("Pythonic") best practice — PEP 8 & the Zen of Python, comprehensions and generators over map/filter, prefer exceptions to returning None, keyword-only arguments, compose classes and use @property, threads for I/O vs. the GIL, asyncio and concurrent.futures for concurrency
+
 ### 50/72 Rule
 - **Also known as:** Git Commit Message Convention, Seven Rules of Git Commits
 - **Proponents:** Tim Pope


### PR DESCRIPTION
## Summary

Adds the **Effective Python** semantic anchor, completing the "Effective *" family alongside the existing `effective-java` and `effective-go` anchors.

- `docs/anchors/effective-python.adoc` (EN) and `effective-python.de.adoc` (DE)
- Category `development-workflow`; roles `software-developer`, `software-architect`; related to `effective-java`, `effective-go`, `solid-principles`
- Core Concepts cover Pythonic thinking (PEP 8 / Zen of Python), comprehensions & generators, functions, classes/`@property`, the GIL & concurrency (`asyncio`, `concurrent.futures`), and robustness/testing
- **Current Status** section is fetch-verified: cites the 3rd edition (125 Items, published 20 Nov 2024, Pearson Addison-Wesley, ISBN 978-0-13-817218-3) and notes a training-data prior most plausibly reflects the 2nd edition (90 Items)
- No **Criticism** section: no citable *named* critic found, consistent with the `effective-java`/`effective-go` siblings

## Housekeeping

- Updated the AgentSkill catalog (`skill/.../catalog.md`) and synced the plugin copy (`plugins/.../catalog.md`)
- Regenerated `website/public/data/*.json` via `npm run extract-metadata` (188 → 189 anchors)

## Verification

- `extract-metadata` parses the new `.adoc` cleanly; anchor appears in `anchors.json` with correct metadata
- EN/DE metadata parity maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * „Effective Python“ wurde als neue deutsch- und englischsprachige Ressourcenübersicht ergänzt.
  * Die Übersicht fasst rund 125 Python-Best Practices zusammen, darunter PEP 8, Generatoren, Comprehensions, Funktionen, Klassen, Testen und Nebenläufigkeit.
  * Ergänzt wurden Einsatzszenarien, aktuelle Editionsinformationen, Metadaten sowie Verweise auf verwandte Ressourcen.
  * Die Ressource ist nun auch in den relevanten Katalogen und Übersichten auffindbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->