### PR TITLE
feat: add ASD-STE100 (Simplified Technical English) semantic anchor

### DIFF
--- a/docs/anchors/asd-ste100.adoc
+++ b/docs/anchors/asd-ste100.adoc
@@ -1,0 +1,47 @@
+= ASD-STE100 (Simplified Technical English)
+:categories: communication-presentation
+:roles: technical-writer, software-developer, consultant, educator, business-analyst
+:related: gutes-deutsch-wolf-schneider, plain-english-strunk-white
+:proponents: AECMA, ASD Simplified Technical English Maintenance Group (STEMG)
+:tags: writing, english, clarity, controlled-language, technical-writing, standard, aerospace
+:tier: 3
+
+[%collapsible]
+====
+Full Name:: ASD Simplified Technical English (ASD-STE100)
+
+Also known as:: STE, Simplified Technical English, AECMA Simplified English
+
+[discrete]
+== *Core Concepts*:
+
+Controlled Vocabulary:: A dictionary of roughly 900 approved words; each word carries exactly one part of speech and one meaning, removing ambiguity that free English tolerates
+
+One Word, One Meaning:: Words outside the dictionary, or with meanings not listed, are disallowed — writers substitute an approved synonym instead
+
+Restricted Sentence Length:: Instructions run to a maximum of 20 words, descriptive text to 25 words; one instruction and one topic per sentence, one topic per paragraph
+
+Restricted Grammar:: Active voice preferred (passive only when the agent is unknown); a narrow set of permitted tenses (imperative, infinitive, simple present/past, future); no complex auxiliary constructions; multi-word nouns capped at three words
+
+Key Proponents:: AECMA / European Association of Aerospace Industries (first guide, 1986); ASD Simplified Technical English Maintenance Group (STEMG), current maintainer
+
+[discrete]
+== *When to Use*:
+
+* Writing maintenance, operating, or procedural documentation for technical or safety-critical equipment
+* Producing documentation for readers with limited English proficiency or a global, non-native-speaker audience
+* Designing UI copy or interface text where consistent, unambiguous wording matters (an application STE has expanded into beyond aerospace)
+* Any controlled-language use case where a fixed vocabulary and grammar reduce translation cost and ambiguity
+
+[discrete]
+== *Related Anchors*:
+
+* <<plain-english-strunk-white,Plain English according to Strunk & White>> — a general-purpose clarity standard for English prose, without a controlled vocabulary
+* <<gutes-deutsch-wolf-schneider,Gutes Deutsch nach Wolf Schneider>> — the German-language equivalent clarity-first standard
+
+[discrete]
+== *Current Status*:
+
+* Issue 9 (January 2025) is the current edition; ASD-STE100 gained international-standard status in 2025, after decades as an industry specification (international specification status since 2005) — a version shift a training-data prior may not reflect
+* Originally scoped to aerospace maintenance documentation, STE now sees documented use outside aerospace and defense — Wikipedia, https://en.wikipedia.org/wiki/Simplified_Technical_English["Simplified Technical English"] (accessed 2026) reports 64% of Issue 8 users worked outside those sectors, and that experts caution against treating STE as a substitute for a full grammar-based style guide or relying on software checkers in place of trained human review
+====

