### PR TITLE
Harness Coverage Wheel: prior-work links in the info panel

### DIFF
--- a/website/public/harness-coverage-wheel.html
+++ b/website/public/harness-coverage-wheel.html
@@ -214,6 +214,17 @@
             Cover these deliberately, or accept them as out of scope for your risk tier.</p>
           <div id="qtreebody"></div>
           <p class="qblind"><b>Not closed by any automated check here:</b> <span id="qblindlist"></span></p>
+          <p class="qintro"><b>Standing on prior work:</b> the idea combines threads that each exist on their own.
+            <a href="https://arxiv.org/abs/1611.04433" target="_blank" rel="noopener">Quamoco</a> maps concrete
+            measurements to ISO 25010 characteristics;
+            <a href="https://www.sqale.org/" target="_blank" rel="noopener">SQALE</a> maps rule violations to quality
+            characteristics; <a href="https://owaspsamm.org/" target="_blank" rel="noopener">OWASP SAMM</a> shows
+            maturity gaps as a radar (security only);
+            <a href="https://scorecard.dev/" target="_blank" rel="noopener">OpenSSF Scorecard</a> is an automated
+            check inventory (supply chain only); and the
+            <a href="https://en.wikipedia.org/wiki/Swiss_cheese_model" target="_blank" rel="noopener">Swiss cheese
+            model</a> is the underlying theory of layered error correction. This wheel wires them together for
+            agentic coding: one broad layer inventory, full ISO 25010 coverage, explicit blind spots, a risk-tier dial.</p>
         </details>
       </div>
     </div>


### PR DESCRIPTION
Follow-up to #719 (this commit landed on the branch just after the merge).

Adds a closing "Standing on prior work" paragraph to the expandable info panel, linking the systems the wheel builds on, each with a one-line positioning:

- **Quamoco** — maps concrete measurements to ISO 25010 characteristics
- **SQALE** — maps rule violations to quality characteristics
- **OWASP SAMM** — maturity gaps as a radar (security only)
- **OpenSSF Scorecard** — automated check inventory (supply chain only)
- **Swiss cheese model** — the underlying theory of layered error correction

The closing sentence names what this wheel wires together: one broad layer inventory, full ISO 25010 coverage, explicit blind spots, a risk-tier dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Der Abschnitt zur ISO-25010-Abdeckung enthält jetzt einen Absatz „Standing on prior work“.
  * Ergänzende Verweise auf Quamco, SQALE, OWASP SAMM, OpenSSF Scorecard und das Schweizer-Käse-Modell wurden hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->