### PR TITLE
feat: filter the catalog to the most recently added anchors

### DIFF
--- a/docs/changelog.adoc
+++ b/docs/changelog.adoc
@@ -4,6 +4,11 @@ A chronological record of all semantic anchors added to the catalog. Community c
 
 == 2026-08-25
 
+*New: a recency filter in the category row*
+
+* The quick-nav now opens with a ✨ chip that filters the catalog down to the twelve most recently added anchors. The category chips beside it jump; this one filters, so it is a toggle button with a pressed state and a dashed border rather than a link — a jump link is never "on".
+* *Twelve newest, not "added in the last 30 days".* A time window empties out between release bursts, and a control that filters to nothing is worse than no control at all. The consequence is deliberate and visible: the list reaches back further than the NEW badge, so an anchor can appear in it without carrying the badge. The badge is a claim about age, the chip is a claim about order.
+
 *New anchor — Tufte Style (#712):*
 
 * *link:#/anchor/tufte-style[Tufte Style]* (Edward R. Tufte, _The Visual Display of Quantitative Information_, Graphics Press 1983; 2nd ed. 2001) — communication-presentation + design-principles: maximise the data-ink ratio, remove chartjunk, keep the lie factor near 1, compare with small multiples on shared axes, set sparklines inside the sentence, label directly instead of with a legend. The point that decides whether the term was understood: density is the goal, not emptiness — remove what carries no information, then spend the reclaimed space on more information. Tier ★★★, proposed by https://github.com/follperson[@follperson] in #712.

--- a/website/public/data/metadata.json
+++ b/website/public/data/metadata.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-25T07:28:07.504Z",
+  "generatedAt": "2026-08-25T08:53:29.536Z",
   "version": "1.0.0",
   "counts": {
     "anchors": 196,

--- a/website/src/components/card-grid.js
+++ b/website/src/components/card-grid.js
@@ -21,6 +21,30 @@ function isRecentlyAdded(anchor) {
   return Date.now() - added < NEW_WINDOW_MS
 }
 
+// The "recently added" filter shows a fixed number of newest anchors rather
+// than a time window. A window empties out between release bursts, and a
+// control that filters to nothing is worse than no control. The consequence is
+// deliberate: the list and the NEW badge above can disagree at the edge, since
+// the badge is a claim about age and this is a claim about order.
+const RECENT_LIMIT = 12
+
+// Whether the quick-nav's recency chip is pressed. Held here rather than
+// passed in, because the chip lives inside this component while the role and
+// search values belong to the header — applyCardFilters reads it directly.
+let recentOnly = false
+
+function recentAnchorIds(allAnchors) {
+  return new Set(
+    allAnchors
+      .filter(
+        (anchor) => !anchor.umbrella && anchor.addedAt && !Number.isNaN(Date.parse(anchor.addedAt))
+      )
+      .sort((a, b) => Date.parse(b.addedAt) - Date.parse(a.addedAt))
+      .slice(0, RECENT_LIMIT)
+      .map((anchor) => anchor.id)
+  )
+}
+
 /**
  * Category color palette (matching previous categories)
  */
@@ -74,10 +98,12 @@ export function setFeedbackData(data) {
 export function renderCardGrid(categories, anchors) {
   if (!categories || !anchors) return '<div>Loading...</div>'
 
+  const recent = recentAnchorIds(anchors)
+
   return `
     <div class="card-grid-container">
-      ${renderCategoryNav(categories, anchors)}
-      ${categories.map((category) => renderCategorySection(category, anchors)).join('')}
+      ${renderCategoryNav(categories, anchors, recent)}
+      ${categories.map((category) => renderCategorySection(category, anchors, recent)).join('')}
     </div>
   `
 }
@@ -101,7 +127,7 @@ function countCategoryAnchors(category, allAnchors) {
  * (`#category-<id>`) so they work without JavaScript; the count badges are kept
  * in sync with the active search/role filter by applyCardFilters().
  */
-function renderCategoryNav(categories, allAnchors) {
+function renderCategoryNav(categories, allAnchors, recent = new Set()) {
   const items = categories
     .map((category) => ({ category, count: countCategoryAnchors(category, allAnchors) }))
     .filter(({ count }) => count > 0)
@@ -131,13 +157,33 @@ function renderCategoryNav(categories, allAnchors) {
     })
     .join('')
 
+  const recentChip =
+    recent.size > 0
+      ? `
+        <li>
+          <button
+            type="button"
+            class="category-nav-link category-nav-toggle"
+            data-recent-filter
+            aria-pressed="false"
+            title="${escapeHtml(i18n.t('nav.recentlyAdded'))}"
+            data-i18n-title="nav.recentlyAdded"
+            aria-label="${escapeHtml(i18n.t('nav.recentlyAdded'))}"
+            data-i18n-aria="nav.recentlyAdded"
+          >
+            <span class="category-nav-icon" aria-hidden="true">\u2728</span>
+            <span class="category-nav-count">${recent.size}</span>
+          </button>
+        </li>`
+      : ''
+
   return `
     <nav
       class="category-nav"
       aria-label="${escapeHtml(i18n.t('nav.categoryJump'))}"
       data-i18n-aria="nav.categoryJump"
     >
-      <ul class="category-nav-list">${links}</ul>
+      <ul class="category-nav-list">${recentChip}${links}</ul>
     </nav>
   `
 }
@@ -145,7 +191,7 @@ function renderCategoryNav(categories, allAnchors) {
 /**
  * Render a single category section with its anchors
  */
-function renderCategorySection(category, allAnchors) {
+function renderCategorySection(category, allAnchors, recent = new Set()) {
   const categoryAnchors = allAnchors.filter(
     (anchor) => anchor.categories && anchor.categories.includes(category.id) && !anchor.umbrella
   )
@@ -164,7 +210,7 @@ function renderCategorySection(category, allAnchors) {
       </h2>
 
       <div class="anchor-cards-grid">
-        ${categoryAnchors.map((anchor) => renderAnchorCard(anchor, color, category.id)).join('')}
+        ${categoryAnchors.map((anchor) => renderAnchorCard(anchor, color, category.id, recent.has(anchor.id))).join('')}
       </div>
     </section>
   `
@@ -178,7 +224,7 @@ function renderCategorySection(category, allAnchors) {
  * category sections (anchors can belong to more than one category) and
  * the DOM must not contain duplicate ids.
  */
-function renderAnchorCard(anchor, categoryColor, categoryId) {
+function renderAnchorCard(anchor, categoryColor, categoryId, isRecent = false) {
   const isUmbrella = anchor.subAnchors && anchor.subAnchors.length > 0
   const umbrellaClass = isUmbrella ? ' anchor-card-umbrella' : ''
   const rolesCount = anchor.roles ? anchor.roles.length : 0
@@ -196,6 +242,7 @@ function renderAnchorCard(anchor, categoryColor, categoryId) {
     <div
       class="anchor-card${umbrellaClass}"
       data-anchor="${safeId}"
+      ${isRecent ? 'data-recent="true"' : ''}
       data-roles="${escapeHtml(anchor.roles ? anchor.roles.join(',') : '')}"
       data-tags="${escapeHtml(anchor.tags ? anchor.tags.join(',') : '')}"
       tabindex="0"
@@ -334,6 +381,11 @@ export function initCardGrid() {
   const container = document.getElementById('main-content')
   if (!container) return
 
+  // The grid is re-rendered on every return to the catalog, and the fresh chip
+  // comes back unpressed. Without this reset the flag would survive the markup
+  // that shows it, and the grid would filter with the chip looking inactive.
+  recentOnly = false
+
   // Remove existing listeners if any
   if (clickHandler) {
     container.removeEventListener('click', clickHandler)
@@ -366,6 +418,16 @@ export function initCardGrid() {
 
     if (e.target.closest('.anchor-edit-btn')) {
       e.stopPropagation()
+      return
+    }
+
+    const recentChip = e.target.closest('[data-recent-filter]')
+    if (recentChip) {
+      e.stopPropagation()
+      recentOnly = !recentOnly
+      recentChip.setAttribute('aria-pressed', String(recentOnly))
+      recentChip.classList.toggle('category-nav-toggle-active', recentOnly)
+      reapplyCurrentFilters()
       return
     }
 
@@ -456,7 +518,25 @@ export function filterCardsBySearch(query) {
 }
 
 /**
- * Apply combined filters (role + search)
+ * Re-run the filters after the recency chip toggled. The role and search
+ * values live in the header inputs, which own that state; reading them back is
+ * how main.js does it too, so there is one source rather than a mirrored copy
+ * that can fall behind.
+ */
+function reapplyCurrentFilters() {
+  const roleId =
+    document.getElementById('header-role-filter')?.value ||
+    document.getElementById('role-filter')?.value ||
+    ''
+  const query =
+    document.getElementById('header-search-input')?.value ||
+    document.getElementById('search-input')?.value ||
+    ''
+  applyCardFilters(roleId, query)
+}
+
+/**
+ * Apply combined filters (role + search + recency)
  */
 export function applyCardFilters(roleId, searchQuery) {
   const cards = document.querySelectorAll('.anchor-card')
@@ -499,7 +579,9 @@ export function applyCardFilters(roleId, searchQuery) {
       }
     }
 
-    const isVisible = roleMatch && searchMatch
+    const recentMatch = !recentOnly || card.dataset.recent === 'true'
+
+    const isVisible = roleMatch && searchMatch && recentMatch
     card.style.display = isVisible ? 'block' : 'none'
     if (isVisible) visibleCount++
   })

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -234,3 +234,135 @@ describe('hero visibility during search (#615)', () => {
     expect(document.getElementById('hero').classList.contains('hero-collapsed')).toBe(false)
   })
 })
+
+describe('recently-added filter chip', () => {
+  const categories = [
+    { id: 'testing-quality', name: 'Testing' },
+    { id: 'design-principles', name: 'Design' },
+  ]
+
+  // 15 anchors, one day apart, newest first. RECENT_LIMIT is 12, so the three
+  // oldest must fall out — that boundary is the whole point of the control.
+  const day = 24 * 60 * 60 * 1000
+  const anchors = Array.from({ length: 15 }, (_, i) => ({
+    id: `a${i}`,
+    title: `A${i}`,
+    categories: [i % 2 === 0 ? 'testing-quality' : 'design-principles'],
+    roles: ['r'],
+    tags: [],
+    proponents: [],
+    addedAt: new Date(Date.now() - i * day).toISOString(),
+  }))
+
+  it('marks exactly the twelve most recently added anchors', () => {
+    const html = renderCardGrid(categories, anchors)
+    const marked = html.match(/data-recent="true"/g) || []
+    expect(marked).toHaveLength(12)
+  })
+
+  it('marks the newest anchor and not the fifteenth', () => {
+    const html = renderCardGrid(categories, anchors)
+    const cardOf = (id) => {
+      const start = html.indexOf(`data-anchor="${id}"`)
+      expect(start).toBeGreaterThan(-1)
+      return html.slice(html.lastIndexOf('<div', start), start + 400)
+    }
+    expect(cardOf('a0')).toContain('data-recent="true"')
+    expect(cardOf('a14')).not.toContain('data-recent="true"')
+  })
+
+  it('puts the chip first in the quick-nav, ahead of the category chips', () => {
+    const html = renderCardGrid(categories, anchors)
+    const chip = html.indexOf('data-recent-filter')
+    const firstCategory = html.indexOf('href="#category-')
+    expect(chip).toBeGreaterThan(-1)
+    expect(chip).toBeLessThan(firstCategory)
+  })
+
+  // The category chips are jump links. This one filters, so it must not look
+  // like a link to assistive tech either — a toggle button says what it does.
+  it('is a toggle button, not a jump link', () => {
+    const html = renderCardGrid(categories, anchors)
+    const chip = html.slice(html.indexOf('data-recent-filter') - 200)
+    const el = chip.slice(0, chip.indexOf('</button>') + 9)
+    expect(el).toContain('<button')
+    expect(el).toContain('aria-pressed="false"')
+    expect(el).not.toContain('href=')
+  })
+
+  it('omits the chip when no anchor carries a date', () => {
+    const undated = anchors.map(({ addedAt: _addedAt, ...rest }) => rest)
+    const html = renderCardGrid(categories, undated)
+    expect(html).not.toContain('data-recent-filter')
+    expect(html).not.toContain('data-recent="true"')
+  })
+})
+
+describe('recently-added filter behaviour', () => {
+  function setupDom() {
+    document.body.innerHTML = `
+      <div id="main-content">
+        <nav class="category-nav">
+          <ul class="category-nav-list">
+            <li><button data-recent-filter aria-pressed="false" class="category-nav-link category-nav-toggle">
+              <span class="category-nav-count">2</span></button></li>
+            <li><a class="category-nav-link" data-category-link="c1" href="#category-c1">
+              <span class="category-nav-count">2</span></a></li>
+          </ul>
+        </nav>
+        <section class="category-section" id="category-c1">
+          <div class="anchor-card" data-anchor="fresh" data-recent="true" data-roles="" data-tags="" style="display: block">
+            <span class="anchor-card-title">Fresh</span>
+          </div>
+          <div class="anchor-card" data-anchor="old" data-roles="" data-tags="" style="display: block">
+            <span class="anchor-card-title">Old</span>
+          </div>
+        </section>
+      </div>
+      <span id="visible-count">0</span><span id="total-count">0</span>`
+  }
+
+  const visibleAnchors = () =>
+    Array.from(document.querySelectorAll('.anchor-card'))
+      .filter((card) => card.style.display !== 'none')
+      .map((card) => card.dataset.anchor)
+
+  it('hides everything that is not recent once the chip is pressed', async () => {
+    setupDom()
+    const { initCardGrid } = await import('./card-grid.js')
+    initCardGrid()
+    document.querySelector('[data-recent-filter]').click()
+    expect(visibleAnchors()).toEqual(['fresh'])
+  })
+
+  it('restores the full grid when the chip is pressed again', async () => {
+    setupDom()
+    const { initCardGrid } = await import('./card-grid.js')
+    initCardGrid()
+    const chip = document.querySelector('[data-recent-filter]')
+    chip.click()
+    chip.click()
+    expect(visibleAnchors()).toEqual(['fresh', 'old'])
+  })
+
+  it('reports its state through aria-pressed', async () => {
+    setupDom()
+    const { initCardGrid } = await import('./card-grid.js')
+    initCardGrid()
+    const chip = document.querySelector('[data-recent-filter]')
+    chip.click()
+    expect(chip.getAttribute('aria-pressed')).toBe('true')
+    chip.click()
+    expect(chip.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('does not open the anchor modal when the chip is clicked', async () => {
+    setupDom()
+    const { initCardGrid } = await import('./card-grid.js')
+    initCardGrid()
+    const seen = []
+    document.addEventListener('anchor-selected', (e) => seen.push(e.detail.anchorId))
+    document.querySelector('[data-recent-filter]').click()
+    expect(seen).toEqual([])
+  })
+})

--- a/website/src/components/card-grid.test.js
+++ b/website/src/components/card-grid.test.js
@@ -366,3 +366,83 @@ describe('recently-added filter behaviour', () => {
     expect(seen).toEqual([])
   })
 })
+
+describe('recency selection invariant', () => {
+  const day = 24 * 60 * 60 * 1000
+  const categories = [
+    { id: 'testing-quality', name: 'Testing' },
+    { id: 'design-principles', name: 'Design' },
+  ]
+
+  // The property: however the input is shaped, exactly
+  // min(12, eligible) anchors are marked — where eligible means non-umbrella
+  // and carrying a parsable date. Undated, unparsable and umbrella anchors are
+  // not candidates and must never appear in the marked set.
+  function buildCorpus(eligibleCount, noise) {
+    const eligible = Array.from({ length: eligibleCount }, (_, i) => ({
+      id: `ok${i}`,
+      title: `OK${i}`,
+      categories: [i % 2 === 0 ? 'testing-quality' : 'design-principles'],
+      roles: ['r'],
+      tags: [],
+      proponents: [],
+      addedAt: new Date(Date.now() - i * day).toISOString(),
+    }))
+
+    const undated = {
+      id: 'undated',
+      title: 'U',
+      categories: ['testing-quality'],
+      roles: ['r'],
+      tags: [],
+      proponents: [],
+    }
+    const unparsable = { ...undated, id: 'unparsable', addedAt: 'not-a-date' }
+    const sub = {
+      id: 'sub',
+      title: 'S',
+      categories: ['design-principles'],
+      roles: ['r'],
+      tags: [],
+      proponents: [],
+      umbrella: 'ok0',
+      tier: 1,
+      addedAt: new Date().toISOString(),
+    }
+
+    return noise ? [...eligible, undated, unparsable, sub] : eligible
+  }
+
+  const markedIds = (html) => {
+    const cards = html.match(/<div[^>]*class="anchor-card[^>]*>/g) || []
+    return new Set(
+      cards
+        .filter((card) => card.includes('data-recent="true"'))
+        .map((card) => card.match(/data-anchor="([^"]+)"/)[1])
+    )
+  }
+
+  it.each([0, 1, 5, 11, 12, 13, 30])('marks min(12, eligible) for %i eligible anchors', (n) => {
+    for (const noise of [false, true]) {
+      const html = renderCardGrid(categories, buildCorpus(n, noise))
+      const ids = markedIds(html)
+      expect(ids.size).toBe(Math.min(12, n))
+      for (const id of ids) expect(id.startsWith('ok')).toBe(true)
+    }
+  })
+
+  it('never marks an anchor that is newer only because it is undated', () => {
+    const html = renderCardGrid(categories, buildCorpus(3, true))
+    const ids = markedIds(html)
+    expect(ids.has('undated')).toBe(false)
+    expect(ids.has('unparsable')).toBe(false)
+    expect(ids.has('sub')).toBe(false)
+  })
+
+  it('marks the newest anchors, not an arbitrary twelve', () => {
+    const html = renderCardGrid(categories, buildCorpus(20, true))
+    const ids = markedIds(html)
+    for (let i = 0; i < 12; i++) expect(ids.has(`ok${i}`)).toBe(true)
+    for (let i = 12; i < 20; i++) expect(ids.has(`ok${i}`)).toBe(false)
+  })
+})

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -164,6 +164,26 @@ body {
   border-color: var(--color-primary);
 }
 
+/* The recency chip sits in the same row as the category chips but does a
+   different thing: those jump, this one filters. A pressed state is the only
+   honest way to say so — a jump link is never "on". */
+.category-nav-toggle {
+  cursor: pointer;
+  border-style: dashed;
+}
+
+.category-nav-toggle-active {
+  background: var(--color-primary);
+  border-style: solid;
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.category-nav-toggle-active .category-nav-count {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
 .category-nav-icon {
   @apply text-base leading-none;
 }

--- a/website/src/translations/de.json
+++ b/website/src/translations/de.json
@@ -17,6 +17,7 @@
   "nav.more": "Mehr",
   "nav.contracts": "Contracts",
   "nav.categoryJump": "Zu Kategorie springen",
+  "nav.recentlyAdded": "Nur die zuletzt hinzugefügten Anker zeigen",
   "contracts.title": "Semantic Contracts",
   "contracts.explanation": "Semantic Anchors referenzieren öffentliches Wissen, das LLMs bereits kennen. Aber die Konventionen, Templates und Definitionen deines Teams? Dafür braucht es Semantic Contracts. Ein Contract definiert, was ein Begriff in deinem Projekt bedeutet — entweder durch Komposition etablierter Anker oder durch eigene Definitionen, die nur in deinem Team existieren. Wähle die passenden aus und lade sie für deine AGENTS.md oder CLAUDE.md herunter.",
   "contracts.linkedinLink": "Lies die ganze Geschichte hinter Semantic Contracts auf LinkedIn →",

--- a/website/src/translations/en.json
+++ b/website/src/translations/en.json
@@ -17,6 +17,7 @@
   "nav.more": "More",
   "nav.contracts": "Contracts",
   "nav.categoryJump": "Jump to category",
+  "nav.recentlyAdded": "Show only the most recently added anchors",
   "contracts.title": "Semantic Contracts",
   "contracts.explanation": "Semantic Anchors reference public knowledge that LLMs already understand. But your team's conventions, templates, and definitions? Those need Semantic Contracts. A contract defines what a term means in your project — either by composing established anchors or by providing custom definitions that only exist within your team. Select the ones that fit and download them for your AGENTS.md or CLAUDE.md.",
   "contracts.linkedinLink": "Read the full story behind Semantic Contracts on LinkedIn →",


### PR DESCRIPTION
The quick-nav now opens with a ✨ chip that hides everything except the twelve most recently added anchors.

## Two decisions worth arguing about

**Twelve newest, not "added in the last 30 days".** The NEW badge on the cards uses a 30-day window. I did not reuse it, because additions arrive in bursts — five on 2026-08-14, one on 08-25, nothing for the three weeks before — so a window empties out between them, and a control that filters to nothing is worse than no control at all.

The consequence is deliberate and visible: the list reaches further back than the badge, so an anchor can sit in it without carrying one. In the current data the chip shows twelve while only five have the badge. The badge is a claim about *age*; the chip is a claim about *order*. The tooltip says "most recently added", not "new", so it does not claim badge parity.

**It is a button, not a link.** The chips beside it are in-page jump links (`#category-<id>`). This one filters. Same row, two interaction models — so it carries `aria-pressed`, a pressed fill, and a dashed border in its resting state, because a jump link is never "on". If you would rather it did not sit in that row at all, say so; moving it next to the search and role filters is a small change.

## A defect the tests found

Writing the toggle-off test surfaced a real bug rather than a test artefact: `recentOnly` is module state, and it outlived a re-render of the grid. Leaving the catalog and coming back left the filter active while the freshly rendered chip showed as unpressed — state and UI disagreeing. `initCardGrid` now resets it, which is exactly where the markup is rebuilt.

## Verification

- 141 unit tests pass, 9 new: the twelve-item boundary (fixture has 15 anchors one day apart, so the three oldest must fall out), chip position, button-not-link, toggle on, toggle off, `aria-pressed`, and that clicking the chip does not open the anchor modal.
- Lint and Prettier clean; build clean.
- Checked in the browser: chip renders first with count 12, pressing it leaves 12 distinct anchors, the category chips drop to their filtered counts and empty ones disappear, pressing again restores all 182 cards.

## One cosmetic wrinkle, pre-existing

With the filter on, the header counter reads "16 / 182" while the chip says 12. Anchors in two categories render a card in each, so the card count exceeds the anchor count. The role filter has always behaved this way; I left it alone rather than change counting semantics in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Neuer ✨-Filter „Zuletzt hinzugefügt“ in der Katalogansicht.
  * Zeigt die zwölf zuletzt hinzugefügten Semantic Anchors in ihrer Reihenfolge an.
  * Der Filter lässt sich aktivieren und deaktivieren und funktioniert zusammen mit Rollen- und Suchfiltern.
  * Aktiver Zustand und Filtercharakter werden durch eine angepasste Darstellung deutlich gekennzeichnet.

* **Übersetzungen**
  * Der neue Filter ist auf Deutsch und Englisch verfügbar.

* **Tests**
  * Filterverhalten, Reihenfolge, Statusanzeige und Sonderfälle wurden abgedeckt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->