--- a/docs/anchors/asd-ste100.de.adoc
+++ b/docs/anchors/asd-ste100.de.adoc
@@ -1,0 +1,47 @@
+= ASD-STE100 (Simplified Technical English)
+:categories: communication-presentation
+:roles: technical-writer, software-developer, consultant, educator, business-analyst
+:related: gutes-deutsch-wolf-schneider, plain-english-strunk-white
+:proponents: AECMA, ASD Simplified Technical English Maintenance Group (STEMG)
+:tier: 3
+:tags: writing, english, clarity, controlled-language, technical-writing, standard, aerospace
+
+[%collapsible]
+====
+Vollständiger Name:: ASD Simplified Technical English (ASD-STE100)
+
+Auch bekannt als:: STE, Simplified Technical English, AECMA Simplified English
+
+[discrete]
+== *Kernkonzepte*:
+
+Kontrolliertes Vokabular:: Ein Wörterbuch mit rund 900 zugelassenen Wörtern; jedes Wort hat genau eine Wortart und eine Bedeutung — das entfernt Mehrdeutigkeit, die freies Englisch zulässt
+
+Ein Wort, eine Bedeutung:: Wörter außerhalb des Wörterbuchs, oder mit nicht gelisteten Bedeutungen, sind untersagt — Autoren verwenden stattdessen ein zugelassenes Synonym
+
+Begrenzte Satzlänge:: Anweisungen umfassen maximal 20 Wörter, beschreibende Texte maximal 25 Wörter; eine Anweisung und ein Thema pro Satz, ein Thema pro Absatz
+
+Begrenzte Grammatik:: Aktiv wird bevorzugt (Passiv nur, wenn der Handelnde unbekannt ist); ein eng begrenztes Set erlaubter Zeitformen (Imperativ, Infinitiv, einfaches Präsens/Präteritum, Futur); keine komplexen Hilfsverbkonstruktionen; mehrteilige Substantive auf drei Wörter begrenzt
+
+Schlüsselvertreter:: AECMA / European Association of Aerospace Industries (erster Leitfaden, 1986); ASD Simplified Technical English Maintenance Group (STEMG), aktueller Herausgeber
+
+[discrete]
+== *Wann zu verwenden*:
+
+* Beim Verfassen von Wartungs-, Bedienungs- oder Verfahrensdokumentation für technische oder sicherheitskritische Ausrüstung
+* Bei Dokumentation für Leser mit begrenzten Englischkenntnissen oder ein globales, nicht-muttersprachliches Publikum
+* Beim Entwurf von UI-Texten oder Schnittstellentexten, wo konsistente, eindeutige Formulierungen zählen (ein Anwendungsfeld, in das STE über die Luftfahrt hinaus expandiert ist)
+* Bei jedem Anwendungsfall für kontrollierte Sprache, bei dem ein festes Vokabular und eine feste Grammatik Übersetzungskosten und Mehrdeutigkeit reduzieren
+
+[discrete]
+== *Verwandte Anker*:
+
+* <<plain-english-strunk-white,Plain English nach Strunk & White>> — ein allgemeiner Klarheitsstandard für englische Prosa, ohne kontrolliertes Vokabular
+* <<gutes-deutsch-wolf-schneider,Gutes Deutsch nach Wolf Schneider>> — das deutschsprachige Äquivalent zu klarheitsfokussierten Standards
+
+[discrete]
+== *Aktueller Status*:
+
+* Issue 9 (Januar 2025) ist die aktuelle Ausgabe; ASD-STE100 erlangte 2025 den Status eines internationalen Standards, nach Jahrzehnten als Industriespezifikation (internationaler Spezifikationsstatus bereits seit 2005) — eine Versionsverschiebung, die ein Trainingsdaten-Prior möglicherweise nicht widerspiegelt
+* Ursprünglich auf Wartungsdokumentation der Luftfahrt beschränkt, wird STE inzwischen dokumentiert auch außerhalb von Luftfahrt und Verteidigung eingesetzt — Wikipedia, https://en.wikipedia.org/wiki/Simplified_Technical_English["Simplified Technical English"] (Stand 2026) berichtet, dass 64 % der Nutzer von Issue 8 außerhalb dieser Branchen arbeiteten, und dass Experten davor warnen, STE als Ersatz für einen vollständigen grammatikbasierten Styleguide zu behandeln oder sich bei der Anwendung auf Software-Prüfwerkzeuge statt geschultes menschliches Review zu verlassen
+====

