### PR TITLE
feat: add Locality of Behaviour (#701), triaged with the prior test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "semantic-anchors",
       "description": "Semantic anchor skills for translating established methodologies and installing persistent coding-agent context.",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "LLM Coding",
         "url": "https://github.com/LLM-Coding"

--- a/docs/anchors/locality-of-behaviour.adoc
+++ b/docs/anchors/locality-of-behaviour.adoc
@@ -1,0 +1,54 @@
+= Locality of Behaviour
+:categories: design-principles
+:roles: software-developer, software-architect, team-lead
+:proponents: Carson Gross
+:tags: locality of behaviour, locality of behavior, LoB, htmx, co-location, action at a distance, readability, hypermedia, separation of concerns
+:related: separation-of-concerns, dry, deep-modules, solid-srp
+:tier: 3
+:prior-test: 2026-08-14
+
+[%collapsible]
+====
+Full Name:: Locality of Behaviour
+
+Also known as:: Locality of Behavior (American spelling, used in _Hypermedia Systems_)
+
+[discrete]
+== *Core Concepts*:
+
+* *The principle in one sentence*, from the essay that named it: "The behaviour of a unit of code should be as obvious as possible by looking only at that unit of code."
+* *Read-time cost over write-time cost.* The measure is how far a reader must travel to answer "what happens when this runs", not how few characters the author typed.
+* *Behaviour at a distance is the failure mode.* A handler registered in a remote file, a convention that binds by name, a framework hook that fires invisibly -- each is correct code that cannot be understood locally.
+* *Co-location as the remedy*: markup, handler, styling and validation for one element live where that element is.
+* *An explicit trade, not a law.* The essay argues against DRY and Separation of Concerns *where they scatter one feature across many files*, and concedes the trade openly rather than claiming the other principles are wrong.
+
+[discrete]
+== *When to Use*:
+
+* Reviewing a design where understanding one element requires opening several unrelated files
+* Deciding whether an abstraction earns its indirection, or only moves code elsewhere
+* Weighing convention-over-configuration, dependency injection, event buses, decorators and lifecycle hooks -- all of which trade locality for other goods
+* Arguing about whether a repeated fragment should be extracted at all
+
+[discrete]
+== *Common Misunderstandings*:
+
+* *Reading it as anti-abstraction.* A good abstraction leaves its invocation and effects obvious at the call site; that is entirely compatible with the principle.
+* *Confusing it with Locality of Reference.* That is a hardware-performance concept about memory access patterns (temporal and spatial locality). The name is a coincidence, not a lineage.
+* *Treating co-location as sufficient.* Visible is not the same as understandable -- see the Criticism section.
+* *Using the abbreviation on its own.* "LoB" reads as "Line of Business" far more often than as this principle.
+====
+
+== *Criticism*:
+
+* *Co-location makes behaviour visible, not understandable.* John Freeman argues in https://www.eloquentarchitecture.com/locality-of-behavior/["Locality of Behavior on its own isn't enough"] (January 2023) that `<button hx-get="/clicked">` shows *that* something happens, not *what*: "One can only achieve behavior transparency to a certain extent without also taking a minute to name things well."
+* *The principle is turned against its own tool.* Chris Done's https://chrisdone.com/posts/htmx-critique/["A modest critique of Htmx"] (August 2024) uses LoB to argue that htmx breaks it: attribute inheritance means behaviour "comes from all the way up there or some other module", so it "is not local". The same objection was raised inside the project in https://github.com/bigskysoftware/htmx/discussions/2835[htmx discussion #2835].
+* *The sharpest objection is that it renames a trade-off.* On https://news.ycombinator.com/item?id=38241623[Hacker News], a commenter calls it "such a poorly defined rule -- it's just an invented name for going against separation of concerns". Recorded because it states the strongest form of the counter-position, but the author is pseudonymous, which is weaker evidence than the named critiques above.
+* *The documented counter-argument is thinner than the claim deserves.* For an essay that attacks Separation of Concerns directly, a search in English and German found no worked rebuttal from the established frontend or SPA side that names the principle. The critique that exists comes from inside the htmx camp or is constructive rather than opposing. That is an absence in our search, not a demonstrated absence.
+
+[discrete]
+== *Current Status*:
+
+* *Named in 2020, still the current formulation.* Carson Gross, https://htmx.org/essays/locality-of-behaviour/["Locality of Behaviour (LoB)"], 29 May 2020. The essay does not claim the idea is new; it credits Richard P. Gabriel's _Patterns of Software_ (Oxford University Press, 1996) for the underlying notion of locality -- a quotation we verified in the essay but not in Gabriel's book itself.
+* *Two spellings, one author.* The essay uses the British "Behaviour"; the book https://hypermedia.systems/client-side-scripting/[_Hypermedia Systems_] (2023) uses the American "Behavior". Both are primary. This entry follows the essay, which is also the spelling that measured stronger on weak models -- see the link:#/prior-tests[prior-test register].
+* *Adopted beyond htmx, but within one family.* Django (Carlton Gibson, https://buttondown.com/carlton/archive/locality-of-behaviour/[2024], calling it "a starting point, not a destination") and Laravel (https://freek.dev/2513-locality-of-behaviour[Freek Van der Herten, 2023]) have taken it up. These are server-rendered ecosystems adjacent to htmx; adoption into independent textbooks, standards or framework documentation is not established.

--- a/docs/anchors/locality-of-behaviour.de.adoc
+++ b/docs/anchors/locality-of-behaviour.de.adoc
@@ -1,0 +1,61 @@
+= Locality of Behaviour
+:categories: design-principles
+:roles: software-developer, software-architect, team-lead
+:proponents: Carson Gross
+:tags: Locality of Behaviour, Locality of Behavior, LoB, htmx, Ko-Lokation, Action at a Distance, Lesbarkeit, Hypermedia, Separation of Concerns
+:related: separation-of-concerns, dry, deep-modules, solid-srp
+:tier: 3
+:prior-test: 2026-08-14
+
+[%collapsible]
+====
+Vollständiger Name:: Locality of Behaviour
+
+Auch bekannt als:: Locality of Behavior (amerikanische Schreibweise, so im Buch _Hypermedia Systems_)
+
+[discrete]
+== *Kernkonzepte*:
+
+Das Prinzip in einem Satz:: So steht es im Essay, das den Begriff geprägt hat: „The behaviour of a unit of code should be as obvious as possible by looking only at that unit of code."
+
+Lesekosten schlagen Schreibkosten:: Maßstab ist, wie weit ein Leser gehen muss, um „Was passiert hier beim Ausführen?" zu beantworten -- nicht, wie wenige Zeichen der Autor getippt hat.
+
+Verhalten auf Distanz ist der Fehlermodus:: Ein Handler in einer entfernten Datei, eine Konvention, die über Namen bindet, ein Framework-Hook, der unsichtbar feuert -- jedes für sich korrekter Code, der lokal nicht verstehbar ist.
+
+Ko-Lokation als Gegenmittel:: Markup, Handler, Styling und Validierung eines Elements liegen dort, wo das Element liegt.
+
+Ein ausgesprochener Tausch, kein Gesetz:: Das Essay argumentiert gegen DRY und Separation of Concerns *dort, wo sie ein Feature über viele Dateien verstreuen*, und benennt den Tausch offen, statt die anderen Prinzipien für falsch zu erklären.
+
+[discrete]
+== *Wann einsetzen*:
+
+* Beim Review eines Entwurfs, bei dem das Verständnis eines Elements das Öffnen mehrerer unbeteiligter Dateien verlangt
+* Bei der Frage, ob eine Abstraktion ihre Indirektion verdient oder Code nur verschiebt
+* Beim Abwägen von Convention over Configuration, Dependency Injection, Event-Bussen, Dekoratoren und Lifecycle-Hooks -- die alle Lokalität gegen andere Güter tauschen
+* Beim Streit darüber, ob ein wiederholtes Fragment überhaupt extrahiert werden soll
+
+[discrete]
+== *Häufige Missverständnisse*:
+
+Es als abstraktionsfeindlich lesen:: Eine gute Abstraktion lässt Aufruf und Wirkung an der Aufrufstelle sichtbar; das verträgt sich bestens mit dem Prinzip.
+
+Verwechslung mit Locality of Reference:: Das ist ein Hardware-Performance-Konzept über Speicherzugriffsmuster (zeitliche und räumliche Lokalität). Die Namensähnlichkeit ist Zufall, keine Verwandtschaft.
+
+Ko-Lokation für hinreichend halten:: Sichtbar ist nicht dasselbe wie verständlich -- siehe Kritik.
+
+Das Kürzel allein verwenden:: „LoB" liest sich weit häufiger als „Line of Business" denn als dieses Prinzip.
+====
+
+== *Kritik*:
+
+* *Ko-Lokation macht Verhalten sichtbar, nicht verständlich.* John Freeman argumentiert in https://www.eloquentarchitecture.com/locality-of-behavior/[„Locality of Behavior on its own isn't enough"] (Januar 2023), `<button hx-get="/clicked">` zeige, *dass* etwas passiert, nicht *was*: „One can only achieve behavior transparency to a certain extent without also taking a minute to name things well."
+* *Das Prinzip wird gegen sein eigenes Werkzeug gewendet.* Chris Done nutzt es in https://chrisdone.com/posts/htmx-critique/[„A modest critique of Htmx"] (August 2024), um htmx selbst zu treffen: Durch Attribut-Vererbung komme Verhalten „from all the way up there or some other module" und sei damit „not local". Derselbe Einwand kam aus dem Projekt heraus in https://github.com/bigskysoftware/htmx/discussions/2835[htmx-Diskussion #2835].
+* *Der schärfste Einwand lautet, es benenne bloß einen Tausch um.* Auf https://news.ycombinator.com/item?id=38241623[Hacker News] heißt es, das sei „such a poorly defined rule -- it's just an invented name for going against separation of concerns". Festgehalten, weil es die Gegenposition in ihrer stärksten Form formuliert; der Autor ist allerdings pseudonym und damit ein schwächerer Beleg als die benannten Kritiken darüber.
+* *Die belegbare Gegenrede ist dünner, als der Anspruch es verlangt.* Für ein Essay, das Separation of Concerns frontal angreift, fand eine Suche auf Englisch und Deutsch keine ausgearbeitete Erwiderung aus dem etablierten Frontend- oder SPA-Lager, die das Prinzip benennt. Was es gibt, kommt aus dem htmx-Umfeld selbst oder ist ergänzend statt widersprechend. Das ist eine Lücke unserer Suche, keine belegte Lücke.
+
+[discrete]
+== *Aktueller Stand*:
+
+* *2020 benannt, Formulierung unverändert.* Carson Gross, https://htmx.org/essays/locality-of-behaviour/[„Locality of Behaviour (LoB)"], 29. Mai 2020. Das Essay beansprucht keine Neuschöpfung des Gedankens, sondern verweist für den Kern auf Richard P. Gabriels _Patterns of Software_ (Oxford University Press, 1996) -- ein Zitat, das wir im Essay belegen konnten, nicht aber in Gabriels Buch selbst.
+* *Zwei Schreibweisen, ein Autor.* Das Essay schreibt britisch „Behaviour", das Buch https://hypermedia.systems/client-side-scripting/[_Hypermedia Systems_] (2023) amerikanisch „Behavior". Beide sind Primärquellen. Dieser Eintrag folgt dem Essay -- das ist zugleich die Schreibweise, die auf schwachen Modellen stärker gemessen hat, siehe link:#/prior-tests[Prior-Test-Register].
+* *Über htmx hinaus übernommen, aber innerhalb einer Familie.* Django (Carlton Gibson, https://buttondown.com/carlton/archive/locality-of-behaviour/[2024], der es „a starting point, not a destination" nennt) und Laravel (https://freek.dev/2513-locality-of-behaviour[Freek Van der Herten, 2023]) haben es aufgegriffen. Das sind serverseitig rendernde Ökosysteme im Umfeld von htmx; eine Aufnahme in unabhängige Lehrbücher, Standards oder Framework-Dokumentationen ist nicht belegt.

--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,13 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-08-14
 
+*New anchor — Locality of Behaviour (#701), the first community proposal triaged with the prior test:*
+
+* *link:#/anchor/locality-of-behaviour[Locality of Behaviour]* (Carson Gross, https://htmx.org/essays/locality-of-behaviour/[htmx essay], 29 May 2020) — design-principles: "The behaviour of a unit of code should be as obvious as possible by looking only at that unit of code." Optimise for read-time cost over write-time cost; behaviour at a distance is the failure mode, co-location the remedy. Tier ★★★, proposed by https://github.com/simonthum[@simonthum] in #701.
+* *It produced the clearest lift measured so far, because the term changes the verdict and not just the vocabulary.* Asked to review a design that registers every click handler in one central JavaScript file, both neutral baseline runs returned a balanced review that listed *Separation of Concerns* among the *strengths* and never mentioned locality. With the term, the first heading is "Behaviour at distance". The baseline praises exactly the position the essay attacks.
+* Two findings are recorded rather than smoothed away. The abbreviation *LoB* returns "Line of Business" on every tier, so the catalog name is spelled out. And the author uses two spellings — British in the essay, American in _Hypermedia Systems_ — so both were tested; the British form measured stronger on weak models, which is also the essay's own spelling. Details in the link:#/prior-tests[prior-test register].
+* The Criticism section carries three named critics, including one who turns the principle against htmx itself, and records that no worked rebuttal from the established frontend side could be found — an absence in our search, not a demonstrated absence.
+
 *Two new anchors, and the first two whose tier was measured rather than judged:*
 
 * *link:#/anchor/premortem[Premortem]* (Gary Klein, _Harvard Business Review_ 85(9), September 2007) — problem-solving + strategic-planning: state as fact that the plan has already failed, then have each participant write down why, independently, and collect the reasons round-robin. The failure is a premise, not a possibility, and that is the whole technique. Tier ★★★. The Criticism section reports the one citable critic found: Jason Collins shows that the widely repeated "30 percent" figure does not say what it is used to say — the 1989 study behind it measured the *number* of reasons generated, and "did not assess the quality of the reasons". The claim that the technique improves correct identification by 30 percent originates in the 2007 restatement, not in the study.

--- a/docs/prior-tests.adoc
+++ b/docs/prior-tests.adoc
@@ -103,3 +103,32 @@ This is separate from the rename check in the table above, where "second-level t
 *Criticism research, 2026-08-14, English and German.* Nothing citable against the term itself — no named author calling it trivial, unfalsifiable or unusable. Three named critics of the surrounding mental-models literature were found (Cedric Chin, Richard Hughes-Jones, Boris Gorelik) and are cited in the anchor, with the explicit note that none of them discusses second-order thinking.
 
 Here the absence is unsurprising rather than suspicious: a term coined by no one and popularised by blogs does not attract rebuttals the way a named method does. Contrast this with the premortem entry above, where an absence of independent critique is odd for a widely adopted technique and more likely reflects our search than the literature. Closed communities — Farnam Street's paid membership among them — are not indexed and were not reachable. No hidden non-English scene is expected for this term, since it is an anglophone blog import with no natively named counterpart; that is a prediction, not a verified result.
+
+=== Locality of Behaviour
+
+[cols="2,1,3"]
+|===
+|Criterion |Verdict |Evidence
+
+|Precise |met, for the spelled-out name |P2 returns software design on both tiers for "locality of behaviour"; the abbreviation does not — see below
+|Rich |met |5/6 runs report `richness=rich`; one weak-tier run reports `moderate`
+|Consistent |met for action, weaker for recall |P3 agrees 6/6 across all three tiers; P1 splits on the weak tier
+|Attributable |met |Carson Gross, htmx essay, 29 May 2020 — confirmed by desk research. The strong tier names him with `confidence=high`
+|Prior density |strong |Recognised and acting as an instruction on the weak tier
+|===
+
+Tier ★★★ for the spelled-out name, route: anchor. Two caveats are recorded below rather than folded into the rating.
+
+*This is the clearest lift measured so far, because the anchor changes the verdict and not just the vocabulary.* The action probe asked for a review of a design that registers all click handlers in one central JavaScript file, matched by CSS selector.
+
+Both neutral baseline runs produced a balanced strengths-and-weaknesses review — and both listed *Separation of Concerns* among the *strengths*. Neither mentioned locality once. With the term, the first heading is "Behaviour at distance", followed by "Why it fails LoB". The baseline praises exactly the position the essay attacks.
+
+*The abbreviation is taken.* "LoB" returns business and enterprise terminology on both tiers, with `mentioned_code_locality=no` in each. The catalog name must be spelled out; the abbreviation alone would fail.
+
+*Recall and execution come apart, and the weak tier misattributes.* Asked who created the principle, the weak tier answers "Dan North (probable)" while the strong tier gives Carson Gross with high confidence. The same weak tier reports `reaching=yes` in both P1 runs and `richness=moderate` in one — yet its action output is specific and correct. A model can apply a move it cannot source.
+
+*Spelling was measured, because the author uses both.* The essay is British ("Behaviour"), the book _Hypermedia Systems_ is American ("Behavior"). On the weak tier the British spelling was recognised in 2 of 2 runs, the American in 1 of 2 — one American run reported `recognized=no` — and both American runs reported only `moderate` richness. The action test does not separate them (2/2 each). At n=2 this is suggestive, not established; the decision does not rest on it alone, since the primary source uses the same spelling.
+
+*Criticism research, 2026-08-14, English and German.* Three named critics found and cited in the anchor: John Freeman (co-location makes behaviour visible, not understandable), Chris Done (htmx breaks the principle through attribute inheritance) and a htmx discussion raising the same objection from inside the project. A fourth, sharper formulation — that the principle merely renames going against separation of concerns — is recorded but pseudonymous.
+
+No worked rebuttal from the established frontend or SPA side was found in either language, which is odd for an essay attacking Separation of Concerns head-on and more likely reflects our search than the discourse. Unreached: X/Twitter, Reddit, the htmx community chat, podcasts, one blog returning 403, and Gabriel's book PDF, which would not convert to text — so the Gabriel quotation is verified in the essay quoting it, not at its source.

--- a/docs/prior-tests.de.adoc
+++ b/docs/prior-tests.de.adoc
@@ -103,3 +103,32 @@ Davon zu unterscheiden ist der Rename-Check in der Tabelle oben: Dort meldete �
 *Kritik-Recherche, 14.08.2026, Englisch und Deutsch.* Zum Begriff selbst nichts Zitierfähiges -- kein benannter Autor, der ihn als trivial, unfalsifizierbar oder unbrauchbar angreift. Gefunden wurden drei benannte Kritiker der umgebenden Mental-Models-Literatur (Cedric Chin, Richard Hughes-Jones, Boris Gorelik); sie stehen im Anker, ausdrücklich mit dem Hinweis, dass keiner von ihnen Second-Order Thinking behandelt.
 
 Hier ist die Abwesenheit erwartbar statt verdächtig: Ein Begriff, den niemand geprägt hat und den Blogs populär gemacht haben, zieht keine Widerlegungen an wie eine benannte Methode. Beim Premortem weiter oben liegt es umgekehrt -- fehlende unabhängige Kritik ist bei einer breit übernommenen Technik erstaunlich und spricht eher für unseren Suchrahmen als für die Literatur. Geschlossene Communities, darunter die kostenpflichtige von Farnam Street, sind nicht indexiert und waren nicht erreichbar. Ein verborgener nicht-englischer Sprachraum ist für diesen Begriff nicht zu erwarten, weil er ein anglophoner Blog-Import ohne heimisch benanntes Gegenstück ist -- das ist eine Vorhersage, kein geprüftes Ergebnis.
+
+=== Locality of Behaviour
+
+[cols="2,1,3"]
+|===
+|Kriterium |Urteil |Beleg
+
+|Präzise |erfüllt, für den ausgeschriebenen Namen |P2 liefert für „locality of behaviour" auf beiden Stufen Software Design; das Kürzel nicht — siehe unten
+|Reich |erfüllt |5/6 Läufe melden `richness=rich`; ein Lauf der schwachen Stufe meldet `moderate`
+|Konsistent |erfüllt beim Anwenden, schwächer beim Erinnern |P3 stimmt 6/6 über alle drei Stufen; P1 spaltet sich auf der schwachen Stufe
+|Zuschreibbar |erfüllt |Carson Gross, htmx-Essay, 29. Mai 2020 — durch Recherche bestätigt. Die starke Stufe nennt ihn mit `confidence=high`
+|Prior-Dichte |stark |Erkannt und als Anweisung wirksam auch auf der schwachen Stufe
+|===
+
+Tier ★★★ für den ausgeschriebenen Namen, Route: Anchor. Zwei Vorbehalte stehen unten, statt in die Bewertung eingerechnet zu werden.
+
+*Das ist der deutlichste bisher gemessene Hebel, weil der Anker das Urteil ändert und nicht nur das Vokabular.* Die Aktionsprobe ließ einen Entwurf bewerten, der alle Click-Handler in einer zentralen JavaScript-Datei registriert, den Elementen über CSS-Selektoren zugeordnet.
+
+Beide neutralen Baseline-Läufe lieferten eine ausgewogene Stärken-Schwächen-Bewertung — und beide führten *Separation of Concerns* unter den *Stärken*. Lokalität erwähnte keiner ein einziges Mal. Mit dem Begriff lautet die erste Überschrift „Behaviour at distance", gefolgt von „Why it fails LoB". Die Baseline lobt genau die Position, die das Essay angreift.
+
+*Das Kürzel ist besetzt.* „LoB" liefert auf beiden Stufen Business- und Enterprise-Terminologie, jeweils mit `mentioned_code_locality=no`. Der Katalogname muss ausgeschrieben sein; das Kürzel allein wäre ein Fehlschlag.
+
+*Erinnern und Ausführen fallen auseinander, und die schwache Stufe schreibt falsch zu.* Auf die Frage nach dem Urheber antwortet sie „Dan North (probable)", die starke Stufe nennt Carson Gross mit hoher Konfidenz. Dieselbe schwache Stufe meldet in beiden P1-Läufen `reaching=yes` und in einem `richness=moderate` — ihre Aktionsausgabe ist trotzdem konkret und richtig. Ein Modell kann eine Bewegung ausführen, deren Herkunft es nicht kennt.
+
+*Die Schreibweise wurde gemessen, weil der Autor beide verwendet.* Das Essay ist britisch („Behaviour"), das Buch _Hypermedia Systems_ amerikanisch („Behavior"). Auf der schwachen Stufe wurde die britische Form in 2 von 2 Läufen erkannt, die amerikanische in 1 von 2 — ein amerikanischer Lauf meldete `recognized=no` — und beide amerikanischen Läufe nur `moderate`. Der Action-Test trennt sie nicht (je 2/2). Bei n=2 ist das ein Hinweis, kein Beleg; die Entscheidung ruht nicht allein darauf, weil die Primärquelle dieselbe Schreibweise verwendet.
+
+*Kritik-Recherche, 14.08.2026, Englisch und Deutsch.* Drei benannte Kritiker gefunden und im Anker zitiert: John Freeman (Ko-Lokation macht Verhalten sichtbar, nicht verständlich), Chris Done (htmx bricht das Prinzip durch Attribut-Vererbung) und eine htmx-Diskussion, die denselben Einwand aus dem Projekt heraus erhebt. Eine vierte, schärfere Formulierung — das Prinzip benenne bloß um, dass man gegen Separation of Concerns verstößt — ist festgehalten, stammt aber von einem Pseudonym.
+
+Eine ausgearbeitete Erwiderung aus dem etablierten Frontend- oder SPA-Lager fand sich in keiner der beiden Sprachen. Für ein Essay, das Separation of Concerns frontal angreift, ist das erstaunlich und spricht eher für unseren Suchrahmen als für den Diskurs. Nicht erreicht: X/Twitter, Reddit, der htmx-Community-Chat, Podcasts, ein Blog mit HTTP 403 sowie Gabriels Buch-PDF, das sich nicht in Text umwandeln ließ — das Gabriel-Zitat ist daher im zitierenden Essay belegt, nicht an der Quelle.

--- a/plugins/semantic-anchors/plugin.json
+++ b/plugins/semantic-anchors/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-anchors",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Semantic anchor skills for translating terminology and installing persistent anchor context into coding agents.",
   "author": {
     "name": "LLM Coding",

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/SKILL.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/SKILL.md
@@ -3,7 +3,7 @@ name: semantic-anchor-translator
 description: Bi-directional translator between verbose descriptions and established terminology (semantic anchors). Use when (1) user describes a concept verbosely and you want to identify the precise term, or (2) user asks for methodology/approach and you want to suggest relevant anchors. Covers 120+ terms across testing, architecture, design principles, problem-solving, requirements, documentation, communication, development workflow, statistical methods, strategic planning, and creative writing.
 metadata:
   author: LLM-Coding
-  version: "1.1"
+  version: "1.2"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -434,6 +434,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** John Ousterhout
 - **Core:** Simple interface hiding powerful implementation — a module is deep when its benefit (functionality provided) far exceeds its cost (interface complexity); shallow modules and "classitis" (too many tiny classes) are the anti-patterns; companion principle: "different layer, different abstraction"; rooted in information hiding (Parnas)
 
+### Locality of Behaviour
+- **Also known as:** Locality of Behavior (American spelling); LoB — but never use the abbreviation alone, it reads as "Line of Business"
+- **Proponents:** Carson Gross (htmx essay, 2020)
+- **Core:** "The behaviour of a unit of code should be as obvious as possible by looking only at that unit of code" — optimise for read-time cost over write-time cost; behaviour at a distance (remote handlers, name-binding conventions, invisible framework hooks) is the failure mode, co-location the remedy; an explicit trade against DRY and Separation of Concerns where they scatter one feature across many files, not a claim that they are wrong
+
 ## Problem-Solving
 
 ### First Principles Thinking

--- a/skill/semantic-anchor-translator/SKILL.md
+++ b/skill/semantic-anchor-translator/SKILL.md
@@ -3,7 +3,7 @@ name: semantic-anchor-translator
 description: Bi-directional translator between verbose descriptions and established terminology (semantic anchors). Use when (1) user describes a concept verbosely and you want to identify the precise term, or (2) user asks for methodology/approach and you want to suggest relevant anchors. Covers 120+ terms across testing, architecture, design principles, problem-solving, requirements, documentation, communication, development workflow, statistical methods, strategic planning, and creative writing.
 metadata:
   author: LLM-Coding
-  version: "1.1"
+  version: "1.2"
   source: https://github.com/LLM-Coding/Semantic-Anchors
 license: MIT
 ---

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -434,6 +434,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** John Ousterhout
 - **Core:** Simple interface hiding powerful implementation — a module is deep when its benefit (functionality provided) far exceeds its cost (interface complexity); shallow modules and "classitis" (too many tiny classes) are the anti-patterns; companion principle: "different layer, different abstraction"; rooted in information hiding (Parnas)
 
+### Locality of Behaviour
+- **Also known as:** Locality of Behavior (American spelling); LoB — but never use the abbreviation alone, it reads as "Line of Business"
+- **Proponents:** Carson Gross (htmx essay, 2020)
+- **Core:** "The behaviour of a unit of code should be as obvious as possible by looking only at that unit of code" — optimise for read-time cost over write-time cost; behaviour at a distance (remote handlers, name-binding conventions, invisible framework hooks) is the failure mode, co-location the remedy; an explicit trade against DRY and Separation of Concerns where they scatter one feature across many files, not a claim that they are wrong
+
 ## Problem-Solving
 
 ### First Principles Thinking


### PR DESCRIPTION
Closes #701. Proposed by @simonthum — thank you, the proposal was unusually well prepared, with the DRY and Separation-of-Concerns tension already worked out.

This is the **first community proposal put through the [Anchor Prior Test](https://llm-coding.github.io/Semantic-Anchors/anchor-prior-test)** rather than accepted on its activation test. The proposal's own test ran on ChatGPT Pro — a frontier model, which is the *least* informative tier under our procedure. A strong anchor has to survive the weak one.

**Verdict: ★★★, route anchor.** Measured 2026-08-14 against `claude-haiku-4-5-20251001`, `claude-sonnet-5` and `claude-opus-5`; decisive probes twice per tier; neutral baseline.

## The lift is the clearest we have measured

The action probe asked for a review of a design that registers every click handler in one central JavaScript file, matched by CSS selector.

Both neutral baseline runs returned a balanced strengths-and-weaknesses review — and both listed **Separation of Concerns among the *strengths***. Neither mentioned locality once. With the term, the first heading is "Behaviour at distance", followed by "Why it fails LoB".

The baseline praises exactly the position the essay attacks. The anchor does not add vocabulary; it flips the evaluation.

## Three findings recorded rather than smoothed away

**The abbreviation is taken.** `LoB` returns business and enterprise terminology on both tiers, `mentioned_code_locality=no` in each. The catalog name is spelled out, and the anchor says so under Common Misunderstandings.

**Recall and execution come apart.** Asked who created the principle, the weak tier answers *"Dan North (probable)"*; the strong tier gives Carson Gross with high confidence. The same weak tier reaches in both free-association runs — yet its action output is specific and correct. A model can apply a move whose source it does not know, which is why the procedure separates the two axes.

**The author uses two spellings**, so both were tested: British in the [essay](https://htmx.org/essays/locality-of-behaviour/), American in [*Hypermedia Systems*](https://hypermedia.systems/client-side-scripting/).

| weak tier | British (essay) | American (book) |
|---|---|---|
| recognised | 2/2 | **1/2** (one run reported `recognized=no`) |
| richness | 1× rich, 1× moderate | 2× moderate |
| action test | 2/2 | 2/2 |

At n=2 that is suggestive, not established, and the register says so. The decision does not rest on it alone — the primary source uses the same spelling.

## Criticism

Three named critics, cited with fetch-verified sources:

- **John Freeman** — co-location makes behaviour *visible*, not *understandable*: `<button hx-get="/clicked">` shows *that* something happens, not *what*
- **Chris Done** — turns the principle against its own tool: htmx's attribute inheritance means behaviour "comes from all the way up there", so it "is not local"
- **htmx discussion #2835** — the same objection raised from inside the project

A fourth and sharper formulation — that the principle "is just an invented name for going against separation of concerns" — is recorded but pseudonymous, and labelled as weaker evidence.

Worth stating plainly: **no worked rebuttal from the established frontend or SPA side was found** in English or German. For an essay attacking Separation of Concerns head-on that is odd, and more likely reflects our search than the discourse. The register names what could not be reached (X, Reddit, the htmx community chat, podcasts, one blog returning 403, and Gabriel's book PDF, which would not convert to text — so the Gabriel quotation is verified in the essay quoting it, not at its source).

## Verification

- Full build green over both `package.json`; 121 unit tests pass
- 194 anchors, three now carrying `:prior-test:` dates; detail pages prerendered EN and DE
- All eight cited sources fetched and content-checked, all returning 200
- Register entry added under the 2026-08-14 run with the criteria matrix, the baseline comparison and the search frame

Versions: `semantic-anchor-translator` 1.1 → 1.2 (catalog changed), plugin and marketplace 0.8.0 → 0.9.0, now moving together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)