### PR TITLE
feat: move press and appearances above the fold on the landing page

### DIFF
--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -27,6 +27,7 @@
 const fs = require('fs')
 const path = require('path')
 const { extractDescription } = require('./generate-jsonld.js')
+const APPEARANCES = require('../website/src/data/appearances.json')
 
 const DIST = path.join(__dirname, '..', 'website', 'dist')
 const SHELL = path.join(DIST, 'index.html')
@@ -613,6 +614,32 @@ function prerenderAnchorPages(shell) {
  * single-sourced from the translations so it never drifts from the live
  * hero. EN overwrites dist/index.html, DE goes to dist/de/index.html.
  */
+/**
+ * Static mirror of the appearances strip under the hero. Deliberately simpler
+ * markup than the live component — same reason the static hero drops the
+ * before/after example: crawlers need the links and the labels, not the
+ * styling. The data is the same JSON the app renders, so the two cannot drift
+ * on who is listed.
+ */
+function buildAppearancesMarkup(tr) {
+  const group = (kind) =>
+    APPEARANCES.filter((entry) => entry.kind === kind)
+      .map(
+        (entry) =>
+          `<a href="${entry.href}" target="_blank" rel="noopener noreferrer">${escapeHtml(
+            entry.label
+          )}</a>`
+      )
+      .join(', ')
+
+  return `
+      <section class="mx-auto max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+        <p>${escapeHtml(tr['footer.featuredIn'] || '')}: ${group('press')}. ${escapeHtml(
+          tr['footer.asSeenOn'] || ''
+        )}: ${group('appearance')}.</p>
+      </section>`
+}
+
 function writeHomeVariant(shell, lang) {
   const tr = loadWebsiteJson(`src/translations/${lang}.json`)
   const title = tr['hero.title'] || ''
@@ -634,6 +661,7 @@ function writeHomeVariant(shell, lang) {
         <h2 class="text-2xl font-bold mb-2">${escapeHtml(answerHeading)}</h2>
         <p class="anchor-answer max-w-3xl" data-answer-block>${escapeHtml(answerBody)}</p>
       </section>
+      ${buildAppearancesMarkup(tr)}
       ${buildCatalogMarkup(lang, tr)}
     `
 

--- a/website/src/components/footer.js
+++ b/website/src/components/footer.js
@@ -1,4 +1,5 @@
 import { i18n } from '../i18n.js'
+import { renderAppearances } from '../data/appearances.js'
 
 export function renderFooter(version) {
   return `
@@ -66,79 +67,11 @@ export function renderFooter(version) {
           </div>
           <div class="flex flex-wrap items-center justify-center gap-2 pt-1">
             <span class="text-xs text-[var(--color-text-secondary)]" data-i18n="footer.asSeenOn">${i18n.t('footer.asSeenOn')}</span>
-            <a
-              href="https://www.youtube.com/watch?v=rQj-B3VTx48"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity"
-              title="${i18n.t('footer.hmzeAlt')}"
-            >
-              <img
-                src="${import.meta.env.BASE_URL}hmze-logo.png"
-                alt="HMZE Podcast"
-                width="28"
-                height="24"
-                class="h-6 w-auto"
-                loading="lazy"
-              />
-              <span class="text-xs text-[var(--color-text-secondary)]">HMZE (DE)</span>
-            </a>
-            <span class="text-gray-300 dark:text-gray-600">|</span>
-            <a
-              href="https://rabauer.dev"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity"
-              title="${i18n.t('footer.rabauerAlt')}"
-            >
-              <img
-                src="${import.meta.env.BASE_URL}rabauer-logo.png"
-                alt="rabauer.dev"
-                width="24"
-                height="24"
-                class="h-6 w-auto"
-                loading="lazy"
-              />
-              <span class="text-xs text-[var(--color-text-secondary)]">rabauer.dev (EN)</span>
-            </a>
-            <span class="text-gray-300 dark:text-gray-600">|</span>
-            <a
-              href="https://byndcode.com/episodes/ep016-ralf-d-mueller/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity"
-              title="${i18n.t('footer.byndcodeAlt')}"
-            >
-              <img
-                src="${import.meta.env.BASE_URL}byndcode-logo.png"
-                alt="Beyond Code Podcast"
-                width="24"
-                height="24"
-                class="h-6 w-auto rounded"
-                loading="lazy"
-              />
-              <span class="text-xs text-[var(--color-text-secondary)]">Beyond Code (DE)</span>
-            </a>
+            ${renderAppearances('appearance', import.meta.env.BASE_URL, (k) => i18n.t(k))}
           </div>
           <div class="flex flex-wrap items-center justify-center gap-2 pt-1">
             <span class="text-xs text-[var(--color-text-secondary)]" data-i18n="footer.featuredIn">${i18n.t('footer.featuredIn')}</span>
-            <a
-              href="https://www.heise.de/news/Semantische-Anker-verkuerzen-den-Kontext-fuer-das-agentische-Coden-11311061.html"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity rounded bg-white px-1.5 py-0.5"
-              title="${i18n.t('footer.heiseAlt')}"
-            >
-              <img
-                src="${import.meta.env.BASE_URL}heise-logo.svg"
-                alt="heise online"
-                width="24"
-                height="21"
-                class="h-5 w-auto"
-                loading="lazy"
-              />
-              <span class="text-xs text-gray-700">heise online (DE)</span>
-            </a>
+            ${renderAppearances('press', import.meta.env.BASE_URL, (k) => i18n.t(k))}
           </div>
         </div>
       </div>

--- a/website/src/components/main-content.js
+++ b/website/src/components/main-content.js
@@ -1,4 +1,5 @@
 import { i18n } from '../i18n.js'
+import { renderAppearances } from '../data/appearances.js'
 
 const HERO_EXAMPLE_COUNT = 6
 
@@ -46,6 +47,27 @@ export function renderMain() {
           <p class="text-sm text-[var(--color-text-secondary)] italic mb-8 max-w-3xl" data-i18n="${keyExpansion}">
             ${i18n.t(keyExpansion)}
           </p>
+
+          <!-- Third-party coverage belongs where people actually look. In the
+               footer it sat below ~200 anchor cards, which nobody scrolls to.
+               Press and appearances stay separately labelled: one is written
+               about us, the other is a conversation we joined. -->
+          <section
+            id="appearances"
+            class="mb-8 border-y border-[var(--color-border)] py-3"
+            aria-label="${i18n.t('footer.featuredIn')}"
+          >
+            <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-2">
+              <span class="text-xs text-[var(--color-text-secondary)]" data-i18n="footer.featuredIn">${i18n.t('footer.featuredIn')}</span>
+              ${renderAppearances('press', import.meta.env.BASE_URL, (k) => i18n.t(k))}
+              <span
+              class="w-full sm:mx-1 sm:h-4 sm:w-px sm:bg-[var(--color-border)]"
+              aria-hidden="true"
+            ></span>
+              <span class="text-xs text-[var(--color-text-secondary)]" data-i18n="footer.asSeenOn">${i18n.t('footer.asSeenOn')}</span>
+              ${renderAppearances('appearance', import.meta.env.BASE_URL, (k) => i18n.t(k))}
+            </div>
+          </section>
 
           <h2 class="text-lg font-semibold text-[var(--color-text)] mb-3" data-i18n="hero.howToUseTitle">
             ${i18n.t('hero.howToUseTitle')}

--- a/website/src/components/main-content.test.js
+++ b/website/src/components/main-content.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../i18n.js', () => ({
+  i18n: {
+    t: (key) => key,
+    currentLang: () => 'en',
+  },
+}))
+
+import { renderMain } from './main-content.js'
+import { APPEARANCES } from '../data/appearances.js'
+
+describe('renderMain — appearances strip', () => {
+  it('shows every appearance above the fold', () => {
+    const html = renderMain()
+    for (const { href, logo } of APPEARANCES) {
+      expect(html).toContain(`href="${href}"`)
+      expect(html).toContain(logo)
+    }
+  })
+
+  // Measured on a 1280x720 laptop: sitting after the how-to-use steps put the
+  // strip 35px below the fold, which defeats the point of moving it out of the
+  // footer. It belongs directly after the before/after example.
+  it('places the strip after the example and before the how-to-use steps', () => {
+    const html = renderMain()
+    const hero = html.indexOf('id="hero"')
+    const strip = html.indexOf('id="appearances"')
+    const howTo = html.indexOf('hero.howToUseTitle')
+    const filters = html.indexOf('id="filters"')
+    expect(hero).toBeGreaterThan(-1)
+    expect(strip).toBeGreaterThan(hero)
+    expect(strip).toBeLessThan(howTo)
+    expect(howTo).toBeLessThan(filters)
+  })
+
+  it('keeps press and appearances as separately labelled groups', () => {
+    const html = renderMain()
+    const strip = html.slice(html.indexOf('id="appearances"'), html.indexOf('id="filters"'))
+    expect(strip).toContain('footer.featuredIn')
+    expect(strip).toContain('footer.asSeenOn')
+  })
+})

--- a/website/src/data/appearances.js
+++ b/website/src/data/appearances.js
@@ -1,0 +1,58 @@
+/**
+ * Where Semantic Anchors has been covered or discussed.
+ *
+ * The list itself lives in appearances.json, because it is read from two
+ * module systems: this ESM module renders it for the app (footer and the
+ * strip under the landing hero), and scripts/prerender-routes.js — plain
+ * CommonJS — reads the same JSON to emit the static home page. A .js module
+ * could not serve both without an async refactor of that script.
+ *
+ * `kind` splits the list into the two groups the site labels differently:
+ * 'press' is coverage written about us, 'appearance' is a conversation we
+ * took part in. They are not the same claim and are not merged.
+ */
+
+import appearances from './appearances.json'
+
+export const APPEARANCES = appearances
+
+const SEPARATOR = '<span class="text-gray-300 dark:text-gray-600">|</span>'
+
+function renderOne(entry, basePath, t) {
+  const imgClass = entry.imgClass || 'h-6 w-auto'
+  const linkClass = [
+    'inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity',
+    entry.linkClass || '',
+  ]
+    .join(' ')
+    .trim()
+  const labelClass = entry.labelClass || 'text-[var(--color-text-secondary)]'
+  return `<a
+              href="${entry.href}"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="${linkClass}"
+              title="${t(entry.titleKey)}"
+            >
+              <img
+                src="${basePath}${entry.logo}"
+                alt="${entry.alt}"
+                width="${entry.width}"
+                height="${entry.height}"
+                class="${imgClass}"
+                loading="lazy"
+              />
+              <span class="text-xs ${labelClass}">${entry.label}</span>
+            </a>`
+}
+
+/**
+ * Render the links of one group, separated by the usual pipe. Returns '' when
+ * the group is empty, so a caller can drop the whole row without a special
+ * case.
+ */
+export function renderAppearances(kind, basePath, t) {
+  return APPEARANCES.filter((entry) => entry.kind === kind)
+    .map((entry) => renderOne(entry, basePath, t))
+    .join(`\n            ${SEPARATOR}\n            `)
+}

--- a/website/src/data/appearances.json
+++ b/website/src/data/appearances.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "heise",
+    "kind": "press",
+    "href": "https://www.heise.de/news/Semantische-Anker-verkuerzen-den-Kontext-fuer-das-agentische-Coden-11311061.html",
+    "logo": "heise-logo.svg",
+    "alt": "heise online",
+    "label": "heise online (DE)",
+    "titleKey": "footer.heiseAlt",
+    "width": 24,
+    "height": 21,
+    "imgClass": "h-5 w-auto",
+    "linkClass": "rounded bg-white px-1.5 py-0.5",
+    "labelClass": "text-gray-700"
+  },
+  {
+    "id": "hmze",
+    "kind": "appearance",
+    "href": "https://www.youtube.com/watch?v=rQj-B3VTx48",
+    "logo": "hmze-logo.png",
+    "alt": "HMZE Podcast",
+    "label": "HMZE (DE)",
+    "titleKey": "footer.hmzeAlt",
+    "width": 28,
+    "height": 24
+  },
+  {
+    "id": "rabauer",
+    "kind": "appearance",
+    "href": "https://rabauer.dev",
+    "logo": "rabauer-logo.png",
+    "alt": "rabauer.dev",
+    "label": "rabauer.dev (EN)",
+    "titleKey": "footer.rabauerAlt",
+    "width": 24,
+    "height": 24
+  },
+  {
+    "id": "byndcode",
+    "kind": "appearance",
+    "href": "https://byndcode.com/episodes/ep016-ralf-d-mueller/",
+    "logo": "byndcode-logo.png",
+    "alt": "Beyond Code Podcast",
+    "label": "Beyond Code (DE)",
+    "titleKey": "footer.byndcodeAlt",
+    "width": 24,
+    "height": 24,
+    "imgClass": "h-6 w-auto rounded"
+  }
+]