--- a/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
+++ b/plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md
@@ -603,6 +603,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** William Strunk Jr., E.B. White
 - **Core:** Omit needless words, use active voice, prefer concrete language, write with nouns and verbs — clarity-first principles for English writing ("The Elements of Style")
 
+### ASD-STE100 (Simplified Technical English)
+- **Also known as:** STE, Simplified Technical English, AECMA Simplified English
+- **Proponents:** AECMA, ASD Simplified Technical English Maintenance Group (STEMG)
+- **Core:** Controlled vocabulary of ~900 approved words (one word, one meaning), restricted sentence length (20 words for instructions, 25 for descriptive text), restricted grammar (active voice, limited tenses) — a controlled-language standard for technical documentation, originating in aerospace maintenance manuals
+
 ### 4MAT
 - **Also known as:** 4MAT System of Instruction, McCarthy's 4MAT, 4MAT Learning Cycle
 - **Proponents:** Bernice McCarthy

--- a/skill/semantic-anchor-translator/references/catalog.md
+++ b/skill/semantic-anchor-translator/references/catalog.md
@@ -603,6 +603,11 @@ Source: https://github.com/LLM-Coding/Semantic-Anchors
 - **Proponents:** William Strunk Jr., E.B. White
 - **Core:** Omit needless words, use active voice, prefer concrete language, write with nouns and verbs — clarity-first principles for English writing ("The Elements of Style")
 
+### ASD-STE100 (Simplified Technical English)
+- **Also known as:** STE, Simplified Technical English, AECMA Simplified English
+- **Proponents:** AECMA, ASD Simplified Technical English Maintenance Group (STEMG)
+- **Core:** Controlled vocabulary of ~900 approved words (one word, one meaning), restricted sentence length (20 words for instructions, 25 for descriptive text), restricted grammar (active voice, limited tenses) — a controlled-language standard for technical documentation, originating in aerospace maintenance manuals
+
 ### 4MAT
 - **Also known as:** 4MAT System of Instruction, McCarthy's 4MAT, 4MAT Learning Cycle
 - **Proponents:** Bernice McCarthy


### PR DESCRIPTION
## Summary
- Adds a new semantic anchor for ASD-STE100 (Simplified Technical English) to the Communication & Presentation category, alongside the existing Strunk & White and Wolf Schneider clarity-first anchors.
- New files: `docs/anchors/asd-ste100.adoc` (EN) and `docs/anchors/asd-ste100.de.adoc` (DE), following the existing anchor template.
- Updates `skill/semantic-anchor-translator/references/catalog.md` and its synced copy in `plugins/semantic-anchors/skills/semantic-anchor-translator/references/catalog.md` per the AgentSkill sync checklist in CLAUDE.md.

## Details
ASD-STE100 (https://www.asd-ste100.org/) is a controlled-language standard for technical documentation, originating in aerospace maintenance manuals (AECMA, first guide 1986) and now maintained by the ASD Simplified Technical English Maintenance Group (STEMG). Core rules: a controlled vocabulary of ~900 approved words (one word, one meaning), restricted sentence length, and restricted grammar. Included a Current Status section noting Issue 9 (2025) and its international-standard status, with a fetch-verified source.

## Test plan
- [ ] Verify AsciiDoc renders correctly (headings, collapsible block, cross-references to related anchors)
- [ ] Confirm `:related:` cross-references resolve (`gutes-deutsch-wolf-schneider`, `plain-english-strunk-white`)
- [ ] Confirm catalog.md entries in both locations stay in sync


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Neue Dokumentation zu ASD-STE100 (Simplified Technical English) hinzugefügt.
  * Beschreibt kontrollierten Wortschatz, Satzlängen, Grammatik, Anwendungsfälle und verwandte Themen.
  * Ergänzt Informationen zum aktuellen Editionsstand und zur Nutzung außerhalb der Luftfahrt.
  * Die Übersichten der verfügbaren semantischen Anker wurden um ASD-STE100 erweitert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->