### PR DESCRIPTION
The "featured in / as seen on" rows sat in the footer, below roughly 200 anchor cards on a 12,400px page. heise is genuine third-party evidence and effectively nobody saw it.

## Where it went, and why there

Inside the hero, directly after the before/after example and before the how-to-use steps — claim, demonstration, evidence, instructions.

Measured at 1280×720: the strip starts at **579px**, fully visible without scrolling, one line, 50px tall. The first placement I tried, after the how-to-use steps, put it at 755px — **35px below the fold**, which would have defeated the point. That measurement is why the test now pins the order explicitly instead of just asserting "somewhere in the hero".

On a 390px phone it wraps to three lines with an explicit break between the two groups, so the second label does not trail the first group's logo.

## What stayed as it was

**Press and appearances remain separately labelled.** One is coverage written about us, the other is a conversation we joined. Merging them into one "as seen on" row would overstate the weaker half.

**The footer row is unchanged.** Anchor and doc pages have no hero, so a reader arriving directly on `/anchor/tufte-style` would otherwise see no evidence at all. The repetition is cheap; the gap would not be.

## One structural change

The list moves to `website/src/data/appearances.json`, because it is now read from **two module systems**: the ESM module renders it for the app, and `scripts/prerender-routes.js` is CommonJS and reads the same JSON to emit the static home page — so crawlers and LLM fetchers get the links, per the pre-render-everything rule. Sharing the *data* rather than the *markup* is what that script already does for the hero, and it means the two can never disagree on who is listed.

Footer markup drops from 144 to 80 lines with no change in output.

## Verification

- 135 unit tests pass (3 new for the strip); the footer's existing mutation-hardened tests stay green, which is the check that the refactor changed nothing.
- Lint and Prettier clean, including `scripts/`.
- Both static home pages verified to carry all four links: `dist/index.html` says "Featured in: …", `dist/de/index.html` says "Bekannt aus: …".
- Checked in the browser at 1280×720 and 390×844; all four logos load, nothing overflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Neuer „Featured in / As seen on“-Bereich auf der Startseite mit Presse- und Auftrittsverweisen.
  * Presse- und Podcast-Links werden nun dynamisch im Hero-Bereich und Footer angezeigt.
  * Einträge enthalten Logos, Beschriftungen und direkte Links.
  * Die Darstellung unterstützt lokalisierte Bezeichnungen und eine getrennte Kennzeichnung der Kategorien.

* **Tests**
  * Darstellung, Reihenfolge und Gruppierung der neuen Verweise wurden ergänzt und abgesichert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->